### PR TITLE
chore: camelcase

### DIFF
--- a/src/types/action.rs
+++ b/src/types/action.rs
@@ -4,12 +4,14 @@ use serde::{Deserialize, Serialize};
 use super::{PartialUserOp, UserOp};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct PartialAction {
     pub op: PartialUserOp,
     pub auth: Option<SignedAuthorization>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Action {
     pub op: UserOp,
     pub auth: Option<SignedAuthorization>,

--- a/src/types/op.rs
+++ b/src/types/op.rs
@@ -23,6 +23,7 @@ sol! {
     /// Since L2s already include calldata compression with savings forwarded to users,
     /// we don't need to be too concerned about calldata overhead.
     #[derive(Debug, Serialize, Deserialize)]
+    #[serde(rename_all = "camelCase")]
     struct UserOp {
         /// The user's address.
         address eoa;
@@ -59,6 +60,7 @@ sol! {
 
     /// A partial [`UserOp`] used for fee estimation.
     #[derive(Debug, Serialize, Deserialize)]
+    #[serde(rename_all = "camelCase")]
     struct PartialUserOp {
         /// The user's address.
         address eoa;

--- a/src/types/quote.rs
+++ b/src/types/quote.rs
@@ -12,6 +12,7 @@ use super::Signed;
 pub type SignedQuote = Signed<Quote>;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Quote {
     /// The amount of the fee token to pay for the call.
     #[serde(with = "alloy::serde::quantity")]
@@ -48,6 +49,7 @@ impl Quote {
 
 // todo: this is temporary and should be replaced once https://github.com/alloy-rs/alloy/pull/2012 is released
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Eip1559Estimation {
     /// The base fee per gas.
     #[serde(with = "alloy::serde::quantity")]

--- a/src/types/signed.rs
+++ b/src/types/signed.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 
 /// A type that has been signed.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Signed<T> {
     #[serde(flatten)]
     ty: T,


### PR DESCRIPTION
To keep the API consistent we camelcase it all