### PR TITLE
feat: add more quote checks

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-use alloy::primitives::Address;
+use alloy::primitives::{Address, B256, U256};
 
 /// Errors returned by `relay_estimateFee`
 #[derive(Debug, thiserror::Error)]
@@ -32,12 +32,21 @@ impl From<EstimateFeeError> for jsonrpsee::types::error::ErrorObject<'static> {
 /// Errors returned by `relay_sendAction`
 #[derive(Debug, thiserror::Error)]
 pub enum SendActionError {
+    /// The payment recipient in the provided [`UserOp`] is not the entrypoint or the tx signer.
+    #[error("the payment recipient is not the entrypoint or the signer")]
+    WrongPaymentRecipient,
     /// The provided EIP-7702 auth item is not chain agnostic.
     #[error("the auth item is not chain agnostic")]
     AuthItemNotChainAgnostic,
     /// The `eoa` field of the provided `UserOp` is not an EIP-7702 delegated account.
     #[error("eoa not delegated: {0}")]
     EoaNotDelegated(Address),
+    /// The payment amount in the userop did not match the amount in the quote.
+    #[error("invalid fee amount, expected {expected}, got {got}")]
+    InvalidFeeAmount { expected: U256, got: U256 },
+    /// The quote was signed for a different userop.
+    #[error("invalid op digest, expected {expected}, got {got}")]
+    InvalidOpDigest { expected: B256, got: B256 },
     /// The quote expired.
     #[error("quote expired")]
     QuoteExpired,

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -207,10 +207,11 @@ where
 
         // todo: this is just a mock, we should add actual amounts
         let quote = Quote {
-            amount: 0,
+            token,
+            amount: U256::ZERO,
             gas_estimate,
             native_fee_estimate: native_fee_estimate.into(),
-            digest: request.op.digest(),
+            digest: op.digest(),
             ttl: SystemTime::now()
                 .checked_add(self.inner.quote_ttl)
                 .expect("should never overflow"),
@@ -226,8 +227,14 @@ where
     }
 
     // todo: chain ids
-    // todo: should we just make quote optional? for Action::Delegate
     async fn send_action(&self, action: Action, quote: SignedQuote) -> RpcResult<TxHash> {
+        // verify payment recipient is entrypoint or us
+        if !action.op.paymentRecipient.is_zero()
+            && action.op.paymentRecipient != self.inner.upstream.default_signer_address()
+        {
+            return Err(SendActionError::WrongPaymentRecipient.into());
+        }
+
         let mut request = TransactionRequest {
             input: executeCall { encodedUserOp: action.op.abi_encode().into() }.abi_encode().into(),
             to: Some(self.inner.upstream.entrypoint().into()),
@@ -257,8 +264,24 @@ where
             }
         }
 
-        // todo: validate paymentToken & paymentAmount & paymentRecipient
-        // todo: validate userop hash matches quote
+        // check that the payment amount matches whats in the quote
+        if quote.ty().amount != action.op.paymentAmount {
+            return Err(SendActionError::InvalidFeeAmount {
+                expected: quote.ty().amount,
+                got: action.op.paymentAmount,
+            }
+            .into());
+        }
+
+        // check that digest of the userop is the same as in the quote
+        if quote.ty().digest != action.op.digest() {
+            return Err(SendActionError::InvalidOpDigest {
+                expected: quote.ty().digest,
+                got: action.op.digest(),
+            }
+            .into());
+        }
+
         // this can be done by just verifying the signature & userop hash against the rfq
         // ticket from `relay_estimateFee`'
         if !quote

--- a/src/types/op.rs
+++ b/src/types/op.rs
@@ -116,14 +116,13 @@ impl UserOp {
 
         Ok(keccak256([&[0x19, 0x01], &domain.hash_struct()[..], &op[..]].concat()))
     }
-}
 
-impl PartialUserOp {
     pub fn digest(&self) -> B256 {
         let mut hasher = Keccak256::new();
         hasher.update(self.eoa);
         hasher.update(&self.executionData);
         hasher.update(self.nonce.to_be_bytes::<32>());
+        hasher.update(self.paymentToken);
         hasher.finalize()
     }
 }

--- a/src/types/quote.rs
+++ b/src/types/quote.rs
@@ -1,7 +1,7 @@
 use std::time::SystemTime;
 
 use alloy::{
-    primitives::{Keccak256, PrimitiveSignature, B256},
+    primitives::{Address, Keccak256, PrimitiveSignature, B256, U256},
     providers::utils::Eip1559Estimation as AlloyEip1559Estimation,
 };
 use serde::{Deserialize, Serialize};
@@ -14,9 +14,10 @@ pub type SignedQuote = Signed<Quote>;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Quote {
+    /// The fee token address.
+    pub token: Address,
     /// The amount of the fee token to pay for the call.
-    #[serde(with = "alloy::serde::quantity")]
-    pub amount: u128,
+    pub amount: U256,
     /// The estimated amount of gas the action will consume.
     #[serde(with = "alloy::serde::quantity")]
     pub gas_estimate: u64,
@@ -39,7 +40,7 @@ impl Quote {
 
     pub fn digest(&self) -> B256 {
         let mut hasher = Keccak256::new();
-        hasher.update(self.amount.to_be_bytes());
+        hasher.update(self.amount.to_be_bytes::<32>());
         hasher.update(self.gas_estimate.to_be_bytes());
         hasher.update(self.digest);
         // todo: hash ttl somehow


### PR DESCRIPTION
Adds more validations for quote:

- Validates that the payment recipient in the userop is either the entrypoint (us) or the tx signer (us)
- Checks that the payment amount and token in the userop matches what's in the quote
- Checks that the digest of the userop (just the eoa, nonce and data) matches whats in the quote