### PR TITLE
fix: panic when checking for EIP-7702 code

### DIFF
--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -258,7 +258,8 @@ where
             let code =
                 self.inner.upstream.get_code(action.op.eoa).await.map_err(SendActionError::from)?;
 
-            if code[0..3] != EIP7702_DELEGATION_DESIGNATOR || code[..] == EIP7702_CLEARED_DELEGATION
+            if code.get(..3) != Some(&EIP7702_DELEGATION_DESIGNATOR[..])
+                || code[..] == EIP7702_CLEARED_DELEGATION
             {
                 return Err(SendActionError::EoaNotDelegated(action.op.eoa).into());
             }


### PR DESCRIPTION
Hit when op.eoa has no code, e.g. with a default request

```json
[
    {
        "op": {
            "eoa": "0x0000000000000000000000000000000000000000",
            "executionData": "0x",
            "nonce": "0x0",
            "payer": "0x0000000000000000000000000000000000000000",
            "paymentToken": "0x0000000000000000000000000000000000000000",
            "paymentRecipient": "0x0000000000000000000000000000000000000000",
            "paymentAmount": "0x0",
            "paymentMaxAmount": "0x0",
            "paymentPerGas": "0x0",
            "combinedGas": "0x0",
            "signature": "0x"
        },
        "auth": null
    },
    {
        "token": "0x0000000000000000000000000000000000000000",
        "amount": "0x0",
        "gasEstimate": "0x0",
        "nativeFeeEstimate": {
            "maxFeePerGas": "0x0",
            "maxPriorityFeePerGas": "0x0"
        },
        "digest": "0x0000000000000000000000000000000000000000000000000000000000000000",
        "ttl": 0,
        "r": "0x1",
        "s": "0x1",
        "yParity": "0x1",
        "v": "0x1",
        "hash": "0x0000000000000000000000000000000000000000000000000000000000000000"
    }
]
```