### PR TITLE
fix: default to nonce salt 0 if not delegated

### DIFF
--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -155,8 +155,8 @@ where
                 input: nonceSaltCall {}.abi_encode().into(),
                 ..Default::default()
             })
-            .await?
-            ._0;
+            .await
+            .map_or(U256::ZERO, |ret| ret._0);
         debug!(eoa = %request.op.eoa, "Got nonce salt {nonce_salt}");
         let inner_signature = self
             .inner


### PR DESCRIPTION
In the case the account is not delegated we should default to 0 here as that is the default nonce salt