### PR TITLE
fix: validate auth chain id for estimatefee

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -8,6 +8,9 @@ pub enum EstimateFeeError {
     /// The provided fee token is not supported.
     #[error("fee token not supported: {0}")]
     UnsupportedFeeToken(Address),
+    /// The provided EIP-7702 auth item is not chain agnostic.
+    #[error("the auth item is not chain agnostic")]
+    AuthItemNotChainAgnostic,
     /// An error occurred talking to RPC.
     #[error(transparent)]
     RpcError(#[from] alloy::transports::RpcError<alloy::transports::TransportErrorKind>),

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -120,6 +120,15 @@ where
             return Err(EstimateFeeError::UnsupportedFeeToken(token).into());
         }
 
+        // validate auth item chain id
+        if request
+            .auth
+            .as_ref()
+            .is_some_and(|auth| auth.chain_id != U256::from(self.inner.upstream.chain_id()))
+        {
+            return Err(EstimateFeeError::AuthItemNotChainAgnostic.into());
+        }
+
         // create key
         let key = Key {
             expiry: U40::from(0),


### PR DESCRIPTION
Provides a nicer error message for invalid auth items in `relay_estimateFee` like we have in `relay_sendAction` instead of a horrid one