### PR TITLE
fix: pubkey for secp256k1 is not packed

### DIFF
--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -134,7 +134,7 @@ where
             expiry: U40::from(0),
             keyType: KeyType::Secp256k1,
             isSuperAdmin: true,
-            publicKey: self.inner.quote_signer.address().into_array().into(),
+            publicKey: self.inner.quote_signer.address().abi_encode().into(),
         };
 
         // fill userop


### PR DESCRIPTION
This should be ABI encoded, not packed