### PR TITLE
fix: ensure secp256k1 sig is correctly encoded

### DIFF
--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -38,7 +38,7 @@ use crate::{
     price::PriceOracle,
     types::{
         executeCall, nonceSaltCall, Action, FeeTokens, Key, KeyType, PartialAction, Quote,
-        Signature, SignedQuote, UserOp, U40,
+        Secp256k1Signature, Signature, SignedQuote, UserOp, U40,
     },
     upstream::Upstream,
 };
@@ -177,7 +177,13 @@ where
             .await
             .map_err(|err| EstimateFeeError::InternalError(err.into()))?;
         op.signature = Signature {
-            innerSignature: inner_signature.as_bytes().into(),
+            innerSignature: Secp256k1Signature {
+                r: inner_signature.r().into(),
+                s: inner_signature.s().into(),
+                v: inner_signature.v() as u8,
+            }
+            .abi_encode()
+            .into(),
             keyHash: key.key_hash(),
             prehash: false,
         }

--- a/src/types/op.rs
+++ b/src/types/op.rs
@@ -79,6 +79,13 @@ sol! {
         bool prehash;
     }
 
+    /// A signature for a Secp256k1 key.
+    struct Secp256k1Signature {
+        bytes32 r;
+        bytes32 s;
+        uint8 v;
+    }
+
     /// Returns the nonce salt.
     function nonceSalt() public view virtual returns (uint256);
 }


### PR DESCRIPTION
Ensures the encoding is 1:1 with the contract