### PR TITLE
feat: return revert reason for op

### DIFF
--- a/src/upstream.rs
+++ b/src/upstream.rs
@@ -59,8 +59,18 @@ where
         &self,
         tx: &TransactionRequest,
     ) -> Result<C::Return, SendActionError> {
+        self.call_with_overrides::<C>(tx, &AddressMap::from_iter([])).await
+    }
+
+    /// Perform an `eth_call` with overrides.
+    pub async fn call_with_overrides<C: SolCall>(
+        &self,
+        tx: &TransactionRequest,
+        overrides: &AddressMap<AccountOverride>,
+    ) -> Result<C::Return, SendActionError> {
         self.provider
             .call(tx)
+            .overrides(overrides)
             .await
             .map_err(|err| SendActionError::InternalError(err.into()))
             .and_then(|r| {


### PR DESCRIPTION
Does an `eth_call` and returns the error code returned by the entrypoint if it is non-zero.

The RPC error returned matches call reverts for `eth_call`, i.e. it has code 3, the revert reason in `data` and a message.

Closes #93 