### PR TITLE
fix: ensure secp256k1 sig is correctly encoded pt2

### DIFF
--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -39,7 +39,7 @@ use crate::{
     price::PriceOracle,
     types::{
         executeCall, nonceSaltCall, Action, FeeTokens, Key, KeyType, PartialAction, Quote,
-        Secp256k1Signature, Signature, SignedQuote, UserOp, U40,
+        Signature, SignedQuote, UserOp, U40,
     },
     upstream::Upstream,
 };
@@ -194,13 +194,7 @@ where
             .await
             .map_err(|err| EstimateFeeError::InternalError(err.into()))?;
         op.signature = Signature {
-            innerSignature: Secp256k1Signature {
-                r: inner_signature.r().into(),
-                s: inner_signature.s().into(),
-                v: inner_signature.v() as u8,
-            }
-            .abi_encode()
-            .into(),
+            innerSignature: inner_signature.as_bytes().into(), // (r, s, v + 27)
             keyHash: key.key_hash(),
             prehash: false,
         }

--- a/src/types/op.rs
+++ b/src/types/op.rs
@@ -79,13 +79,6 @@ sol! {
         bool prehash;
     }
 
-    /// A signature for a Secp256k1 key.
-    struct Secp256k1Signature {
-        bytes32 r;
-        bytes32 s;
-        uint8 v;
-    }
-
     /// Returns the nonce salt.
     function nonceSalt() public view virtual returns (uint256);
 }


### PR DESCRIPTION
We need to encode it as (r, s, v) where v is 27/28, not 0/1.