### PR TITLE
chore: rm metrics-derive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2924,18 +2924,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "metrics-derive"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3dbdd96ed57d565ec744cba02862d707acf373c5772d152abae6ec5c4e24f6c"
-dependencies = [
- "proc-macro2",
- "quote",
- "regex",
- "syn 2.0.98",
-]
-
-[[package]]
 name = "metrics-exporter-prometheus"
 version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3582,7 +3570,6 @@ dependencies = [
  "http-body 1.0.1",
  "jsonrpsee",
  "metrics",
- "metrics-derive",
  "metrics-exporter-prometheus",
  "reqwest",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,6 @@ http = "1"
 http-body = "1"
 jsonrpsee = { version = "0.24", features = ["server", "client", "macros"] }
 metrics = "0.24.0"
-metrics-derive = "0.1.0"
 metrics-exporter-prometheus = "0.16"
 reqwest = { version = "0.12", default-features = false }
 serde = "1"


### PR DESCRIPTION
we can just use `metrics` directly, functionally there is almost no difference