### PR TITLE
feat: fetch entrypoint addr from eoa

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ Run the relay, passing in the following flags. In the example below, the binary 
 ```sh
 cargo run --bin relay -- \
     --upstream $RPC_URL \
-    --entrypoint $ENTRYPOINT_ADDR \
     --fee-token $FEE_TOKEN_ADDR \ # You can pass this multiple times
     --secret-key $TX_SIGNING_PRIV_KEY \
     --quote-secret-key $QUOTE_SIGNING_PRIV_KEY

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -40,9 +40,6 @@ pub struct Args {
     /// Must be a valid HTTP or HTTPS URL pointing to an Ethereum JSON-RPC endpoint.
     #[arg(long, value_name = "RPC_ENDPOINT")]
     pub upstream: Url,
-    /// The address of the entrypoint contract.
-    #[arg(long, value_name = "ADDRESS")]
-    pub entrypoint: Address,
     /// The lifetime of a fee quote.
     #[arg(long, value_name = "SECONDS", value_parser = parse_duration_secs, default_value = "5")]
     pub quote_ttl: Duration,
@@ -84,7 +81,7 @@ impl Args {
         let quote_signer_addr = quote_signer.address();
 
         // construct rpc module
-        let upstream = Upstream::new(provider, self.entrypoint).await?;
+        let upstream = Upstream::new(provider).await?;
         let address = upstream.default_signer_address();
         let price_oracle = PriceOracle::new();
         price_oracle

--- a/src/types/account.rs
+++ b/src/types/account.rs
@@ -1,0 +1,10 @@
+use alloy::sol;
+
+sol! {
+    contract Delegation {
+        address public constant ENTRY_POINT;
+
+        /// Returns the nonce salt.
+        function nonceSalt() public view virtual returns (uint256);
+    }
+}

--- a/src/types/entrypoint.rs
+++ b/src/types/entrypoint.rs
@@ -1,24 +1,26 @@
 use alloy::sol;
 
 sol! {
-    /// For returning the gas used and the error from a simulation.
-    #[derive(Debug)]
-    error SimulationResult(uint256 gUsed, bytes4 err);
+    contract EntryPoint {
+        /// For returning the gas used and the error from a simulation.
+        #[derive(Debug)]
+        error SimulationResult(uint256 gUsed, bytes4 err);
 
-    /// Executes a single encoded user operation.
-    ///
-    /// `encodedUserOp` is given by `abi.encode(userOp)`, where `userOp` is a struct of type `UserOp`.
-    /// If sufficient gas is provided, returns an error selector that is non-zero
-    /// if there is an error during the payment, verification, and call execution.
-    function execute(bytes calldata encodedUserOp)
-        public
-        payable
-        virtual
-        nonReentrant
-        returns (bytes4 err);
+        /// Executes a single encoded user operation.
+        ///
+        /// `encodedUserOp` is given by `abi.encode(userOp)`, where `userOp` is a struct of type `UserOp`.
+        /// If sufficient gas is provided, returns an error selector that is non-zero
+        /// if there is an error during the payment, verification, and call execution.
+        function execute(bytes calldata encodedUserOp)
+            public
+            payable
+            virtual
+            nonReentrant
+            returns (bytes4 err);
 
-    /// Simulates an execution and reverts with the amount of gas used, and the error selector.
-    ///
-    /// An error selector of 0 means the call did not revert.
-    function simulateExecute(bytes calldata encodedUserOp) public payable virtual;
+        /// Simulates an execution and reverts with the amount of gas used, and the error selector.
+        ///
+        /// An error selector of 0 means the call did not revert.
+        function simulateExecute(bytes calldata encodedUserOp) public payable virtual;
+    }
 }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1,4 +1,7 @@
 //! Shared primitive types.
+mod account;
+pub use account::*;
+
 mod action;
 pub use action::*;
 

--- a/src/types/op.rs
+++ b/src/types/op.rs
@@ -68,9 +68,6 @@ sol! {
         bytes32 keyHash;
         bool prehash;
     }
-
-    /// Returns the nonce salt.
-    function nonceSalt() public view virtual returns (uint256);
 }
 
 mod eip712 {

--- a/src/upstream.rs
+++ b/src/upstream.rs
@@ -17,7 +17,6 @@ use crate::{
 pub struct Upstream<P> {
     provider: P,
     chain_id: ChainId,
-    entrypoint: Address,
 }
 
 impl<P> Upstream<P> {
@@ -32,19 +31,14 @@ where
     P: Provider + WalletProvider,
 {
     /// Create a new [`Upstream`]
-    pub async fn new(provider: P, entrypoint: Address) -> TransportResult<Self> {
+    pub async fn new(provider: P) -> TransportResult<Self> {
         let chain_id = provider.get_chain_id().await?;
-        Ok(Self { chain_id, provider, entrypoint })
+        Ok(Self { chain_id, provider })
     }
 
     /// Get the address of this upstream's signer.
     pub fn default_signer_address(&self) -> Address {
         self.provider.default_signer_address()
-    }
-
-    /// Get the entrypoint on this chain.
-    pub fn entrypoint(&self) -> Address {
-        self.entrypoint
     }
 
     /// Get the code of the given account.

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -152,7 +152,6 @@ async fn e2e() {
             address: std::net::IpAddr::V4(Ipv4Addr::LOCALHOST),
             port: 3131,
             upstream,
-            entrypoint,
             quote_ttl: Duration::from_secs(60),
             quote_secret_key: relay_key.clone(),
             fee_tokens: vec![erc20],


### PR DESCRIPTION
Instead of passing in the address of the entrypoint, we fetch it from the user account. This allows us to have multiple entrypoints running at the same time, as the EOA will validate that the call comes from a specific entrypoint. This also simplifies config somewhat.

One downside is that we don't necessarily know if we support the interface of the entrypoint. Later, we should fetch the entrypoint version and change how we interact with it accordingly, but this is fine for now.