### PR TITLE
refactor: wrapper structs for account & entrypoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,6 +63,8 @@ dependencies = [
  "alloy-serde",
  "alloy-signer",
  "alloy-signer-aws",
+ "alloy-signer-gcp",
+ "alloy-signer-ledger",
  "alloy-signer-local",
  "alloy-transport",
  "alloy-transport-http",
@@ -82,9 +84,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce20c85f6b24a5da40b2350a748e348417f0465dedbb523a4d149143bc4a41ce"
+checksum = "69e32ef5c74bbeb1733c37f4ac7f866f8c8af208b7b4265e21af609dcac5bd5e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -99,9 +101,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e23af02ccded0031ef2b70df4fe9965b1c742c5d5384c8c767ae0311f7e62b9"
+checksum = "0fa13b7b1e1e3fedc42f0728103bfa3b4d566d3d42b606db449504d88dbdbdcf"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -113,9 +115,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-contract"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71c7a59f261333db00fa10a3de9480f31121bb919ad38487040d7833d5982203"
+checksum = "ee6180fb232becdea70fad57c63b6967f01f74ab9595671b870f504116dd29de"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -133,9 +135,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-core"
-version = "0.8.20"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "074e41c92e2a3cc36448d4a9b94ba05b8faac466d7981d158ed68fd88e22d3b7"
+checksum = "482f377cebceed4bb1fb5e7970f0805e2ab123d06701be9351b67ed6341e74aa"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -146,15 +148,16 @@ dependencies = [
 
 [[package]]
 name = "alloy-dyn-abi"
-version = "0.8.20"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f2d547eba3f2d331b0e08f64a24e202f66d4f291e2a3e0073914c0e1400ced3"
+checksum = "555896f0b8578adb522b1453b6e6cc6704c3027bd0af20058befdde992cee8e9"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
  "alloy-sol-type-parser",
  "alloy-sol-types",
  "const-hex",
+ "derive_more",
  "itoa",
  "serde",
  "serde_json",
@@ -198,9 +201,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7149e011edbd588f6df6564b369c75f6b538d76db14053d95e0b43b2d92e4266"
+checksum = "5591581ca2ab0b3e7226a4047f9a1bfcf431da1d0cce3752fda609fea3c27e37"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -218,9 +221,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acaec0cc4c1489d61d6f33d0c3dd522c750025f4b5c8f59cd546221e4df660e5"
+checksum = "0cded3a2d4bd7173f696458c5d4c98c18a628dfcc9f194385e80a486e412e2e0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -231,9 +234,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-abi"
-version = "0.8.20"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d62cf1b25f5a50ca2d329b0b4aeb0a0dedeaf225ad3c5099d83b1a4c4616186e"
+checksum = "4012581681b186ba0882007ed873987cc37f86b1b488fe6b91d5efd0b585dc41"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-type-parser",
@@ -243,9 +246,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0c5c9651fd20a2fd4a57606b6a570d1c17ab86e686b962b2f1ecac68b51e020"
+checksum = "762414662d793d7aaa36ee3af6928b6be23227df1681ce9c039f6f11daadef64"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -257,9 +260,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b02ed56783fb2c086a4ac8961175dd6d3ad163e6cf6125f0b83f7de03379b607"
+checksum = "8be03f2ebc00cf88bd06d3c6caf387dceaa9c7e6b268216779fa68a9bf8ab4e6"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -282,9 +285,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0624cfa9311aa8283cd3bf5eed883d0d1e823e2a4d57b30e1b49af4b3678a6b"
+checksum = "3a00ce618ae2f78369918be0c20f620336381502c83b6ed62c2f7b2db27698b0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -295,12 +298,15 @@ dependencies = [
 
 [[package]]
 name = "alloy-node-bindings"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c96f1a87e3b2842d6a35bbebedf2bd48a49ee757ec63d0cfc1f3cb86338e972c"
+checksum = "81a3906afb50446392eb798dae4b918ba4ffcca47542efda7215776ddc8b5037"
 dependencies = [
  "alloy-genesis",
+ "alloy-network",
  "alloy-primitives",
+ "alloy-signer",
+ "alloy-signer-local",
  "k256",
  "rand",
  "serde_json",
@@ -312,9 +318,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "0.8.20"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc1360603efdfba91151e623f13a4f4d3dc4af4adc1cbd90bf37c81e84db4c77"
+checksum = "478bedf4d24e71ea48428d1bc278553bd7c6ae07c30ca063beb0b09fe58a9e74"
 dependencies = [
  "alloy-rlp",
  "bytes",
@@ -323,7 +329,7 @@ dependencies = [
  "derive_more",
  "foldhash",
  "hashbrown 0.15.2",
- "indexmap",
+ "indexmap 2.7.1",
  "itoa",
  "k256",
  "keccak-asm",
@@ -339,9 +345,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07c68df5354225da542efeb6d9388b65773b3304309b437416146e9d1e2bc1bd"
+checksum = "cbe0a2acff0c4bd1669c71251ce10fc455cbffa1b4d0a817d5ea4ba7e5bb3db7"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -354,8 +360,7 @@ dependencies = [
  "alloy-rpc-client",
  "alloy-rpc-types-anvil",
  "alloy-rpc-types-eth",
- "alloy-signer",
- "alloy-signer-local",
+ "alloy-sol-types",
  "alloy-transport",
  "alloy-transport-http",
  "async-stream",
@@ -366,7 +371,7 @@ dependencies = [
  "futures-utils-wasm",
  "lru",
  "parking_lot",
- "pin-project",
+ "pin-project 1.1.9",
  "reqwest",
  "serde",
  "serde_json",
@@ -401,16 +406,16 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0371aae9b44a35e374c94c7e1df5cbccf0f52b2ef7c782291ed56e86d88ec106"
+checksum = "b37cc3c7883dc41be1b01460127ad7930466d0a4bb6ba15a02ee34d2745e2d7c"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
  "alloy-transport",
  "alloy-transport-http",
  "futures",
- "pin-project",
+ "pin-project 1.1.9",
  "reqwest",
  "serde",
  "serde_json",
@@ -424,9 +429,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1428d64569961b00373c503a3de306656e94ef1f2a474e93fd41a6daae0d6ac7"
+checksum = "6f18e68a3882f372e045ddc89eb455469347767d17878ca492cfbac81e71a111"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-anvil",
@@ -437,9 +442,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d721727cc493a58bd197a3ebbd42b88c0393c1f30da905bb7a31686c820f4c2d"
+checksum = "10d06300df4a87d960add35909240fc72da355dd2ac926fa6999f9efafbdc5a7"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -449,9 +454,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66e119337400d8b0348e1576ab37ffa56d1a04cbc977a84d4fa0a527d7cb0c21"
+checksum = "318ae46dd12456df42527c3b94c1ae9001e1ceb707f7afe2c7807ac4e49ebad9"
 dependencies = [
  "alloy-consensus-any",
  "alloy-rpc-types-eth",
@@ -460,9 +465,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a4a43d8b1344e3ef115ed7a2cee934876e4a64d2b9d9bee8738f9806900757e"
+checksum = "8b4dbee4d82f8a22dde18c28257bed759afeae7ba73da4a1479a039fd1445d04"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -480,9 +485,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86aa42c36e3c0db5bd9a7314e98aa261a61d5e3d6a0bd7e51fb8b0a3d6438481"
+checksum = "8732058f5ca28c1d53d241e8504620b997ef670315d7c8afab856b3e3b80d945"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -491,13 +496,16 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c613222abd016e03ba548f41db938a2c99108b59c0c66ca105eab1b7a2e6b40a"
+checksum = "f96b3526fdd779a4bd0f37319cfb4172db52a7ac24cdbb8804b72091c18e1701"
 dependencies = [
+ "alloy-dyn-abi",
  "alloy-primitives",
+ "alloy-sol-types",
  "async-trait",
  "auto_impl",
+ "either",
  "elliptic-curve",
  "k256",
  "thiserror 2.0.11",
@@ -505,9 +513,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-aws"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "729df0003039c90f66f52a67b3dda8dbdcb6439585eeb72f0e0019950329a6ed"
+checksum = "f6f7fae8dec636317c89e08498675c9421a214f1791a59dcaea2094c1a2dbf07"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -522,10 +530,48 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloy-signer-local"
-version = "0.11.0"
+name = "alloy-signer-gcp"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39163b956c81e8fd9605194d6b5b92dd93b0e0252810e69f9a4cebe3a8614f46"
+checksum = "d7fcc881fb827d16c1379d375e7f5f26159039fb6956b9f1408989be6bf91444"
+dependencies = [
+ "alloy-consensus",
+ "alloy-network",
+ "alloy-primitives",
+ "alloy-signer",
+ "async-trait",
+ "gcloud-sdk",
+ "k256",
+ "spki",
+ "thiserror 2.0.11",
+ "tracing",
+]
+
+[[package]]
+name = "alloy-signer-ledger"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "327a0cfa3d68a60862aeaa42fbdfb5cc7d66275a79e01a3f9cfe38d293b6215a"
+dependencies = [
+ "alloy-consensus",
+ "alloy-dyn-abi",
+ "alloy-network",
+ "alloy-primitives",
+ "alloy-signer",
+ "alloy-sol-types",
+ "async-trait",
+ "coins-ledger",
+ "futures-util",
+ "semver 1.0.25",
+ "thiserror 2.0.11",
+ "tracing",
+]
+
+[[package]]
+name = "alloy-signer-local"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe8f78cd6b7501c7e813a1eb4a087b72d23af51f5bb66d4e948dc840bdd207d8"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -539,9 +585,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro"
-version = "0.8.20"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13f28f2131dc3a7b8e2cda882758ad4d5231ca26281b9861d4b18c700713e2da"
+checksum = "a2708e27f58d747423ae21d31b7a6625159bd8d867470ddd0256f396a68efa11"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
@@ -553,15 +599,15 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-expander"
-version = "0.8.20"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ee2da033256a3b27131c030933eab0460a709fbcc4d4bd57bf9a5650b2441c5"
+checksum = "c6b7984d7e085dec382d2c5ef022b533fcdb1fe6129200af30ebf5afddb6a361"
 dependencies = [
  "alloy-json-abi",
  "alloy-sol-macro-input",
  "const-hex",
  "heck",
- "indexmap",
+ "indexmap 2.7.1",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
@@ -572,9 +618,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "0.8.20"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e9d9918b0abb632818bf27e2dfb86b209be8433baacf22100b190bbc0904bd4"
+checksum = "33d6a9fc4ed1a3c70bdb2357bec3924551c1a59f24e5a04a74472c755b37f87d"
 dependencies = [
  "alloy-json-abi",
  "const-hex",
@@ -589,9 +635,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-type-parser"
-version = "0.8.20"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a971129d242338d92009470a2f750d3b2630bc5da00a40a94d51f5d456b5712f"
+checksum = "1b1b3e9a48a6dd7bb052a111c8d93b5afc7956ed5e2cb4177793dc63bb1d2a36"
 dependencies = [
  "serde",
  "winnow",
@@ -599,9 +645,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-types"
-version = "0.8.20"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75f306fc801b3aa2e3c4785b7b5252ec8b19f77b30e3b75babfd23849c81bd8c"
+checksum = "6044800da35c38118fd4b98e18306bd3b91af5dedeb54c1b768cf1b4fb68f549"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -612,9 +658,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40e2f34fcd849676c8fe274a6e72f0664dfede7ce06d12daa728d2e72f1b4393"
+checksum = "5a8d762eadce3e9b65eac09879430c6f4fce3736cac3cac123f9b1bf435ddd13"
 dependencies = [
  "alloy-json-rpc",
  "base64 0.22.1",
@@ -631,9 +677,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e291c97c3c0ebb5d03c34e3a55c0f7c5bfa307536a2efaaa6fae4b3a4d09851"
+checksum = "20819c4cb978fb39ce6ac31991ba90f386d595f922f42ef888b4a18be190713e"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -646,9 +692,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-trie"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6917c79e837aa7b77b7a6dae9f89cbe15313ac161c4d3cfaf8909ef21f3d22d8"
+checksum = "d95a94854e420f07e962f7807485856cde359ab99ab6413883e15235ad996e8b"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -658,6 +704,21 @@ dependencies = [
  "serde",
  "smallvec",
  "tracing",
+]
+
+[[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -709,6 +770,12 @@ dependencies = [
  "once_cell",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "anyhow"
+version = "1.0.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
 
 [[package]]
 name = "ark-ff"
@@ -841,6 +908,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "async-compression"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df895a515f70646414f4b45c0b79082783b80552b373a68283012928df56f522"
+dependencies = [
+ "flate2",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -1247,6 +1327,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http 1.2.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper",
+ "tower 0.5.2",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http 1.2.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1301,7 +1428,7 @@ version = "0.69.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
 dependencies = [
- "bitflags",
+ "bitflags 2.8.0",
  "cexpr",
  "clang-sys",
  "itertools 0.12.1",
@@ -1335,6 +1462,12 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
@@ -1362,9 +1495,9 @@ dependencies = [
 
 [[package]]
 name = "blst"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4378725facc195f1a538864863f6de233b500a8862747e7f165078a419d5e874"
+checksum = "47c79a94619fade3c0b887670333513a67ac28a6a7e653eb260bf0d4103db38d"
 dependencies = [
  "cc",
  "glob",
@@ -1426,9 +1559,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.12"
+version = "1.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "755717a7de9ec452bf7f3f1a3099085deabd7f2962b861dae91ecd7a365903d2"
+checksum = "c7777341816418c02e033934a09f20dc0ccaf65a5201ef8a450ae0105a573fda"
 dependencies = [
  "jobserver",
  "libc",
@@ -1455,6 +1588,25 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chrono"
+version = "0.4.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "num-traits",
+ "serde",
+ "windows-targets",
+]
 
 [[package]]
 name = "clang-sys"
@@ -1509,11 +1661,34 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "cmake"
-version = "0.1.53"
+version = "0.1.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e24a03c8b52922d68a1589ad61032f2c1aa5a8158d2aa0d93c6e9534944bbad6"
+checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "coins-ledger"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab9bc0994d0aa0f4ade5f3a9baf4a8d936f250278c85a1124b401860454246ab"
+dependencies = [
+ "async-trait",
+ "byteorder",
+ "cfg-if",
+ "const-hex",
+ "getrandom 0.2.15",
+ "hidapi-rusb",
+ "js-sys",
+ "log",
+ "nix",
+ "once_cell",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -1622,6 +1797,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
+name = "crc32fast"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1685,6 +1869,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
 dependencies = [
  "const-oid",
+ "pem-rfc7468",
  "zeroize",
 ]
 
@@ -1799,6 +1984,7 @@ dependencies = [
  "ff",
  "generic-array",
  "group",
+ "pem-rfc7468",
  "pkcs8",
  "rand_core",
  "sec1",
@@ -1869,6 +2055,16 @@ dependencies = [
  "rand",
  "rustc-hex",
  "static_assertions",
+]
+
+[[package]]
+name = "flate2"
+version = "1.0.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -2025,6 +2221,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42012b0f064e01aa58b545fe3727f90f7dd4020f4a3ea735b50344965f5a57e9"
 
 [[package]]
+name = "gcloud-sdk"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6392faf01950e198a204b13034efd7aadda1877e7c174f5442ee39bad5d99bd"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "chrono",
+ "futures",
+ "hyper 1.6.0",
+ "jsonwebtoken",
+ "once_cell",
+ "prost",
+ "prost-types",
+ "reqwest",
+ "secret-vault-value",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tonic",
+ "tower 0.5.2",
+ "tower-layer",
+ "tower-util",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2042,8 +2266,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2082,7 +2308,7 @@ dependencies = [
  "gloo-utils",
  "http 1.2.0",
  "js-sys",
- "pin-project",
+ "pin-project 1.1.9",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -2139,7 +2365,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap",
+ "indexmap 2.7.1",
  "slab",
  "tokio",
  "tokio-util",
@@ -2158,12 +2384,18 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.2.0",
- "indexmap",
+ "indexmap 2.7.1",
  "slab",
  "tokio",
  "tokio-util",
  "tracing",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -2202,6 +2434,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "hidapi-rusb"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efdc2ec354929a6e8f3c6b6923a4d97427ec2f764cfee8cd4bfe890946cdf08b"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "rusb",
 ]
 
 [[package]]
@@ -2362,11 +2606,24 @@ dependencies = [
  "hyper 1.6.0",
  "hyper-util",
  "log",
- "rustls 0.23.22",
+ "rustls 0.23.23",
  "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.1",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper 1.6.0",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
  "tower-service",
 ]
 
@@ -2403,6 +2660,29 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -2572,6 +2852,16 @@ checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
@@ -2695,8 +2985,8 @@ dependencies = [
  "gloo-net",
  "http 1.2.0",
  "jsonrpsee-core",
- "pin-project",
- "rustls 0.23.22",
+ "pin-project 1.1.9",
+ "rustls 0.23.23",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "soketto",
@@ -2723,7 +3013,7 @@ dependencies = [
  "http-body-util",
  "jsonrpsee-types",
  "parking_lot",
- "pin-project",
+ "pin-project 1.1.9",
  "rand",
  "rustc-hash 2.1.1",
  "serde",
@@ -2749,7 +3039,7 @@ dependencies = [
  "hyper-util",
  "jsonrpsee-core",
  "jsonrpsee-types",
- "rustls 0.23.22",
+ "rustls 0.23.23",
  "rustls-platform-verifier",
  "serde",
  "serde_json",
@@ -2787,7 +3077,7 @@ dependencies = [
  "hyper-util",
  "jsonrpsee-core",
  "jsonrpsee-types",
- "pin-project",
+ "pin-project 1.1.9",
  "route-recognizer",
  "serde",
  "serde_json",
@@ -2834,6 +3124,21 @@ dependencies = [
  "jsonrpsee-core",
  "jsonrpsee-types",
  "url",
+]
+
+[[package]]
+name = "jsonwebtoken"
+version = "9.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+dependencies = [
+ "base64 0.22.1",
+ "js-sys",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
 ]
 
 [[package]]
@@ -2897,6 +3202,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "libusb1-sys"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da050ade7ac4ff1ba5379af847a10a10a8e284181e060105bf8d86960ce9ce0f"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2943,10 +3260,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "memoffset"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "metrics"
@@ -2969,7 +3301,7 @@ dependencies = [
  "hyper 1.6.0",
  "hyper-rustls 0.27.5",
  "hyper-util",
- "indexmap",
+ "indexmap 2.7.1",
  "ipnet",
  "metrics",
  "metrics-util",
@@ -3002,6 +3334,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3009,9 +3351,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8402cab7aefae129c6977bb0ff1b8fd9a04eb5b51efc50a70bea51cda0c7924"
+checksum = "b3b1c9bd4fe1f0f8b387f6eb9eb3b4a1aa26185e5750efb9140301703f62cd1b"
 dependencies = [
  "adler2",
 ]
@@ -3042,6 +3384,19 @@ dependencies = [
  "security-framework 2.11.1",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+ "memoffset",
+ "pin-utils",
 ]
 
 [[package]]
@@ -3162,7 +3517,7 @@ version = "0.10.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61cfb4e166a8bb8c9b55c500bc2308550148ece889be90f609377e58140f42c6"
 dependencies = [
- "bitflags",
+ "bitflags 2.8.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -3270,6 +3625,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pem"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e459365e590736a54c3fa561947c84837534b8e9af6fc5bf781307e82658fae"
+dependencies = [
+ "base64 0.22.1",
+ "serde",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3288,11 +3662,31 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
+version = "0.4.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ef0f924a5ee7ea9cbcea77529dba45f8a9ba9f622419fe3386ca581a3ae9d5a"
+dependencies = [
+ "pin-project-internal 0.4.30",
+]
+
+[[package]]
+name = "pin-project"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfe2e71e1471fe07709406bf725f710b02927c9c54b2b5b2ec0e8087d97c327d"
 dependencies = [
- "pin-project-internal",
+ "pin-project-internal 1.1.9",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "0.4.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "851c8d0ce9bebe43790dedfc86614c23494ac9f423dd618d3a61fc693eafe61e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3424,7 +3818,7 @@ checksum = "14cae93065090804185d3b75f0bf93b8eeda30c7a9b4a33d3bdb3988d6229e50"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags",
+ "bitflags 2.8.0",
  "lazy_static",
  "num-traits",
  "rand",
@@ -3434,6 +3828,38 @@ dependencies = [
  "rusty-fork",
  "tempfile",
  "unarray",
+]
+
+[[package]]
+name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
+dependencies = [
+ "prost",
 ]
 
 [[package]]
@@ -3456,6 +3882,58 @@ name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quinn"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62e96808277ec6f97351a2380e6c25114bc9e67037775464979f3037c92d05ef"
+dependencies = [
+ "bytes",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash 2.1.1",
+ "rustls 0.23.23",
+ "socket2",
+ "thiserror 2.0.11",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2fe5ef3495d7d2e377ff17b1a8ce2ee2ec2a18cde8b6ad6619d65d0701c135d"
+dependencies = [
+ "bytes",
+ "getrandom 0.2.15",
+ "rand",
+ "ring",
+ "rustc-hash 2.1.1",
+ "rustls 0.23.23",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.11",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c40286217b4ba3a71d644d752e6a0b71f13f1b6a2c5311acfcbe0c2418ed904"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "quote"
@@ -3527,7 +4005,7 @@ version = "11.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6928fa44c097620b706542d428957635951bade7143269085389d42c8a4927e"
 dependencies = [
- "bitflags",
+ "bitflags 2.8.0",
 ]
 
 [[package]]
@@ -3536,7 +4014,7 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
 dependencies = [
- "bitflags",
+ "bitflags 2.8.0",
 ]
 
 [[package]]
@@ -3624,6 +4102,7 @@ version = "0.12.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da"
 dependencies = [
+ "async-compression",
  "base64 0.22.1",
  "bytes",
  "futures-core",
@@ -3632,28 +4111,37 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.6.0",
+ "hyper-rustls 0.27.5",
  "hyper-tls",
  "hyper-util",
  "ipnet",
  "js-sys",
  "log",
  "mime",
+ "mime_guess",
  "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls 0.23.23",
+ "rustls-native-certs 0.8.1",
  "rustls-pemfile 2.2.0",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls 0.26.1",
+ "tokio-util",
  "tower 0.5.2",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "windows-registry",
 ]
@@ -3730,6 +4218,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
 
 [[package]]
+name = "rusb"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab9f9ff05b63a786553a4c02943b74b34a988448671001e9a27e2f0565cc05a4"
+dependencies = [
+ "libc",
+ "libusb1-sys",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3777,7 +4275,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags",
+ "bitflags 2.8.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -3798,9 +4296,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.22"
+version = "0.23.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb9263ab4eb695e42321db096e3b8fbd715a59b154d5c88d82db2175b681ba7"
+checksum = "47796c98c480fce5406ef69d1c76378375492c3b0a0de587be0c1d9feb12f395"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -3872,6 +4370,9 @@ name = "rustls-pki-types"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
+dependencies = [
+ "web-time",
+]
 
 [[package]]
 name = "rustls-platform-verifier"
@@ -3884,7 +4385,7 @@ dependencies = [
  "jni",
  "log",
  "once_cell",
- "rustls 0.23.22",
+ "rustls 0.23.23",
  "rustls-native-certs 0.7.3",
  "rustls-platform-verifier-android",
  "rustls-webpki 0.102.8",
@@ -3995,12 +4496,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "secret-vault-value"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc32a777b53b3433b974c9c26b6d502a50037f8da94e46cb8ce2ced2cfdfaea0"
+dependencies = [
+ "prost",
+ "prost-types",
+ "serde",
+ "serde_json",
+ "zeroize",
+]
+
+[[package]]
 name = "security-framework"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags",
+ "bitflags 2.8.0",
  "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
@@ -4014,7 +4528,7 @@ version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
 dependencies = [
- "bitflags",
+ "bitflags 2.8.0",
  "core-foundation 0.10.0",
  "core-foundation-sys",
  "libc",
@@ -4182,6 +4696,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "simple_asn1"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror 2.0.11",
+ "time",
+]
+
+[[package]]
 name = "sketches-ddsketch"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4317,9 +4843,9 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "0.8.20"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f6a4b9002584ea56d0a19713b65da44cbbf6070aca9ae0360577cba5c4db68"
+checksum = "9c2de690018098e367beeb793991c7d4dc7270f42c9d2ac4ccc876c1368ca430"
 dependencies = [
  "paste",
  "proc-macro2",
@@ -4433,6 +4959,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
 dependencies = [
  "deranged",
+ "itoa",
  "num-conv",
  "powerfmt",
  "serde",
@@ -4474,6 +5001,21 @@ dependencies = [
  "displaydoc",
  "zerovec",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "022db8904dfa342efe721985167e9fcd16c29b226db4397ed752a761cfce81e8"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -4529,7 +5071,7 @@ version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37"
 dependencies = [
- "rustls 0.23.22",
+ "rustls 0.23.23",
  "tokio",
 ]
 
@@ -4567,13 +5109,46 @@ checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
 
 [[package]]
 name = "toml_edit"
-version = "0.22.23"
+version = "0.22.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02a8b472d1a3d7c18e2d61a489aee3453fd9031c33e4f55bd533f4a7adca1bee"
+checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
 dependencies = [
- "indexmap",
+ "indexmap 2.7.1",
  "toml_datetime",
  "winnow",
+]
+
+[[package]]
+name = "tonic"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum",
+ "base64 0.22.1",
+ "bytes",
+ "h2 0.4.7",
+ "http 1.2.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.6.0",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project 1.1.9",
+ "prost",
+ "rustls-native-certs 0.8.1",
+ "rustls-pemfile 2.2.0",
+ "socket2",
+ "tokio",
+ "tokio-rustls 0.26.1",
+ "tokio-stream",
+ "tower 0.4.13",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -4584,8 +5159,13 @@ checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
  "futures-core",
  "futures-util",
- "pin-project",
+ "indexmap 1.9.3",
+ "pin-project 1.1.9",
  "pin-project-lite",
+ "rand",
+ "slab",
+ "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -4612,7 +5192,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "403fa3b783d4b626a8ad51d766ab03cb6d2dbfc46b1c5d4448395e6628dc9697"
 dependencies = [
- "bitflags",
+ "bitflags 2.8.0",
  "bytes",
  "http 1.2.0",
  "pin-project-lite",
@@ -4631,6 +5211,18 @@ name = "tower-service"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tower-util"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1093c19826d33807c72511e68f73b4a0469a3f22c2bd5f7d5212178b4b89674"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project 0.4.30",
+ "tower-service",
+]
 
 [[package]]
 name = "tracing"
@@ -4729,6 +5321,12 @@ name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
+name = "unicase"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
 name = "unicode-ident"
@@ -4928,6 +5526,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "wasmtimer"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4946,6 +5557,16 @@ name = "web-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5002,6 +5623,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-registry"
@@ -5117,9 +5747,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86e376c75f4f43f44db463cf729e0d3acbf954d13e22c51e26e4c264b4ab545f"
+checksum = "59690dea168f2198d1a3b0cac23b8063efcd11012f10ae4698f284808c8ef603"
 dependencies = [
  "memchr",
 ]
@@ -5130,7 +5760,7 @@ version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
 dependencies = [
- "bitflags",
+ "bitflags 2.8.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ name = "relay"
 [dependencies]
 alloy = { version = "0.11", features = [
     "dyn-abi",
+    "eip712",
     "providers",
     "rpc",
     "rpc-types",

--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ Run the relay, passing in the following flags. In the example below, the binary 
 ```sh
 cargo run --bin relay -- \
     --upstream $RPC_URL \
-    --entrypoint $ENTRYPOINT_ADDR \
     --fee-token $FEE_TOKEN_ADDR \ # You can pass this multiple times
     --secret-key $TX_SIGNING_PRIV_KEY \
     --quote-secret-key $QUOTE_SIGNING_PRIV_KEY

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -40,9 +40,6 @@ pub struct Args {
     /// Must be a valid HTTP or HTTPS URL pointing to an Ethereum JSON-RPC endpoint.
     #[arg(long, value_name = "RPC_ENDPOINT")]
     pub upstream: Url,
-    /// The address of the entrypoint contract.
-    #[arg(long, value_name = "ADDRESS")]
-    pub entrypoint: Address,
     /// The lifetime of a fee quote.
     #[arg(long, value_name = "SECONDS", value_parser = parse_duration_secs, default_value = "5")]
     pub quote_ttl: Duration,
@@ -84,7 +81,7 @@ impl Args {
         let quote_signer_addr = quote_signer.address();
 
         // construct rpc module
-        let upstream = Upstream::new(provider, self.entrypoint).await?;
+        let upstream = Upstream::new(provider).await?;
         let address = upstream.default_signer_address();
         let price_oracle = PriceOracle::new();
         price_oracle

--- a/src/error.rs
+++ b/src/error.rs
@@ -125,10 +125,26 @@ pub enum PriceOracleError {
 /// Errors when performing `eth_call`s and decoding the result.
 #[derive(Debug, thiserror::Error)]
 pub enum CallError {
+    /// The userop reverted when estimating gas.
+    #[error("op reverted")]
+    OpRevert {
+        /// The error code returned by the entrypoint.
+        revert_reason: Bytes,
+    },
     /// An error occurred talking to RPC.
     #[error(transparent)]
     RpcError(#[from] alloy::transports::RpcError<alloy::transports::TransportErrorKind>),
     /// An error occurred ABI enc/decoding.
     #[error(transparent)]
     AbiError(#[from] alloy::sol_types::Error),
+}
+
+impl From<CallError> for EstimateFeeError {
+    fn from(err: CallError) -> Self {
+        match err {
+            CallError::OpRevert { revert_reason } => Self::OpRevert { revert_reason },
+            CallError::RpcError(err) => Self::RpcError(err),
+            CallError::AbiError(err) => Self::InternalError(err.into()),
+        }
+    }
 }

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -11,11 +11,12 @@
 use alloy::{
     eips::eip7702::constants::{PER_AUTH_BASE_COST, PER_EMPTY_ACCOUNT_COST},
     hex,
-    primitives::{fixed_bytes, map::AddressMap, Address, Bytes, TxHash, U256},
+    network::{TransactionBuilder, TransactionBuilder7702},
+    primitives::{map::AddressMap, Address, Bytes, TxHash, U256},
     providers::{Provider, WalletProvider},
     rpc::types::{state::AccountOverride, TransactionRequest},
     signers::Signer,
-    sol_types::{SolCall, SolError, SolValue},
+    sol_types::{SolCall, SolValue},
 };
 use jsonrpsee::{
     core::{async_trait, RpcResult},
@@ -29,11 +30,11 @@ use tracing::{debug, warn};
 
 use crate::{
     constants::{INNER_ENTRYPOINT_GAS_OVERHEAD, TX_GAS_BUFFER, USER_OP_GAS_BUFFER},
-    error::{CallError, EstimateFeeError, SendActionError},
+    error::{EstimateFeeError, SendActionError},
     price::PriceOracle,
     types::{
-        executeCall, nonceSaltCall, simulateExecuteCall, Action, FeeTokens, Key, KeyType,
-        PartialAction, Quote, Signature, SignedQuote, SimulationResult, UserOp, U40,
+        Account, Action, Entry, EntryPoint, FeeTokens, Key, KeyType, PartialAction, Quote,
+        Signature, SignedQuote, UserOp, U40,
     },
     upstream::Upstream,
 };
@@ -122,13 +123,11 @@ where
         let overrides = AddressMap::from_iter([
             (
                 self.inner.quote_signer.address(),
-                AccountOverride {
-                    balance: Some(U256::MAX.div_ceil(2.try_into().unwrap())),
-                    ..Default::default()
-                },
+                AccountOverride::default().with_balance(U256::MAX.div_ceil(2.try_into().unwrap())),
             ),
             (
                 request.op.eoa,
+                // todo: we can't use builder api here because we only maybe set the code sometimes https://github.com/alloy-rs/alloy/issues/2062
                 AccountOverride {
                     state_diff: Some(key.storage_slots()),
                     // we manually etch the 7702 designator since we do not have a signed auth item
@@ -140,49 +139,38 @@ where
             ),
         ]);
 
+        // load account and entrypoint
+        let account = Account::new(request.op.eoa, self.inner.upstream.provider())
+            .with_overrides(overrides.clone());
+        let entrypoint = Entry::new(
+            account.entrypoint().await.map_err(EstimateFeeError::from)?,
+            self.inner.upstream.provider(),
+        )
+        .with_overrides(overrides.clone());
+
         // fill userop
         let mut op = UserOp {
             eoa: request.op.eoa,
             executionData: request.op.executionData.clone(),
             nonce: request.op.nonce,
-            payer: Address::ZERO,
             paymentToken: token.address,
-            paymentRecipient: Address::ZERO,
-            paymentAmount: U256::ZERO,
-            paymentMaxAmount: U256::ZERO,
-            paymentPerGas: U256::ZERO,
             // we intentionally do not use the maximum amount of gas since the contracts add a small
             // overhead when checking if there is sufficient gas for the op
             combinedGas: U256::from(20_000_000),
-            signature: Bytes::default(),
+            ..Default::default()
         };
 
         // sign userop
-        debug!(eoa = %request.op.eoa, "Retrieving nonce salt");
-        let nonce_salt = self
-            .inner
-            .upstream
-            .call_with_overrides::<nonceSaltCall>(
-                &TransactionRequest {
-                    to: Some(request.op.eoa.into()),
-                    input: nonceSaltCall {}.abi_encode().into(),
-                    ..Default::default()
-                },
-                &overrides,
-            )
-            .await
-            .map_or(U256::ZERO, |ret| ret._0);
-        debug!(eoa = %request.op.eoa, "Got nonce salt {nonce_salt}");
         let inner_signature = self
             .inner
             .quote_signer
-            .sign_hash(
-                &op.eip712_digest(
-                    self.inner.upstream.entrypoint(),
-                    self.inner.upstream.chain_id(),
-                    nonce_salt,
-                )
-                .map_err(|err| EstimateFeeError::InternalError(err.into()))?,
+            .sign_typed_data(
+                &op.as_eip712(account.nonce_salt().await.unwrap_or_default())
+                    .map_err(|err| EstimateFeeError::InternalError(err.into()))?,
+                &entrypoint
+                    .eip712_domain(op.is_multichain())
+                    .await
+                    .map_err(EstimateFeeError::from)?,
             )
             .await
             .map_err(|err| EstimateFeeError::InternalError(err.into()))?;
@@ -196,39 +184,8 @@ where
 
         // we perform a call to `simulateExecute`, which reverts with the amount of gas used and an
         // error selector.
-        let mut gas_estimate = match self
-            .inner
-            .upstream
-            .call_with_overrides::<simulateExecuteCall>(
-                &TransactionRequest {
-                    from: Some(self.inner.quote_signer.address()),
-                    to: Some(self.inner.upstream.entrypoint().into()),
-                    input: simulateExecuteCall { encodedUserOp: op.abi_encode().into() }
-                        .abi_encode()
-                        .into(),
-                    ..Default::default()
-                },
-                &overrides,
-            )
-            .await
-        {
-            Err(CallError::RpcError(alloy::transports::RpcError::ErrorResp(err))) => {
-                let data = err.as_revert_data().unwrap_or_default();
-                if let Ok(result) = SimulationResult::abi_decode(&data, false) {
-                    if result.err != fixed_bytes!("00000000") {
-                        return Err(EstimateFeeError::OpRevert {
-                            revert_reason: result.err.into(),
-                        }
-                        .into());
-                    }
-
-                    result.gUsed.to::<u64>()
-                } else {
-                    return Err(EstimateFeeError::OpRevert { revert_reason: data }.into());
-                }
-            }
-            _ => return Err(EstimateFeeError::SimulationError.into()),
-        };
+        let mut gas_estimate =
+            entrypoint.simulate_execute(&op).await.map_err(EstimateFeeError::from)?.to::<u64>();
         let native_fee_estimate =
             self.inner.upstream.estimate_eip1559().await.map_err(EstimateFeeError::from)?;
 
@@ -243,7 +200,6 @@ where
 
         // Add some leeway, since the actual simulation may no be enough.
         gas_estimate += USER_OP_GAS_BUFFER;
-
         debug!(eoa = %request.op.eoa, gas_estimate = %gas_estimate, "Estimated operation");
 
         // Get paymentPerGas
@@ -282,65 +238,87 @@ where
     }
 
     // todo: chain ids
-    async fn send_action(&self, action: Action, quote: SignedQuote) -> RpcResult<TxHash> {
+    async fn send_action(&self, request: Action, quote: SignedQuote) -> RpcResult<TxHash> {
         // verify payment recipient is entrypoint or us
-        if !action.op.paymentRecipient.is_zero()
-            && action.op.paymentRecipient != self.inner.upstream.default_signer_address()
+        if !request.op.paymentRecipient.is_zero()
+            && request.op.paymentRecipient != self.inner.upstream.default_signer_address()
         {
             return Err(SendActionError::WrongPaymentRecipient.into());
         }
 
+        // possibly mocking the code for the eoa
+        let overrides = AddressMap::from_iter([(
+            request.op.eoa,
+            AccountOverride {
+                // we manually etch the 7702 designator since we do not have a signed auth item
+                code: request.auth.as_ref().map(|auth| {
+                    Bytes::from([&EIP7702_DELEGATION_DESIGNATOR, auth.address.as_slice()].concat())
+                }),
+                ..Default::default()
+            },
+        )]);
+
+        // get the account and entrypoint
+        let account =
+            Account::new(request.op.eoa, self.inner.upstream.provider()).with_overrides(overrides);
+        let entrypoint =
+            account.entrypoint().await.map_err(|err| SendActionError::InternalError(err.into()))?;
+
         // Calculate tx.gas with the 63/64 check, auth cost and extra for leeway.
         let mut tx_gas =
             TX_GAS_BUFFER + ((quote.ty().gas_estimate + INNER_ENTRYPOINT_GAS_OVERHEAD) * 64) / 63;
-        if action.auth.is_some() {
+        if request.auth.is_some() {
             tx_gas += PER_AUTH_BASE_COST + PER_EMPTY_ACCOUNT_COST;
         }
 
-        let mut request = TransactionRequest {
-            input: executeCall { encodedUserOp: action.op.abi_encode().into() }.abi_encode().into(),
-            to: Some(self.inner.upstream.entrypoint().into()),
-            // note: we also set the `from` field here to correctly estimate for contracts that use
-            // e.g. `tx.origin`
-            from: Some(self.inner.upstream.default_signer_address()),
-            chain_id: Some(self.inner.upstream.chain_id()),
-            gas: Some(tx_gas),
-            max_fee_per_gas: Some(quote.ty().native_fee_estimate.max_fee_per_gas),
-            max_priority_fee_per_gas: Some(quote.ty().native_fee_estimate.max_priority_fee_per_gas),
-            ..Default::default()
-        };
+        let mut tx = TransactionRequest::default()
+            .with_chain_id(self.inner.upstream.chain_id())
+            .input(
+                EntryPoint::executeCall { encodedUserOp: request.op.abi_encode().into() }
+                    .abi_encode()
+                    .into(),
+            )
+            .to(entrypoint)
+            .from(self.inner.upstream.default_signer_address())
+            .gas_limit(tx_gas)
+            .max_fee_per_gas(quote.ty().native_fee_estimate.max_fee_per_gas)
+            .max_priority_fee_per_gas(quote.ty().native_fee_estimate.max_priority_fee_per_gas);
 
-        if let Some(auth) = action.auth {
+        if let Some(auth) = request.auth {
             // todo: persist auth
             if !auth.inner().chain_id().is_zero() {
                 return Err(SendActionError::AuthItemNotChainAgnostic.into());
             }
-            request.authorization_list = Some(vec![auth]);
+            tx.set_authorization_list(vec![auth]);
         } else {
-            let code =
-                self.inner.upstream.get_code(action.op.eoa).await.map_err(SendActionError::from)?;
+            let code = self
+                .inner
+                .upstream
+                .get_code(request.op.eoa)
+                .await
+                .map_err(SendActionError::from)?;
 
             if code.get(..3) != Some(&EIP7702_DELEGATION_DESIGNATOR[..])
                 || code[..] == EIP7702_CLEARED_DELEGATION
             {
-                return Err(SendActionError::EoaNotDelegated(action.op.eoa).into());
+                return Err(SendActionError::EoaNotDelegated(request.op.eoa).into());
             }
         }
 
         // check that the payment amount matches whats in the quote
-        if quote.ty().amount != action.op.paymentAmount {
+        if quote.ty().amount != request.op.paymentAmount {
             return Err(SendActionError::InvalidFeeAmount {
                 expected: quote.ty().amount,
-                got: action.op.paymentAmount,
+                got: request.op.paymentAmount,
             }
             .into());
         }
 
         // check that digest of the userop is the same as in the quote
-        if quote.ty().digest != action.op.digest() {
+        if quote.ty().digest != request.op.digest() {
             return Err(SendActionError::InvalidOpDigest {
                 expected: quote.ty().digest,
-                got: action.op.digest(),
+                got: request.op.digest(),
             }
             .into());
         }
@@ -364,7 +342,7 @@ where
         Ok(self
             .inner
             .upstream
-            .sign_and_send(request)
+            .sign_and_send(tx)
             .await
             .inspect_err(
                 |err| warn!(target: "rpc::wallet", ?err, "Error adding sponsored tx to pool"),

--- a/src/types/account.rs
+++ b/src/types/account.rs
@@ -1,0 +1,81 @@
+use alloy::{
+    primitives::{Address, U256},
+    providers::Provider,
+    rpc::types::state::StateOverride,
+    sol,
+    transports::{TransportErrorKind, TransportResult},
+};
+use tracing::debug;
+use Delegation::DelegationInstance;
+
+sol! {
+    #[sol(rpc)]
+    contract Delegation {
+        address public constant ENTRY_POINT;
+
+        /// Returns the nonce salt.
+        function nonceSalt() public view virtual returns (uint256);
+    }
+}
+
+/// A Porto account.
+#[derive(Debug)]
+pub struct Account<P: Provider> {
+    delegation: DelegationInstance<(), P>,
+    overrides: StateOverride,
+}
+
+impl<P: Provider> Account<P> {
+    /// Create a new instance of [`Account`].
+    pub fn new(address: Address, provider: P) -> Self {
+        Self {
+            delegation: DelegationInstance::new(address, provider),
+            overrides: StateOverride::default(),
+        }
+    }
+
+    /// Sets overrides for all calls on this account.
+    pub fn with_overrides(mut self, overrides: StateOverride) -> Self {
+        self.overrides = overrides;
+        self
+    }
+
+    /// Get the entrypoint address for this account.
+    pub async fn entrypoint(&self) -> TransportResult<Address> {
+        debug!(eoa = %self.delegation.address(), "Fetching entrypoint");
+        let entrypoint = self
+            .delegation
+            .ENTRY_POINT()
+            .call()
+            .overrides(&self.overrides)
+            .await
+            .map_err(TransportErrorKind::custom)?;
+        debug!(
+            eoa = %self.delegation.address(),
+            entrypoint = %entrypoint.ENTRY_POINT,
+            "Fetched entrypoint"
+        );
+
+        Ok(entrypoint.ENTRY_POINT)
+    }
+
+    /// Get the nonce salt for this account.
+    pub async fn nonce_salt(&self) -> TransportResult<U256> {
+        debug!(eoa = %self.delegation.address(), "Fetching nonce salt");
+        let nonce_salt = self
+            .delegation
+            .nonceSalt()
+            .call()
+            .overrides(&self.overrides)
+            .await
+            .map_err(TransportErrorKind::custom)?
+            ._0;
+        debug!(
+            eoa = %self.delegation.address(),
+            "Fetched nonce salt {}",
+            nonce_salt
+        );
+
+        Ok(nonce_salt)
+    }
+}

--- a/src/types/entrypoint.rs
+++ b/src/types/entrypoint.rs
@@ -1,24 +1,159 @@
-use alloy::sol;
+use alloy::{
+    dyn_abi::Eip712Domain,
+    primitives::{fixed_bytes, Address, Bytes, FixedBytes, U256},
+    providers::Provider,
+    rpc::types::state::StateOverride,
+    sol,
+    sol_types::{SolError, SolValue},
+    transports::{TransportErrorKind, TransportResult},
+};
+use EntryPoint::EntryPointInstance;
+
+use crate::error::CallError;
+
+use super::UserOp;
+
+/// The 4-byte selector returned by the entrypoint if there is no error during execution.
+const NO_ERROR: FixedBytes<4> = fixed_bytes!("00000000");
 
 sol! {
-    /// For returning the gas used and the error from a simulation.
-    #[derive(Debug)]
-    error SimulationResult(uint256 gUsed, bytes4 err);
+    #[sol(rpc)]
+    contract EntryPoint {
+        /// For returning the gas used and the error from a simulation.
+        #[derive(Debug)]
+        error SimulationResult(uint256 gUsed, bytes4 err);
 
-    /// Executes a single encoded user operation.
-    ///
-    /// `encodedUserOp` is given by `abi.encode(userOp)`, where `userOp` is a struct of type `UserOp`.
-    /// If sufficient gas is provided, returns an error selector that is non-zero
-    /// if there is an error during the payment, verification, and call execution.
-    function execute(bytes calldata encodedUserOp)
-        public
-        payable
-        virtual
-        nonReentrant
-        returns (bytes4 err);
+        /// Executes a single encoded user operation.
+        ///
+        /// `encodedUserOp` is given by `abi.encode(userOp)`, where `userOp` is a struct of type `UserOp`.
+        /// If sufficient gas is provided, returns an error selector that is non-zero
+        /// if there is an error during the payment, verification, and call execution.
+        function execute(bytes calldata encodedUserOp)
+            public
+            payable
+            virtual
+            nonReentrant
+            returns (bytes4 err);
 
-    /// Simulates an execution and reverts with the amount of gas used, and the error selector.
+        /// Simulates an execution and reverts with the amount of gas used, and the error selector.
+        ///
+        /// An error selector of 0 means the call did not revert.
+        function simulateExecute(bytes calldata encodedUserOp) public payable virtual;
+
+        /// Returns the EIP712 domain of the entrypoint.
+        ///
+        /// See: https://eips.ethereum.org/EIPS/eip-5267
+        function eip712Domain()
+            public
+            view
+            virtual
+            returns (
+                bytes1 fields,
+                string memory name,
+                string memory version,
+                uint256 chainId,
+                address verifyingContract,
+                bytes32 salt,
+                uint256[] memory extensions
+            );
+    }
+}
+
+/// A Porto entrypoint.
+#[derive(Debug)]
+pub struct Entry<P: Provider> {
+    entrypoint: EntryPointInstance<(), P>,
+    overrides: StateOverride,
+}
+
+impl<P: Provider> Entry<P> {
+    /// Create a new instance of [`Entry`].
+    pub fn new(address: Address, provider: P) -> Self {
+        Self {
+            entrypoint: EntryPointInstance::new(address, provider),
+            overrides: StateOverride::default(),
+        }
+    }
+
+    /// Get the address of the entrypoint.
+    pub fn address(&self) -> &Address {
+        self.entrypoint.address()
+    }
+
+    /// Sets overrides for all calls on this entrypoint.
+    pub fn with_overrides(mut self, overrides: StateOverride) -> Self {
+        self.overrides = overrides;
+        self
+    }
+
+    /// Get the [`Eip712Domain`] for this entrypoint.
     ///
-    /// An error selector of 0 means the call did not revert.
-    function simulateExecute(bytes calldata encodedUserOp) public payable virtual;
+    /// If `multichain` is `true`, then the chain ID is omitted from the domain.
+    pub async fn eip712_domain(&self, multichain: bool) -> TransportResult<Eip712Domain> {
+        let domain = self
+            .entrypoint
+            .eip712Domain()
+            .call()
+            .overrides(&self.overrides)
+            .await
+            .map_err(TransportErrorKind::custom)?;
+
+        Ok(Eip712Domain::new(
+            Some(domain.name.into()),
+            Some(domain.version.into()),
+            (!multichain).then_some(domain.chainId),
+            Some(domain.verifyingContract),
+            None,
+        ))
+    }
+
+    /// Call `EntryPoint.simulateExecute` with the provided [`UserOp`].
+    pub async fn simulate_execute(&self, op: &UserOp) -> Result<U256, CallError> {
+        let ret = self
+            .entrypoint
+            .simulateExecute(op.abi_encode().into())
+            .call()
+            .overrides(&self.overrides)
+            .await;
+
+        match ret {
+            Err(alloy::contract::Error::TransportError(err)) => {
+                let revert_data = err.as_error_resp().and_then(|res| res.as_revert_data());
+
+                if let Ok(result) = EntryPoint::SimulationResult::abi_decode(
+                    revert_data.as_deref().unwrap_or(&Bytes::default()),
+                    false,
+                ) {
+                    if result.err != NO_ERROR {
+                        Err(CallError::OpRevert { revert_reason: result.err.into() })
+                    } else {
+                        Ok(result.gUsed)
+                    }
+                } else if let Some(data) = revert_data {
+                    Err(CallError::OpRevert { revert_reason: data })
+                } else {
+                    Err(TransportErrorKind::custom_str("could not simulate op").into())
+                }
+            }
+            Err(err) => Err(TransportErrorKind::custom(err).into()),
+            Ok(_) => Err(TransportErrorKind::custom_str("could not simulate op").into()),
+        }
+    }
+
+    /// Call `EntryPoint.execute` with the provided [`UserOp`].
+    pub async fn execute(&self, op: &UserOp) -> Result<(), CallError> {
+        let ret = self
+            .entrypoint
+            .execute(op.abi_encode().into())
+            .call()
+            .overrides(&self.overrides)
+            .await
+            .map_err(TransportErrorKind::custom)?;
+
+        if ret.err != NO_ERROR {
+            Err(CallError::OpRevert { revert_reason: ret.err.into() })
+        } else {
+            Ok(())
+        }
+    }
 }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1,4 +1,7 @@
 //! Shared primitive types.
+mod account;
+pub use account::*;
+
 mod action;
 pub use action::*;
 

--- a/src/upstream.rs
+++ b/src/upstream.rs
@@ -1,23 +1,18 @@
 //! A container for chain-specific information and RPCs.
 use alloy::{
-    primitives::{map::AddressMap, Address, Bytes, ChainId, TxHash},
+    primitives::{Address, Bytes, ChainId, TxHash},
     providers::{Provider, WalletProvider},
-    rpc::types::{state::AccountOverride, TransactionRequest},
-    sol_types::SolCall,
+    rpc::types::TransactionRequest,
     transports::TransportResult,
 };
 
-use crate::{
-    error::CallError,
-    types::{Eip1559Estimation, IERC20},
-};
+use crate::types::{Eip1559Estimation, IERC20};
 
 /// A wrapper around an Alloy provider for signing and sending sponsored transactions.
 #[derive(Clone, Debug)]
 pub struct Upstream<P> {
     provider: P,
     chain_id: ChainId,
-    entrypoint: Address,
 }
 
 impl<P> Upstream<P> {
@@ -32,19 +27,14 @@ where
     P: Provider + WalletProvider,
 {
     /// Create a new [`Upstream`]
-    pub async fn new(provider: P, entrypoint: Address) -> TransportResult<Self> {
+    pub async fn new(provider: P) -> TransportResult<Self> {
         let chain_id = provider.get_chain_id().await?;
-        Ok(Self { chain_id, provider, entrypoint })
+        Ok(Self { chain_id, provider })
     }
 
     /// Get the address of this upstream's signer.
     pub fn default_signer_address(&self) -> Address {
         self.provider.default_signer_address()
-    }
-
-    /// Get the entrypoint on this chain.
-    pub fn entrypoint(&self) -> Address {
-        self.entrypoint
     }
 
     /// Get the code of the given account.
@@ -57,25 +47,6 @@ where
         Ok(IERC20::new(token, &self.provider).decimals().call().await?._0)
     }
 
-    /// Perform an `eth_call`.
-    pub async fn call<C: SolCall>(&self, tx: &TransactionRequest) -> Result<C::Return, CallError> {
-        self.call_with_overrides::<C>(tx, &AddressMap::from_iter([])).await
-    }
-
-    /// Perform an `eth_call` with overrides.
-    pub async fn call_with_overrides<C: SolCall>(
-        &self,
-        tx: &TransactionRequest,
-        overrides: &AddressMap<AccountOverride>,
-    ) -> Result<C::Return, CallError> {
-        self.provider
-            .call(tx)
-            .overrides(overrides)
-            .await
-            .map_err(Into::into)
-            .and_then(|r| C::abi_decode_returns(&r[..], false).map_err(Into::into))
-    }
-
     /// Estimate EIP-1559 fees.
     pub async fn estimate_eip1559(&self) -> TransportResult<Eip1559Estimation> {
         self.provider.estimate_eip1559_fees(None).await.map(Into::into)
@@ -84,5 +55,10 @@ where
     /// Sign and send the transaction request.
     pub async fn sign_and_send(&self, tx: TransactionRequest) -> TransportResult<TxHash> {
         self.provider.send_transaction(tx).await.map(|pending| *pending.tx_hash())
+    }
+
+    /// Get the provider for this upstream.
+    pub fn provider(&self) -> &P {
+        &self.provider
     }
 }

--- a/tests/e2e/environment.rs
+++ b/tests/e2e/environment.rs
@@ -119,7 +119,6 @@ impl Environment {
                 address: std::net::IpAddr::V4(Ipv4Addr::LOCALHOST),
                 port: 3131,
                 upstream,
-                entrypoint,
                 quote_ttl: Duration::from_secs(60),
                 quote_secret_key: RELAY_PRIVATE_KEY.to_string(),
                 fee_tokens: vec![erc20],


### PR DESCRIPTION
Introduces new wrapper structs `Account` and `EntryPoint` for dealing with their respective contract calls and so on.

Builds on top of #106 

Towards #52 as it cleans things up a bit and prepares us for just using a provider (or a map of providers) in the RPC module