### PR TITLE
chore: rm useless eip1559 type

### DIFF
--- a/src/types/quote.rs
+++ b/src/types/quote.rs
@@ -8,7 +8,7 @@ use std::{
 
 use alloy::{
     primitives::{Address, ChainId, Keccak256, PrimitiveSignature, B256, U256},
-    providers::{utils::Eip1559Estimation as AlloyEip1559Estimation, Provider, WalletProvider},
+    providers::{utils::Eip1559Estimation, Provider, WalletProvider},
 };
 use alloy_chains::Chain;
 use futures_util::future::try_join_all;
@@ -119,26 +119,5 @@ impl Quote {
                 .to_be_bytes(),
         );
         hasher.finalize()
-    }
-}
-
-// todo: this is temporary and should be replaced once https://github.com/alloy-rs/alloy/pull/2012 is released
-/// An EIP-1559 fee estimate.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct Eip1559Estimation {
-    /// The base fee per gas.
-    #[serde(with = "alloy::serde::quantity")]
-    pub max_fee_per_gas: u128,
-    /// The max priority fee per gas.
-    #[serde(with = "alloy::serde::quantity")]
-    pub max_priority_fee_per_gas: u128,
-}
-
-impl From<AlloyEip1559Estimation> for Eip1559Estimation {
-    fn from(
-        AlloyEip1559Estimation { max_fee_per_gas, max_priority_fee_per_gas}: AlloyEip1559Estimation,
-    ) -> Self {
-        Self { max_fee_per_gas, max_priority_fee_per_gas }
     }
 }

--- a/src/upstream.rs
+++ b/src/upstream.rs
@@ -1,12 +1,13 @@
 //! A container for chain-specific information and RPCs.
 use alloy::{
+    eips::eip1559::Eip1559Estimation,
     primitives::{Address, Bytes, ChainId, TxHash},
     providers::{Provider, WalletProvider},
     rpc::types::TransactionRequest,
     transports::TransportResult,
 };
 
-use crate::types::{Eip1559Estimation, IERC20};
+use crate::types::IERC20;
 
 /// A wrapper around an Alloy provider for signing and sending sponsored transactions.
 #[derive(Clone, Debug)]
@@ -49,7 +50,7 @@ where
 
     /// Estimate EIP-1559 fees.
     pub async fn estimate_eip1559(&self) -> TransportResult<Eip1559Estimation> {
-        self.provider.estimate_eip1559_fees(None).await.map(Into::into)
+        self.provider.estimate_eip1559_fees(None).await
     }
 
     /// Sign and send the transaction request.


### PR DESCRIPTION
This is no longer needed as `Eip1559Estimation` was recently made ser/de