### PR TITLE
chore: init tracing subscriber in main

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -21,8 +21,7 @@ use std::{
 };
 use tower::{layer::layer_fn, ServiceBuilder};
 use tower_http::cors::{AllowMethods, AllowOrigin, CorsLayer};
-use tracing::{info, level_filters::LevelFilter};
-use tracing_subscriber::{fmt, prelude::*, EnvFilter};
+use tracing::info;
 use url::Url;
 
 /// The Ithaca relayer service sponsors transactions for EIP-7702 accounts.
@@ -57,15 +56,6 @@ pub struct Args {
 impl Args {
     /// Run the relayer service.
     pub async fn run(self) -> eyre::Result<()> {
-        tracing_subscriber::registry()
-            .with(fmt::layer())
-            .with(
-                EnvFilter::builder()
-                    .with_default_directive(LevelFilter::INFO.into())
-                    .from_env_lossy(),
-            )
-            .init();
-
         // setup metrics
         let handle = build_exporter();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,8 @@
 //! A relay service that sponsors transactions for EIP-7702 accounts.
 use clap::Parser;
 use relay::cli::*;
+use tracing::level_filters::LevelFilter;
+use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 
 #[tokio::main]
 async fn main() {
@@ -10,6 +12,13 @@ async fn main() {
     if std::env::var_os("RUST_BACKTRACE").is_none() {
         std::env::set_var("RUST_BACKTRACE", "1");
     }
+
+    tracing_subscriber::registry()
+        .with(fmt::layer())
+        .with(
+            EnvFilter::builder().with_default_directive(LevelFilter::INFO.into()).from_env_lossy(),
+        )
+        .init();
 
     let args = Args::parse();
     if let Err(err) = args.run().await {


### PR DESCRIPTION
Libraries should not concern themselves with tracing subscribers, so this should be moved to the binary itself