### PR TITLE
refactor: just use provider

### DIFF
--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -324,11 +324,7 @@ impl RelayApiServer for Relay {
                 return Err(SendActionError::AuthItemNotChainAgnostic.into());
             }
 
-            let expected_nonce = self
-                .inner
-                .chains
-                .get(request.chain_id)
-                .unwrap()
+            let expected_nonce = provider
                 .get_transaction_count(request.op.eoa)
                 .await
                 .map_err(SendActionError::from)?;


### PR DESCRIPTION
We already have the provider here so we can just use it directly