### PR TITLE
fix: set nonce after eth_call

### DIFF
--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -382,15 +382,6 @@ impl RelayApiServer for Relay {
             return Err(SendActionError::QuoteExpired.into());
         }
 
-        // broadcast the tx
-        tx.set_nonce(
-            self.inner
-                .nonce_manager
-                .get_next_nonce(&provider, tx_signer_address)
-                .await
-                .map_err(|err| SendActionError::InternalError(err.into()))?,
-        );
-
         // try eth_call before committing to send the actual transaction
         provider
             .call(&tx)
@@ -407,6 +398,14 @@ impl RelayApiServer for Relay {
                 Ok(())
             })?;
 
+        // broadcast the tx
+        tx.set_nonce(
+            self.inner
+                .nonce_manager
+                .get_next_nonce(&provider, tx_signer_address)
+                .await
+                .map_err(|err| SendActionError::InternalError(err.into()))?,
+        );
         Ok(provider
             .send_raw_transaction(
                 &tx.build(&self.inner.tx_signer)


### PR DESCRIPTION
if the eth call fails we still bump the nonce internally, introduced in #133