### PR TITLE
feat: replace `COINS_CONFIG` with config `CoinRegistry`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ crates/testing/resources/**/cache/*
 
 # Environment files
 .env
+
+# Relay configuration
+relay.toml
+registry.toml

--- a/README.md
+++ b/README.md
@@ -25,12 +25,18 @@ cargo run --bin relay -- \
     --fee-token $FEE_TOKEN_ADDR \ # You can pass this multiple times
     --secret-key $TX_SIGNING_PRIV_KEY \
     --quote-secret-key $QUOTE_SIGNING_PRIV_KEY
+    # --registry $REGISTRY_PATH  # Maps chain ids and token addresses to coins (eg. ETH, USDC, USDT).
+    # --config $CONFIG_PATH
 ```
 
 If no `--config` flag is given, a default `relay.toml` is created in the working directory. In both cases, if the file doesn’t exist, it will be created from the CLI arguments; if it does, its values are loaded and overridden by any CLI flags, *without* updating the file.
 
-Example:
+Similarly, if no `--registry` flag is given, a default registry configuration file `registry.toml` is created in the working directory.
+
+Examples:
 ```toml
+# relay.toml
+
 [server]
 address = "127.0.0.1"
 port = 8323
@@ -46,8 +52,29 @@ ttl = 5
 [quote.gas]
 user_op_buffer = 25000
 tx_buffer = 1000000
+```
 
-[coin_registry]
+```toml
+// registry.toml
+
+1 = [
+    "ETH",
+    [
+    "0xdac17f958d2ee523a2206206994597c13d831ec7",
+    "USDT",
+],
+    [
+    "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+    "USDC",
+],
+]
+8453 = [
+    "ETH",
+    [
+    "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+    "USDC",
+],
+]
 ```
 
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,16 +1,11 @@
 //! Relay configuration.
-use crate::{
-    constants::{TX_GAS_BUFFER, USER_OP_GAS_BUFFER},
-    types::CoinKind,
-};
-use alloy::primitives::{Address, ChainId};
+use crate::constants::{TX_GAS_BUFFER, USER_OP_GAS_BUFFER};
+use alloy::primitives::Address;
 use reqwest::Url;
 use serde::{Deserialize, Serialize};
 use std::{
-    collections::HashMap,
     net::{IpAddr, Ipv4Addr},
     path::Path,
-    sync::Arc,
     time::Duration,
 };
 
@@ -26,8 +21,6 @@ pub struct RelayConfig {
     /// Secrets.
     #[serde(skip_serializing, default)]
     pub secrets: SecretsConfig,
-    /// Global map from ([ChainId], Option<[Address]>) to [CoinKind].
-    pub coin_registry: Arc<HashMap<(ChainId, Option<Address>), CoinKind>>,
 }
 
 /// Server configuration.
@@ -101,7 +94,6 @@ impl Default for RelayConfig {
                 ttl: Duration::from_secs(5),
             },
             secrets: SecretsConfig::default(),
-            coin_registry: Default::default(),
         }
     }
 }
@@ -164,17 +156,6 @@ impl RelayConfig {
     /// Sets the secret key used to sign transactions.
     pub fn with_transaction_key(mut self, secret_key: String) -> Self {
         self.secrets.transaction_key = secret_key;
-        self
-    }
-
-    /// Extend the coin registry with additional entries.
-    pub fn extend_coin_registry(
-        mut self,
-        registry: HashMap<(ChainId, Option<Address>), CoinKind>,
-    ) -> Self {
-        let mut new_registry = (*self.coin_registry).clone();
-        new_registry.extend(registry);
-        self.coin_registry = Arc::new(new_registry);
         self
     }
 

--- a/src/price/mod.rs
+++ b/src/price/mod.rs
@@ -8,10 +8,9 @@ pub use oracle::PriceOracle;
 
 #[cfg(test)]
 mod tests {
-    use std::time::Duration;
-
     use super::*;
-    use crate::types::{CoinKind, CoinPair};
+    use crate::types::{CoinKind, CoinPair, CoinRegistry};
+    use std::{sync::Arc, time::Duration};
     use tokio::time::sleep;
 
     #[ignore] // requires GECKO_API
@@ -19,6 +18,7 @@ mod tests {
     async fn coingecko() {
         let oracle = PriceOracle::new();
         oracle.spawn_fetcher(
+            Arc::new(CoinRegistry::default()),
             PriceFetcher::CoinGecko,
             &[
                 CoinPair { from: CoinKind::USDT, to: CoinKind::ETH },

--- a/src/price/oracle.rs
+++ b/src/price/oracle.rs
@@ -1,10 +1,10 @@
 use super::CoinGecko;
 use crate::{
     price::fetchers::PriceFetcher,
-    types::{CoinKind, CoinPair},
+    types::{CoinKind, CoinPair, CoinRegistry},
 };
 use alloy::primitives::U256;
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Arc};
 use tokio::sync::{mpsc, oneshot};
 use tracing::trace;
 
@@ -76,9 +76,14 @@ impl PriceOracle {
     }
 
     /// Spawns a price fetcher with a [`CoinPair`] list.
-    pub fn spawn_fetcher(&self, fetcher: PriceFetcher, pairs: &[CoinPair]) {
+    pub fn spawn_fetcher(
+        &self,
+        coin_registry: Arc<CoinRegistry>,
+        fetcher: PriceFetcher,
+        pairs: &[CoinPair],
+    ) {
         match fetcher {
-            PriceFetcher::CoinGecko => CoinGecko::launch(pairs, self.tx.clone()),
+            PriceFetcher::CoinGecko => CoinGecko::launch(coin_registry, pairs, self.tx.clone()),
         }
     }
 

--- a/src/types/coin_registry.rs
+++ b/src/types/coin_registry.rs
@@ -1,0 +1,144 @@
+use super::CoinKind;
+use alloy::primitives::{Address, ChainId, address};
+use alloy_chains::{Chain, NamedChain};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::{collections::HashMap, path::Path};
+
+/// Maps [`ChainId`] and token addresses ([`CoinRegistryKey`]) to [`CoinKind`].
+#[derive(Debug, Clone)]
+pub struct CoinRegistry(HashMap<CoinRegistryKey, CoinKind>);
+
+impl CoinRegistry {
+    /// Extends inner registry with more entries.
+    pub fn extend<I>(&mut self, registry: I)
+    where
+        I: IntoIterator<Item = ((ChainId, Option<Address>), CoinKind)>,
+    {
+        self.0.extend(registry.into_iter().map(|(k, v)| (k.into(), v)));
+    }
+
+    /// Returns [`CoinKind`] corresponding to [`CoinRegistryKey`].
+    pub fn get(&self, key: &CoinRegistryKey) -> Option<&CoinKind> {
+        self.0.get(key)
+    }
+
+    /// Returns an iterator over all pairs ([`CoinRegistryKey`], [`CoinKind`]).
+    pub fn iter(&self) -> impl Iterator<Item = (&CoinRegistryKey, &CoinKind)> {
+        self.0.iter()
+    }
+
+    /// Load from a json file.
+    pub fn load_from_file<P: AsRef<Path>>(path: P) -> eyre::Result<Self> {
+        let content = std::fs::read_to_string(path)?;
+        let config = toml::from_str(&content)?;
+        Ok(config)
+    }
+
+    /// Save to a json file.
+    pub fn save_to_file<P: AsRef<Path>>(&self, path: P) -> eyre::Result<()> {
+        let content = toml::to_string_pretty(self)?;
+        std::fs::write(path, content)?;
+        Ok(())
+    }
+}
+
+impl Default for CoinRegistry {
+    fn default() -> Self {
+        let ethereum: ChainId = Chain::mainnet().into();
+        let op: ChainId = Chain::optimism_mainnet().into();
+        let base: ChainId = Chain::base_mainnet().into();
+        let odyssey: ChainId = NamedChain::Odyssey.into();
+
+        let eth = CoinKind::ETH;
+        let usdt = CoinKind::USDT;
+        let usdc = CoinKind::USDC;
+
+        Self(
+            [
+                // ETH mappings
+                ((ethereum, None), eth),
+                ((op, None), eth),
+                ((base, None), eth),
+                ((odyssey, None), eth),
+                // USDT mappings
+                ((ethereum, address!("dAC17F958D2ee523a2206206994597C13D831ec7").into()), usdt),
+                ((op, address!("0xdAC17F958D2ee523a2206206994597C13D831ec7").into()), usdt),
+                ((odyssey, address!("238c8CD93ee9F8c7Edf395548eF60c0d2e46665E").into()), usdt),
+                ((odyssey, address!("706aa5c8e5cc2c67da21ee220718f6f6b154e75c").into()), usdt),
+                // USDC mappings
+                ((ethereum, address!("a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48").into()), usdc),
+                ((base, address!("833589fCD6eDb6E08f4c7C32D4f71b54bdA02913").into()), usdc),
+            ]
+            .into_iter()
+            .map(|(k, v)| (k.into(), v))
+            .collect(),
+        )
+    }
+}
+
+/// Key type of [`CoinRegistry`].
+///
+/// A `(chain, None)` refers to native chain coins. eg. ETH.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct CoinRegistryKey {
+    /// Chain.
+    pub chain: ChainId,
+    /// Address in case it's a deployed token.
+    pub token_address: Option<Address>,
+}
+
+impl From<(ChainId, Option<Address>)> for CoinRegistryKey {
+    fn from(value: (ChainId, Option<Address>)) -> Self {
+        CoinRegistryKey { chain: value.0, token_address: value.1 }
+    }
+}
+
+/// Intermediate serde representation for a coin entry to get a nicer looking serialized output.
+#[derive(Serialize, Deserialize)]
+#[serde(untagged)]
+enum CoinType {
+    Native(CoinKind),
+    Token(Address, CoinKind),
+}
+
+impl Serialize for CoinRegistry {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut grouped: HashMap<String, Vec<CoinType>> = HashMap::new();
+        for (CoinRegistryKey { chain, token_address }, &coin_kind) in self.iter() {
+            let chain_key = chain.to_string();
+            let entry = match token_address {
+                None => CoinType::Native(coin_kind),
+                Some(address) => CoinType::Token(*address, coin_kind),
+            };
+            grouped.entry(chain_key).or_default().push(entry);
+        }
+        grouped.serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for CoinRegistry {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let grouped: HashMap<String, Vec<CoinType>> = HashMap::deserialize(deserializer)?;
+        let mut map = HashMap::new();
+        for (chain_str, entries) in grouped {
+            let chain = chain_str.parse().map_err(serde::de::Error::custom)?;
+            for entry in entries {
+                match entry {
+                    CoinType::Native(coin_kind) => {
+                        map.insert((chain, None).into(), coin_kind);
+                    }
+                    CoinType::Token(address, coin_kind) => {
+                        map.insert((chain, Some(address)).into(), coin_kind);
+                    }
+                }
+            }
+        }
+        Ok(CoinRegistry(map))
+    }
+}

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -8,6 +8,9 @@ pub use action::*;
 mod coin;
 pub use coin::*;
 
+mod coin_registry;
+pub use coin_registry::*;
+
 mod entrypoint;
 pub use entrypoint::*;
 

--- a/src/types/token.rs
+++ b/src/types/token.rs
@@ -1,4 +1,4 @@
-use super::{CoinKind, IERC20::IERC20Instance};
+use crate::types::{CoinKind, CoinRegistry, IERC20::IERC20Instance};
 use alloy::{
     primitives::{Address, ChainId, map::HashMap},
     providers::{DynProvider, Provider},
@@ -32,7 +32,11 @@ pub struct FeeTokens(
 
 impl FeeTokens {
     /// Create a new [`FeeTokens`]
-    pub async fn new(tokens: &[Address], providers: Vec<DynProvider>) -> Result<Self, eyre::Error> {
+    pub async fn new(
+        coin_registry: &CoinRegistry,
+        tokens: &[Address],
+        providers: Vec<DynProvider>,
+    ) -> Result<Self, eyre::Error> {
         // todo: this is ugly
         let futs = providers
             .iter()
@@ -46,7 +50,7 @@ impl FeeTokens {
                     } else {
                         (
                             IERC20Instance::new(*token, provider).decimals().call().await?._0,
-                            CoinKind::get_token(chain.into(), *token).ok_or_else(|| {
+                            CoinKind::get_token(coin_registry, chain, *token).ok_or_else(|| {
                                 eyre::eyre!("Token not supported: {token} @ {chain}.")
                             })?,
                         )


### PR DESCRIPTION
on top of https://github.com/ithacaxyz/relay/pull/149

Replaces static `COINS_CONFIG` with `CoinRegistry`

 * Moves `CoinRegistry` out of `RelayConfig`.
 * Adds CLI flag `--registry registry.json`
 * `try_spawn` now requires `CoinRegistry` 

```rust
/// Spawns the relay service using the provided [`RelayConfig`] and [`CoinRegistry`].
pub async fn try_spawn(
    config: RelayConfig,
    registry: CoinRegistry,
    metrics: Option<PrometheusHandle>,
) -> eyre::Result<ServerHandle> {
```

registry.json

```json
// registry.json
{
  "1": [
    "ETH", // Native
    [
      "0xdac17f958d2ee523a2206206994597c13d831ec7",
      "USDT"
    ],
    [
      "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
      "USDC"
    ]
  ],
}
```