### PR TITLE
fix: fetch initial nonce from pending block

### DIFF
--- a/src/nonce.rs
+++ b/src/nonce.rs
@@ -53,7 +53,7 @@ impl NonceManager for MultiChainNonceManager {
         let mut nonce = nonce.lock().await;
         let new_nonce = if *nonce == NONE {
             // Initialize the nonce if we haven't seen this account before.
-            provider.get_transaction_count(address).await?
+            provider.get_transaction_count(address).pending().await?
         } else {
             *nonce + 1
         };


### PR DESCRIPTION
In case of restarts, we want to make sure we fetch the initial nonce for an account from the pending block, not from the latest block, in case there are any transactions in flight