### PR TITLE
chore: rename `latency` to `node_latency`

### DIFF
--- a/src/metrics/periodic/mod.rs
+++ b/src/metrics/periodic/mod.rs
@@ -87,6 +87,6 @@ mod tests {
             "balance{address=\"0x0000000000000000000000000000000000000000\",chain_id=\"1\"} 0"
         ));
 
-        assert!(metrics_output.contains("latency{url=\"http://localhost:8545/\",quantile"));
+        assert!(metrics_output.contains("node_latency{url=\"http://localhost:8545/\",quantile"));
     }
 }

--- a/src/metrics/periodic/types/latency.rs
+++ b/src/metrics/periodic/types/latency.rs
@@ -29,7 +29,7 @@ where
             let elapsed = start.elapsed().as_millis() as f64;
 
             histogram!(
-                "latency",
+                "node_latency",
                 "url" => format!("{url}"),
             )
             .record(elapsed);


### PR DESCRIPTION
The current name `latency` is a bit too broad

Closes #40 