### PR TITLE
docs: fix toc

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,10 @@ A transparent cross-chain transaction router for EIP-7702 accounts, specifically
 
 ## Table of Contents
 
-- [Ithaca Relay](#ithaca-relay)
-  - [Table of Contents](#table-of-contents)
-  - [Running](#running)
-  - [Testing](#testing)
+- [Running](#running)
+- [Testing](#testing)
     - [End-to-End](#end-to-end)
-  - [Deploying](#deploying)
+- [Deploying](#deploying)
 
 ## Running
 


### PR DESCRIPTION
The table of contents had some links that did not make sense (table of contents links to table of contents?)