### PR TITLE
chore: e2e test touch-ups

### DIFF
--- a/tests/e2e/cases/simple.rs
+++ b/tests/e2e/cases/simple.rs
@@ -157,12 +157,17 @@ async fn auth_then_two_authorizes_then_erc20_transfer() -> Result<()> {
     let test_vector = vec![
         TxContext {
             expected: ExpectedOutcome::Pass,
+            calls: vec![],
+            auth: Some(AuthKind::Auth),
+            ..Default::default()
+        },
+        TxContext {
+            expected: ExpectedOutcome::Pass,
             calls: vec![Call {
                 target: EOA_ADDRESS,
                 value: U256::ZERO,
                 data: authorizeCall { key: key1.clone() }.abi_encode().into(),
             }],
-            auth: Some(AuthKind::Auth),
             ..Default::default()
         },
         TxContext {

--- a/tests/e2e/environment.rs
+++ b/tests/e2e/environment.rs
@@ -131,14 +131,11 @@ impl Environment {
                 .with_quote_ttl(Duration::from_secs(60))
                 .with_quote_key(RELAY_PRIVATE_KEY.to_string())
                 .with_transaction_key(RELAY_PRIVATE_KEY.to_string())
-                .with_fee_tokens(&[erc20]),
+                .with_fee_tokens(&[erc20])
+                .with_quote_constant_rate(1.0),
             None,
         )
         .await?;
-
-        // Wait for it to boot
-        // todo: health endpoint
-        sleep(Duration::from_secs(1)).await;
 
         let relay_endpoint = HttpClientBuilder::default()
             .build(format!("http://localhost:{relay_port}"))

--- a/tests/e2e/mod.rs
+++ b/tests/e2e/mod.rs
@@ -206,9 +206,9 @@ pub async fn prepare_action_request(
         payer: Address::ZERO,
         paymentToken: env.erc20,
         paymentRecipient: Address::ZERO,
-        paymentAmount: U256::ZERO,
-        paymentMaxAmount: U256::ZERO,
-        paymentPerGas: U256::ZERO,
+        paymentAmount: quote.ty().amount,
+        paymentMaxAmount: quote.ty().amount,
+        paymentPerGas: quote.ty().amount / U256::from(quote.ty().gas_estimate),
         combinedGas: U256::from(quote.ty().gas_estimate),
         signature: bytes!(""),
     };
@@ -217,7 +217,7 @@ pub async fn prepare_action_request(
     let payload = op.as_eip712()?;
     let domain = entry.eip712_domain(op.is_multichain()).await.unwrap();
 
-    op.signature = if nonce == 0 {
+    op.signature = if tx.key.is_none() {
         env.eoa_signer
             .sign_payload_hash(payload.eip712_signing_hash(&domain))
             .await


### PR DESCRIPTION
* remove wait time
* use root signing when `key.is_none() `
* change erc20 transfer sequence to: delegate, auth(k1), auth(k2), transfer(k2)