### PR TITLE
feat: set paymentrecipient

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -69,9 +69,6 @@ pub enum SendActionError {
     /// The chain is not supported.
     #[error("unsupported chain {0}")]
     UnsupportedChain(ChainId),
-    /// The payment recipient in the provided [`UserOp`] is not the entrypoint or the tx signer.
-    #[error("the payment recipient is not the entrypoint or the signer")]
-    WrongPaymentRecipient,
     /// The provided EIP-7702 auth item is not chain agnostic.
     #[error("the auth item is not chain agnostic")]
     AuthItemNotChainAgnostic,


### PR DESCRIPTION
We don't need to verify here; we can just set `paymentRecipient` as it is not signed by the user.