### PR TITLE
feat: add CI job for running e2e tests on Odyssey

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -17,7 +17,10 @@ concurrency:
 
 jobs:
   test:
-    name: test
+    name: test – ${{ matrix.variant }}
+    strategy:
+      matrix:
+        variant: [local, odyssey_fork]
     env:
       RUST_BACKTRACE: 1
     timeout-minutes: 30
@@ -43,6 +46,14 @@ jobs:
         with:
           cache-on-failure: true
       - uses: taiki-e/install-action@nextest
+
+      - name: Set Odyssey Env
+        if: ${{ matrix.variant == 'odyssey_fork' }}
+        run: |
+          echo "TEST_FORK_URL=https://odyssey.ithaca.xyz" >> $GITHUB_ENV
+          echo "TEST_ENTRYPOINT=0xB28AF4994867Faf0be7aa6b1bfD6477a0d282410" >> $GITHUB_ENV
+          echo "TEST_DELEGATION=0x766dd4f7d39233d0c46e241011e18de4207197d8" >> $GITHUB_ENV
+
       - name: Run tests
         run: |
           TEST_CONTRACTS=tests/account/out cargo nextest run \


### PR DESCRIPTION
Runs the e2e tests in a odyssey shadow fork, with the `delegation` and `entrypoint` pointing to the proxy.