### PR TITLE
feat: add `EoaKind` enum to `Environment` 

### DIFF
--- a/tests/e2e/cases/calls.rs
+++ b/tests/e2e/cases/calls.rs
@@ -31,7 +31,7 @@ async fn calls_with_upgraded_account() -> eyre::Result<()> {
         .collect::<(Vec<_>, Vec<_>)>();
 
     // Upgrade environment EOA signer with the above admin keys.
-    let env = Environment::setup().await?;
+    let env = Environment::setup_with_upgraded().await?;
     upgrade_account(&env, keys.clone()).await;
 
     // Every key will sign a ERC20 transfer
@@ -51,8 +51,7 @@ async fn calls_with_upgraded_account() -> eyre::Result<()> {
             .prepare_calls(PrepareCallsParameters {
                 calls: vec![erc20_transfer.clone()],
                 chain_id: env.chain_id,
-                // It's an upgraded account, so it's the eoa_signer
-                from: env.eoa_signer.address(),
+                from: env.eoa.address(),
                 capabilities: PrepareCallsCapabilities {
                     authorize_keys: None, // todo: add test authorize "inline"
                     revoke_keys: None,

--- a/tests/e2e/cases/porto.rs
+++ b/tests/e2e/cases/porto.rs
@@ -24,7 +24,7 @@ async fn behavior_delegation() -> Result<()> {
             // Authorize key (delegation provided in the call)
             TxContext {
                 calls: vec![Call {
-                    target: env.eoa_signer.address(),
+                    target: env.eoa.address(),
                     value: U256::ZERO,
                     data: authorizeCall { key: key.clone() }.abi_encode().into(),
                 }],
@@ -64,7 +64,7 @@ async fn execution_guard_spend_limit_and_guard() -> Result<()> {
             // Authorize admin key
             TxContext {
                 calls: vec![Call {
-                    target: env.eoa_signer.address(),
+                    target: env.eoa.address(),
                     value: U256::ZERO,
                     data: authorizeCall { key: key.clone() }.abi_encode().into(),
                 }],
@@ -76,12 +76,12 @@ async fn execution_guard_spend_limit_and_guard() -> Result<()> {
             TxContext {
                 calls: vec![
                     Call {
-                        target: env.eoa_signer.address(),
+                        target: env.eoa.address(),
                         value: U256::ZERO,
                         data: authorizeCall { key: another_key.clone() }.abi_encode().into(),
                     },
                     Call {
-                        target: env.eoa_signer.address(),
+                        target: env.eoa.address(),
                         value: U256::ZERO,
                         data: Delegation::setCanExecuteCall {
                             keyHash: another_key.key_hash(),
@@ -93,7 +93,7 @@ async fn execution_guard_spend_limit_and_guard() -> Result<()> {
                         .into(),
                     },
                     Call {
-                        target: env.eoa_signer.address(),
+                        target: env.eoa.address(),
                         value: U256::ZERO,
                         data: Delegation::setSpendLimitCall {
                             keyHash: another_key.key_hash(),
@@ -156,12 +156,12 @@ async fn behavior_spend_limits() -> Result<()> {
             TxContext {
                 calls: vec![
                     Call {
-                        target: env.eoa_signer.address(),
+                        target: env.eoa.address(),
                         value: U256::ZERO,
                         data: authorizeCall { key: key.clone() }.abi_encode().into(),
                     },
                     Call {
-                        target: env.eoa_signer.address(),
+                        target: env.eoa.address(),
                         value: U256::ZERO,
                         data: Delegation::setSpendLimitCall {
                             keyHash: key.key_hash(),
@@ -226,7 +226,7 @@ async fn execution_guard_target_scope() -> Result<()> {
             // Authorize admin key
             TxContext {
                 calls: vec![Call {
-                    target: env.eoa_signer.address(),
+                    target: env.eoa.address(),
                     value: U256::ZERO,
                     data: authorizeCall { key: key.clone() }.abi_encode().into(),
                 }],
@@ -239,12 +239,12 @@ async fn execution_guard_target_scope() -> Result<()> {
             TxContext {
                 calls: vec![
                     Call {
-                        target: env.eoa_signer.address(),
+                        target: env.eoa.address(),
                         value: U256::ZERO,
                         data: authorizeCall { key: another_key.clone() }.abi_encode().into(),
                     },
                     Call {
-                        target: env.eoa_signer.address(),
+                        target: env.eoa.address(),
                         value: U256::ZERO,
                         data: Delegation::setCanExecuteCall {
                             keyHash: another_key.key_hash(),
@@ -308,7 +308,7 @@ async fn execution_guard_target_scope_selector() -> Result<()> {
             // Authorize admin key
             TxContext {
                 calls: vec![Call {
-                    target: env.eoa_signer.address(),
+                    target: env.eoa.address(),
                     value: U256::ZERO,
                     data: authorizeCall { key: key.clone() }.abi_encode().into(),
                 }],
@@ -321,12 +321,12 @@ async fn execution_guard_target_scope_selector() -> Result<()> {
             TxContext {
                 calls: vec![
                     Call {
-                        target: env.eoa_signer.address(),
+                        target: env.eoa.address(),
                         value: U256::ZERO,
                         data: authorizeCall { key: another_key.clone() }.abi_encode().into(),
                     },
                     Call {
-                        target: env.eoa_signer.address(),
+                        target: env.eoa.address(),
                         value: U256::ZERO,
                         data: Delegation::setCanExecuteCall {
                             keyHash: another_key.key_hash(),
@@ -422,7 +422,7 @@ async fn execution_guard_default() -> Result<()> {
             // Authorize admin key with delegation
             TxContext {
                 calls: vec![Call {
-                    target: env.eoa_signer.address(),
+                    target: env.eoa.address(),
                     value: U256::ZERO,
                     data: authorizeCall { key: key.clone() }.abi_encode().into(),
                 }],
@@ -434,12 +434,12 @@ async fn execution_guard_default() -> Result<()> {
             TxContext {
                 calls: vec![
                     Call {
-                        target: env.eoa_signer.address(),
+                        target: env.eoa.address(),
                         value: U256::ZERO,
                         data: authorizeCall { key: another_key.clone() }.abi_encode().into(),
                     },
                     Call {
-                        target: env.eoa_signer.address(),
+                        target: env.eoa.address(),
                         value: U256::ZERO,
                         data: Delegation::setCanExecuteCall {
                             keyHash: another_key.key_hash(),
@@ -518,7 +518,7 @@ async fn delegated_false_eoa_key_to_authorize_p256() -> Result<()> {
             // Send authorize call (EOA signs; delegation parameter provided)
             TxContext {
                 calls: vec![Call {
-                    target: env.eoa_signer.address(),
+                    target: env.eoa.address(),
                     value: U256::ZERO,
                     data: authorizeCall { key: key.clone() }.abi_encode().into(),
                 }],
@@ -564,7 +564,7 @@ async fn delegated_true_eoa_key_to_authorize_p256() -> Result<()> {
             // Then authorize the new key (signed by EOA)
             TxContext {
                 calls: vec![Call {
-                    target: env.eoa_signer.address(),
+                    target: env.eoa.address(),
                     value: U256::ZERO,
                     data: authorizeCall { key: key.clone() }.abi_encode().into(),
                 }],
@@ -610,7 +610,7 @@ async fn key_p256_key_to_authorize_p256() -> Result<()> {
             // Authorize first key using EOA
             TxContext {
                 calls: vec![Call {
-                    target: env.eoa_signer.address(),
+                    target: env.eoa.address(),
                     value: U256::ZERO,
                     data: authorizeCall { key: key.clone() }.abi_encode().into(),
                 }],
@@ -620,7 +620,7 @@ async fn key_p256_key_to_authorize_p256() -> Result<()> {
             // Authorize a second (P256) key using the first key
             TxContext {
                 calls: vec![Call {
-                    target: env.eoa_signer.address(),
+                    target: env.eoa.address(),
                     value: U256::ZERO,
                     data: authorizeCall { key: another_key.clone() }.abi_encode().into(),
                 }],
@@ -668,7 +668,7 @@ async fn key_p256_key_to_authorize_p256_session() -> Result<()> {
             // Authorize the admin key (P256)
             TxContext {
                 calls: vec![Call {
-                    target: env.eoa_signer.address(),
+                    target: env.eoa.address(),
                     value: U256::ZERO,
                     data: authorizeCall { key: key.clone() }.abi_encode().into(),
                 }],
@@ -680,12 +680,12 @@ async fn key_p256_key_to_authorize_p256_session() -> Result<()> {
             TxContext {
                 calls: vec![
                     Call {
-                        target: env.eoa_signer.address(),
+                        target: env.eoa.address(),
                         value: U256::ZERO,
                         data: authorizeCall { key: session_key.clone() }.abi_encode().into(),
                     },
                     Call {
-                        target: env.eoa_signer.address(),
+                        target: env.eoa.address(),
                         value: U256::ZERO,
                         data: Delegation::setCanExecuteCall {
                             keyHash: session_key.key_hash(),
@@ -740,7 +740,7 @@ async fn key_p256_key_to_authorize_webcryptop256() -> Result<()> {
             // Authorize the first key (P256)
             TxContext {
                 calls: vec![Call {
-                    target: env.eoa_signer.address(),
+                    target: env.eoa.address(),
                     value: U256::ZERO,
                     data: authorizeCall { key: key.clone() }.abi_encode().into(),
                 }],
@@ -750,7 +750,7 @@ async fn key_p256_key_to_authorize_webcryptop256() -> Result<()> {
             // Authorize the second key (WebCryptoP256) using the first key
             TxContext {
                 calls: vec![Call {
-                    target: env.eoa_signer.address(),
+                    target: env.eoa.address(),
                     value: U256::ZERO,
                     data: authorizeCall { key: another_key.clone() }.abi_encode().into(),
                 }],

--- a/tests/e2e/cases/simple.rs
+++ b/tests/e2e/cases/simple.rs
@@ -24,7 +24,7 @@ async fn auth_then_erc20_transfer() -> Result<()> {
             vec![
                 TxContext {
                     calls: vec![Call {
-                        target: env.eoa_signer.address(),
+                        target: env.eoa.address(),
                         value: U256::ZERO,
                         data: authorizeCall { key: key.clone() }.abi_encode().into(),
                     }],
@@ -59,14 +59,14 @@ async fn invalid_auth_nonce() -> Result<()> {
     run_e2e(|env| {
         vec![TxContext {
             calls: vec![Call {
-                target: env.eoa_signer.address(),
+                target: env.eoa.address(),
                 value: U256::ZERO,
                 data: authorizeCall {
                     key: Key {
                         expiry: Default::default(),
                         keyType: KeyType::Secp256k1,
                         isSuperAdmin: true,
-                        publicKey: env.eoa_signer.address().abi_encode().into(),
+                        publicKey: env.eoa.address().abi_encode().into(),
                     },
                 }
                 .abi_encode()
@@ -89,14 +89,14 @@ async fn invalid_auth_signature() -> Result<()> {
     run_e2e(|env| {
         vec![TxContext {
             calls: vec![Call {
-                target: env.eoa_signer.address(),
+                target: env.eoa.address(),
                 value: U256::ZERO,
                 data: authorizeCall {
                     key: Key {
                         expiry: Default::default(),
                         keyType: KeyType::Secp256k1,
                         isSuperAdmin: true,
-                        publicKey: env.eoa_signer.address().abi_encode().into(),
+                        publicKey: env.eoa.address().abi_encode().into(),
                     },
                 }
                 .abi_encode()
@@ -113,17 +113,17 @@ async fn invalid_auth_signature() -> Result<()> {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn invalid_auth_quote_check() -> Result<()> {
-    let env = Environment::setup().await?;
+    let env = Environment::setup_with_upgraded().await?;
     let tx = TxContext {
         calls: vec![Call {
-            target: env.eoa_signer.address(),
+            target: env.eoa.address(),
             value: U256::ZERO,
             data: authorizeCall {
                 key: Key {
                     expiry: Default::default(),
                     keyType: KeyType::Secp256k1,
                     isSuperAdmin: true,
-                    publicKey: env.eoa_signer.address().abi_encode().into(),
+                    publicKey: env.eoa.address().abi_encode().into(),
                 },
             }
             .abi_encode()
@@ -161,7 +161,7 @@ async fn auth_then_two_authorizes_then_erc20_transfer() -> Result<()> {
             TxContext {
                 expected: ExpectedOutcome::Pass,
                 calls: vec![Call {
-                    target: env.eoa_signer.address(),
+                    target: env.eoa.address(),
                     value: U256::ZERO,
                     data: authorizeCall { key: key1.clone() }.abi_encode().into(),
                 }],
@@ -170,7 +170,7 @@ async fn auth_then_two_authorizes_then_erc20_transfer() -> Result<()> {
             TxContext {
                 expected: ExpectedOutcome::Pass,
                 calls: vec![Call {
-                    target: env.eoa_signer.address(),
+                    target: env.eoa.address(),
                     value: U256::ZERO,
                     data: authorizeCall { key: key2.clone() }.abi_encode().into(),
                 }],
@@ -208,12 +208,12 @@ async fn spend_limits() -> Result<()> {
                 expected: ExpectedOutcome::Pass,
                 calls: vec![
                     Call {
-                        target: env.eoa_signer.address(),
+                        target: env.eoa.address(),
                         value: U256::ZERO,
                         data: authorizeCall { key: key1.clone() }.abi_encode().into(),
                     },
                     Call {
-                        target: env.eoa_signer.address(),
+                        target: env.eoa.address(),
                         value: U256::ZERO,
                         data: Delegation::setSpendLimitCall {
                             keyHash: key1.key_hash(),

--- a/tests/e2e/types.rs
+++ b/tests/e2e/types.rs
@@ -90,7 +90,7 @@ impl AuthKind {
 
         Ok(auth_struct.into_signed(
             self.signer()
-                .unwrap_or(&env.eoa_signer)
+                .unwrap_or(env.eoa.root_signer())
                 .sign_hash(&auth_hash)
                 .await
                 .wrap_err("Auth signing failed")?,


### PR DESCRIPTION
* Adds `PREPAccount::calculate_digest` with test case from solidity.
* Adds `EoaKind` enum to `Environment` in preparation for `createAccount` implementation/tests.

In the future, tests will be run with a keyless eoa (`PREPAccount`) and true/upgraded eoa (`DynSigner`). Right now only `EoaKind::Upgraded` is in use