### PR TITLE
feat: setup tests with upgraded and prep accounts

### DIFF
--- a/src/signers/dyn.rs
+++ b/src/signers/dyn.rs
@@ -11,6 +11,7 @@ use aws_config::BehaviorVersion;
 use std::{fmt, ops::Deref, str::FromStr, sync::Arc};
 
 /// Abstraction over local signer or AWS.
+#[derive(Clone)]
 pub struct DynSigner(pub Arc<dyn FullSigner<PrimitiveSignature> + Send + Sync>);
 
 impl fmt::Debug for DynSigner {

--- a/src/types/key.rs
+++ b/src/types/key.rs
@@ -1,6 +1,7 @@
 use super::{
     super::signers::{DynSigner, Eip712PayLoadSigner, P256Key, P256Signer, WebAuthnSigner},
     U40,
+    capabilities::AuthorizeKey,
 };
 use alloy::{
     dyn_abi::Eip712Domain,
@@ -294,6 +295,11 @@ impl KeyWith712Signer {
     /// Returns a reference to the inner [`Key`].
     pub fn key(&self) -> &Key {
         &self.key
+    }
+
+    /// Returns a [`AuthorizeKey`] equivalent.
+    pub fn to_authorized(&self) -> AuthorizeKey {
+        AuthorizeKey { key: self.key.clone(), permissions: vec![] }
     }
 }
 

--- a/tests/e2e/cases/calls.rs
+++ b/tests/e2e/cases/calls.rs
@@ -1,6 +1,6 @@
 //! Prepare calls related end-to-end test cases
 
-use crate::e2e::{MockErc20, cases::upgrade::upgrade_account, environment::Environment};
+use crate::e2e::{AuthKind, MockErc20, cases::upgrade::upgrade_account, environment::Environment};
 use alloy::{
     primitives::{Address, B256, U256},
     providers::{PendingTransactionBuilder, Provider},
@@ -32,7 +32,7 @@ async fn calls_with_upgraded_account() -> eyre::Result<()> {
 
     // Upgrade environment EOA signer with the above admin keys.
     let env = Environment::setup_with_upgraded().await?;
-    upgrade_account(&env, keys.clone()).await;
+    upgrade_account(&env, &keys, AuthKind::Auth).await;
 
     // Every key will sign a ERC20 transfer
     let erc20_transfer = Call {

--- a/tests/e2e/cases/mod.rs
+++ b/tests/e2e/cases/mod.rs
@@ -3,5 +3,7 @@
 mod calls;
 mod porto;
 mod prep;
+pub use prep::prep_account;
 mod simple;
 mod upgrade;
+pub use upgrade::upgrade_account;

--- a/tests/e2e/cases/porto.rs
+++ b/tests/e2e/cases/porto.rs
@@ -1,6 +1,6 @@
 //! Porto equivalent end-to-end test cases
 
-use crate::e2e::*;
+use crate::e2e::{common_calls as calls, *};
 use alloy::{
     hex,
     primitives::{B256, Bytes, FixedBytes, U256, address, b256, fixed_bytes},
@@ -23,27 +23,14 @@ async fn behavior_delegation() -> Result<()> {
         vec![
             // Authorize key (delegation provided in the call)
             TxContext {
-                calls: vec![Call {
-                    target: env.eoa.address(),
-                    value: U256::ZERO,
-                    data: authorizeCall { key: key.clone() }.abi_encode().into(),
-                }],
+                authorization_keys: vec![key.to_authorized()],
                 expected: ExpectedOutcome::Pass,
                 auth: Some(AuthKind::Auth),
                 ..Default::default()
             },
             // Perform a transfer signed by the authorized key
             TxContext {
-                calls: vec![Call {
-                    target: env.erc20,
-                    value: U256::ZERO,
-                    data: MockErc20::transferCall {
-                        recipient: Address::ZERO,
-                        amount: U256::from(100_000_000_000_000u64),
-                    }
-                    .abi_encode()
-                    .into(),
-                }],
+                calls: vec![calls::transfer(env.erc20, Address::ZERO, U256::from(10000000u64))],
                 expected: ExpectedOutcome::Pass,
                 key: Some(&key),
                 ..Default::default()
@@ -63,25 +50,17 @@ async fn execution_guard_spend_limit_and_guard() -> Result<()> {
         vec![
             // Authorize admin key
             TxContext {
-                calls: vec![Call {
-                    target: env.eoa.address(),
-                    value: U256::ZERO,
-                    data: authorizeCall { key: key.clone() }.abi_encode().into(),
-                }],
+                authorization_keys: vec![key.to_authorized()],
                 expected: ExpectedOutcome::Pass,
                 auth: Some(AuthKind::Auth),
                 ..Default::default()
             },
             // Authorize another key, set execution guard and spend limit (1.5 ETH) for it
             TxContext {
+                authorization_keys: vec![another_key.to_authorized()],
                 calls: vec![
                     Call {
-                        target: env.eoa.address(),
-                        value: U256::ZERO,
-                        data: authorizeCall { key: another_key.clone() }.abi_encode().into(),
-                    },
-                    Call {
-                        target: env.eoa.address(),
+                        target: Address::ZERO,
                         value: U256::ZERO,
                         data: Delegation::setCanExecuteCall {
                             keyHash: another_key.key_hash(),
@@ -92,50 +71,22 @@ async fn execution_guard_spend_limit_and_guard() -> Result<()> {
                         .abi_encode()
                         .into(),
                     },
-                    Call {
-                        target: env.eoa.address(),
-                        value: U256::ZERO,
-                        data: Delegation::setSpendLimitCall {
-                            keyHash: another_key.key_hash(),
-                            token: env.erc20,
-                            period: Delegation::SpendPeriod::Day,
-                            limit: U256::from(1_500_000_000_000_000_000u64),
-                        }
-                        .abi_encode()
-                        .into(),
-                    },
+                    calls::daily_limit(env.erc20, U256::from(150u64), &another_key),
                 ],
+                key: Some(&key),
                 expected: ExpectedOutcome::Pass,
                 ..Default::default()
             },
-            // Successful transfer of 1 ETH
+            // Successful transfer
             TxContext {
-                calls: vec![Call {
-                    target: env.erc20,
-                    value: U256::ZERO,
-                    data: MockErc20::transferCall {
-                        recipient: Address::ZERO,
-                        amount: U256::from(1_000_000_000_000_000_000u64),
-                    }
-                    .abi_encode()
-                    .into(),
-                }],
+                calls: vec![calls::transfer(env.erc20, Address::ZERO, U256::from(100u64))],
                 expected: ExpectedOutcome::Pass,
                 key: Some(&another_key),
                 ..Default::default()
             },
-            // Another transfer of 1 ETH exceeds spend limit → fail
+            // Another transfer exceeds spend limit → fail
             TxContext {
-                calls: vec![Call {
-                    target: env.erc20,
-                    value: U256::ZERO,
-                    data: MockErc20::transferCall {
-                        recipient: Address::ZERO,
-                        amount: U256::from(1_000_000_000_000_000_000u64),
-                    }
-                    .abi_encode()
-                    .into(),
-                }],
+                calls: vec![calls::transfer(env.erc20, Address::ZERO, U256::from(100u64))],
                 expected: ExpectedOutcome::FailSend,
                 key: Some(&another_key),
                 ..Default::default()
@@ -152,63 +103,34 @@ async fn behavior_spend_limits() -> Result<()> {
     let key = KeyWith712Signer::random_admin(KeyType::P256)?.unwrap();
     run_e2e(|env| {
         vec![
-            // Delegate, authorize and set spend limit (1.5 ETH) in one call
             TxContext {
-                calls: vec![
-                    Call {
-                        target: env.eoa.address(),
-                        value: U256::ZERO,
-                        data: authorizeCall { key: key.clone() }.abi_encode().into(),
-                    },
-                    Call {
-                        target: env.eoa.address(),
-                        value: U256::ZERO,
-                        data: Delegation::setSpendLimitCall {
-                            keyHash: key.key_hash(),
-                            token: env.erc20,
-                            period: Delegation::SpendPeriod::Day,
-                            limit: U256::from(1_500_000_000_000_000_000u64), // 1.5 ETH in wei
-                        }
-                        .abi_encode()
-                        .into(),
-                    },
-                ],
+                authorization_keys: vec![key.to_authorized()],
                 expected: ExpectedOutcome::Pass,
                 auth: Some(AuthKind::Auth),
                 ..Default::default()
             },
+            TxContext {
+                calls: vec![
+                    calls::daily_limit(env.erc20, U256::from(1500000000000000000u64), &key), // 1.5 ETH in wei
+                ],
+                expected: ExpectedOutcome::Pass,
+                key: Some(&key),
+                ..Default::default()
+            },
             // Successful transfer of 1 ETH
             TxContext {
-                calls: vec![Call {
-                    target: env.erc20,
-                    value: U256::ZERO,
-                    data: MockErc20::transferCall {
-                        recipient: Address::ZERO,
-                        amount: U256::from(1_000_000_000_000_000_000u64), // 1 ETH
-                    }
-                    .abi_encode()
-                    .into(),
-                }],
+                calls: vec![calls::transfer(env.erc20, Address::ZERO, U256::from(1000000000000000000u64))], // 1 ETH in wei
                 expected: ExpectedOutcome::Pass,
                 key: Some(&key),
                 ..Default::default()
             },
             // Another transfer of 1 ETH exceeds the 1.5 ETH limit → fail
             TxContext {
-                calls: vec![Call {
-                    target: env.erc20,
-                    value: U256::ZERO,
-                    data: MockErc20::transferCall {
-                        recipient: Address::ZERO,
-                        amount: U256::from(1_000_000_000_000_000_000u64),
-                    }
-                    .abi_encode()
-                    .into(),
-                }],
+                calls: vec![calls::transfer(env.erc20, Address::ZERO, U256::from(1000000000000000000u64))], // 1 ETH in wei
                 expected: ExpectedOutcome::FailSend,
                 key: Some(&key),
                 ..Default::default()
-            },
+            }
         ]
     })
     .await?;
@@ -225,11 +147,7 @@ async fn execution_guard_target_scope() -> Result<()> {
         vec![
             // Authorize admin key
             TxContext {
-                calls: vec![Call {
-                    target: env.eoa.address(),
-                    value: U256::ZERO,
-                    data: authorizeCall { key: key.clone() }.abi_encode().into(),
-                }],
+                authorization_keys: vec![key.to_authorized()],
                 expected: ExpectedOutcome::Pass,
                 auth: Some(AuthKind::Auth),
                 ..Default::default()
@@ -237,57 +155,33 @@ async fn execution_guard_target_scope() -> Result<()> {
             // Authorize another key and set execution guard with a target scope (only env.erc20
             // allowed)
             TxContext {
-                calls: vec![
-                    Call {
-                        target: env.eoa.address(),
-                        value: U256::ZERO,
-                        data: authorizeCall { key: another_key.clone() }.abi_encode().into(),
-                    },
-                    Call {
-                        target: env.eoa.address(),
-                        value: U256::ZERO,
-                        data: Delegation::setCanExecuteCall {
-                            keyHash: another_key.key_hash(),
-                            fnSel: DEFAULT_EXECUTE_SELECTOR,
-                            target: env.erc20,
-                            can: true,
-                        }
-                        .abi_encode()
-                        .into(),
-                    },
-                ],
+                authorization_keys: vec![another_key.to_authorized()],
+                calls: vec![Call {
+                    target: Address::ZERO,
+                    value: U256::ZERO,
+                    data: Delegation::setCanExecuteCall {
+                        keyHash: another_key.key_hash(),
+                        fnSel: DEFAULT_EXECUTE_SELECTOR,
+                        target: env.erc20,
+                        can: true,
+                    }
+                    .abi_encode()
+                    .into(),
+                }],
                 expected: ExpectedOutcome::Pass,
                 key: Some(&key),
                 ..Default::default()
             },
             // Valid transfer (target matches)
             TxContext {
-                calls: vec![Call {
-                    target: env.erc20,
-                    value: U256::ZERO,
-                    data: MockErc20::transferCall {
-                        recipient: Address::ZERO,
-                        amount: U256::from(100_000_000_000_000u64),
-                    }
-                    .abi_encode()
-                    .into(),
-                }],
+                calls: vec![calls::transfer(env.erc20, Address::ZERO, U256::from(10000000u64))],
                 expected: ExpectedOutcome::Pass,
                 key: Some(&another_key),
                 ..Default::default()
             },
             // Failing transfer (different target)
             TxContext {
-                calls: vec![Call {
-                    target: env.erc20_alt, // assume this is a different contract address
-                    value: U256::ZERO,
-                    data: MockErc20::transferCall {
-                        recipient: Address::ZERO,
-                        amount: U256::from(100_000_000_000_000u64),
-                    }
-                    .abi_encode()
-                    .into(),
-                }],
+                calls: vec![calls::transfer(env.erc20_alt, Address::ZERO, U256::from(10000000u64))],
                 expected: ExpectedOutcome::FailSend,
                 key: Some(&another_key),
                 ..Default::default()
@@ -307,11 +201,7 @@ async fn execution_guard_target_scope_selector() -> Result<()> {
         vec![
             // Authorize admin key
             TxContext {
-                calls: vec![Call {
-                    target: env.eoa.address(),
-                    value: U256::ZERO,
-                    data: authorizeCall { key: key.clone() }.abi_encode().into(),
-                }],
+                authorization_keys: vec![key.to_authorized()],
                 expected: ExpectedOutcome::Pass,
                 auth: Some(AuthKind::Auth),
                 ..Default::default()
@@ -319,56 +209,33 @@ async fn execution_guard_target_scope_selector() -> Result<()> {
             // Authorize another key and set execution guard with target and selector (for
             // "transfer")
             TxContext {
-                calls: vec![
-                    Call {
-                        target: env.eoa.address(),
-                        value: U256::ZERO,
-                        data: authorizeCall { key: another_key.clone() }.abi_encode().into(),
-                    },
-                    Call {
-                        target: env.eoa.address(),
-                        value: U256::ZERO,
-                        data: Delegation::setCanExecuteCall {
-                            keyHash: another_key.key_hash(),
-                            can: true,
-                            fnSel: MockErc20::transferCall::SELECTOR.into(),
-                            target: env.erc20,
-                        }
-                        .abi_encode()
-                        .into(),
-                    },
-                ],
-                expected: ExpectedOutcome::Pass,
-                ..Default::default()
-            },
-            // Valid transfer call using "transfer"
-            TxContext {
+                authorization_keys: vec![another_key.to_authorized()],
                 calls: vec![Call {
-                    target: env.erc20,
+                    target: Address::ZERO,
                     value: U256::ZERO,
-                    data: MockErc20::transferCall {
-                        recipient: Address::ZERO,
-                        amount: U256::from(100_000_000_000_000u64),
+                    data: Delegation::setCanExecuteCall {
+                        keyHash: another_key.key_hash(),
+                        can: true,
+                        fnSel: MockErc20::transferCall::SELECTOR.into(),
+                        target: env.erc20,
                     }
                     .abi_encode()
                     .into(),
                 }],
+                expected: ExpectedOutcome::Pass,
+                key: Some(&key),
+                ..Default::default()
+            },
+            // Valid transfer call using "transfer"
+            TxContext {
+                calls: vec![calls::transfer(env.erc20, Address::ZERO, U256::from(10000000u64))],
                 expected: ExpectedOutcome::Pass,
                 key: Some(&another_key),
                 ..Default::default()
             },
             // Failing call using a different selector (e.g. "mint")
             TxContext {
-                calls: vec![Call {
-                    target: env.erc20,
-                    value: U256::ZERO,
-                    data: MockErc20::mintCall {
-                        a: Address::ZERO,
-                        val: U256::from(100_000_000_000_000u64),
-                    }
-                    .abi_encode()
-                    .into(),
-                }],
+                calls: vec![calls::mint(env.erc20, Address::ZERO, U256::from(10000000u64))],
                 expected: ExpectedOutcome::FailSend,
                 key: Some(&another_key),
                 ..Default::default()
@@ -382,27 +249,21 @@ async fn execution_guard_target_scope_selector() -> Result<()> {
 /// porto test: "default"
 #[tokio::test(flavor = "multi_thread")]
 async fn send_default() -> Result<()> {
-    run_e2e(|env| {
+    run_e2e_upgraded(&|env| {
         vec![
             // Delegate (empty calls with auth)
             TxContext {
-                calls: vec![],
                 expected: ExpectedOutcome::Pass,
                 auth: Some(AuthKind::Auth),
                 ..Default::default()
             },
             // Transfer call: transfer 0.0001 ETH worth (using a placeholder value)
             TxContext {
-                calls: vec![Call {
-                    target: env.erc20,
-                    value: U256::ZERO,
-                    data: MockErc20::transferCall {
-                        recipient: Address::ZERO, // using ZERO as a stand-in for a random address
-                        amount: U256::from(100_000_000_000_000u64), // ≈0.0001 ETH in wei
-                    }
-                    .abi_encode()
-                    .into(),
-                }],
+                calls: vec![calls::transfer(
+                    env.erc20,
+                    Address::ZERO,
+                    U256::from(100000000000000u64),
+                )],
                 expected: ExpectedOutcome::Pass,
                 ..Default::default()
             },
@@ -421,51 +282,33 @@ async fn execution_guard_default() -> Result<()> {
         vec![
             // Authorize admin key with delegation
             TxContext {
-                calls: vec![Call {
-                    target: env.eoa.address(),
-                    value: U256::ZERO,
-                    data: authorizeCall { key: key.clone() }.abi_encode().into(),
-                }],
+                authorization_keys: vec![key.to_authorized()],
                 expected: ExpectedOutcome::Pass,
                 auth: Some(AuthKind::Auth),
                 ..Default::default()
             },
             // Authorize and set execution guard using default values for selector and target
             TxContext {
-                calls: vec![
-                    Call {
-                        target: env.eoa.address(),
-                        value: U256::ZERO,
-                        data: authorizeCall { key: another_key.clone() }.abi_encode().into(),
-                    },
-                    Call {
-                        target: env.eoa.address(),
-                        value: U256::ZERO,
-                        data: Delegation::setCanExecuteCall {
-                            keyHash: another_key.key_hash(),
-                            can: true,
-                            fnSel: DEFAULT_EXECUTE_SELECTOR,
-                            target: DEFAULT_EXECUTE_TO,
-                        }
-                        .abi_encode()
-                        .into(),
-                    },
-                ],
-                expected: ExpectedOutcome::Pass,
-                ..Default::default()
-            },
-            // Transfer signed by the second key
-            TxContext {
+                authorization_keys: vec![another_key.to_authorized()],
                 calls: vec![Call {
-                    target: env.erc20,
+                    target: Address::ZERO,
                     value: U256::ZERO,
-                    data: MockErc20::transferCall {
-                        recipient: Address::ZERO,
-                        amount: U256::from(100_000_000_000_000u64),
+                    data: Delegation::setCanExecuteCall {
+                        keyHash: another_key.key_hash(),
+                        can: true,
+                        fnSel: DEFAULT_EXECUTE_SELECTOR,
+                        target: DEFAULT_EXECUTE_TO,
                     }
                     .abi_encode()
                     .into(),
                 }],
+                expected: ExpectedOutcome::Pass,
+                key: Some(&key),
+                ..Default::default()
+            },
+            // Transfer signed by the second key
+            TxContext {
+                calls: vec![calls::transfer(env.erc20, Address::ZERO, U256::from(10000000u64))],
                 expected: ExpectedOutcome::Pass,
                 key: Some(&another_key),
                 ..Default::default()
@@ -479,27 +322,17 @@ async fn execution_guard_default() -> Result<()> {
 /// porto test: "default" (prepare & sendPrepared)
 #[tokio::test(flavor = "multi_thread")]
 async fn prepare_send_prepared_default() -> Result<()> {
-    run_e2e(|env| {
+    run_e2e_upgraded(&|env| {
         vec![
             // Delegate
             TxContext {
-                calls: vec![],
                 expected: ExpectedOutcome::Pass,
                 auth: Some(AuthKind::Auth),
                 ..Default::default()
             },
             // Prepared transfer call (simulating prepare then sendPrepared)
             TxContext {
-                calls: vec![Call {
-                    target: env.erc20,
-                    value: U256::ZERO,
-                    data: MockErc20::transferCall {
-                        recipient: Address::ZERO,
-                        amount: U256::from(100_000_000_000_000u64),
-                    }
-                    .abi_encode()
-                    .into(),
-                }],
+                calls: vec![calls::transfer(env.erc20, Address::ZERO, U256::from(10000000u64))],
                 expected: ExpectedOutcome::Pass,
                 ..Default::default()
             },
@@ -517,27 +350,14 @@ async fn delegated_false_eoa_key_to_authorize_p256() -> Result<()> {
         vec![
             // Send authorize call (EOA signs; delegation parameter provided)
             TxContext {
-                calls: vec![Call {
-                    target: env.eoa.address(),
-                    value: U256::ZERO,
-                    data: authorizeCall { key: key.clone() }.abi_encode().into(),
-                }],
+                authorization_keys: vec![key.to_authorized()],
                 expected: ExpectedOutcome::Pass,
                 auth: Some(AuthKind::Auth),
                 ..Default::default()
             },
             // Transfer call signed by the newly authorized key
             TxContext {
-                calls: vec![Call {
-                    target: env.erc20,
-                    value: U256::ZERO,
-                    data: MockErc20::transferCall {
-                        recipient: Address::ZERO,
-                        amount: U256::from(100_000_000_000_000u64),
-                    }
-                    .abi_encode()
-                    .into(),
-                }],
+                calls: vec![calls::transfer(env.erc20, Address::ZERO, U256::from(10000000u64))],
                 expected: ExpectedOutcome::Pass,
                 key: Some(&key),
                 ..Default::default()
@@ -554,35 +374,16 @@ async fn delegated_true_eoa_key_to_authorize_p256() -> Result<()> {
     let key = KeyWith712Signer::random_admin(KeyType::P256)?.unwrap();
     run_e2e(|env| {
         vec![
-            // Delegate first
+            // Authorize the new key (signed by EOA)
             TxContext {
-                calls: vec![],
+                authorization_keys: vec![key.to_authorized()],
                 expected: ExpectedOutcome::Pass,
                 auth: Some(AuthKind::Auth),
                 ..Default::default()
             },
-            // Then authorize the new key (signed by EOA)
-            TxContext {
-                calls: vec![Call {
-                    target: env.eoa.address(),
-                    value: U256::ZERO,
-                    data: authorizeCall { key: key.clone() }.abi_encode().into(),
-                }],
-                expected: ExpectedOutcome::Pass,
-                ..Default::default()
-            },
             // Transfer call signed by the authorized key
             TxContext {
-                calls: vec![Call {
-                    target: env.erc20,
-                    value: U256::ZERO,
-                    data: MockErc20::transferCall {
-                        recipient: Address::ZERO,
-                        amount: U256::from(100_000_000_000_000u64),
-                    }
-                    .abi_encode()
-                    .into(),
-                }],
+                calls: vec![calls::transfer(env.erc20, Address::ZERO, U256::from(10000000u64))],
                 expected: ExpectedOutcome::Pass,
                 key: Some(&key),
                 ..Default::default()
@@ -600,46 +401,23 @@ async fn key_p256_key_to_authorize_p256() -> Result<()> {
     let another_key = KeyWith712Signer::random_admin(KeyType::P256)?.unwrap();
     run_e2e(|env| {
         vec![
-            // Delegate
+            // Authorize first key
             TxContext {
-                calls: vec![],
+                authorization_keys: vec![key.to_authorized()],
                 expected: ExpectedOutcome::Pass,
                 auth: Some(AuthKind::Auth),
                 ..Default::default()
             },
-            // Authorize first key using EOA
-            TxContext {
-                calls: vec![Call {
-                    target: env.eoa.address(),
-                    value: U256::ZERO,
-                    data: authorizeCall { key: key.clone() }.abi_encode().into(),
-                }],
-                expected: ExpectedOutcome::Pass,
-                ..Default::default()
-            },
             // Authorize a second (P256) key using the first key
             TxContext {
-                calls: vec![Call {
-                    target: env.eoa.address(),
-                    value: U256::ZERO,
-                    data: authorizeCall { key: another_key.clone() }.abi_encode().into(),
-                }],
+                authorization_keys: vec![another_key.to_authorized()],
                 expected: ExpectedOutcome::Pass,
                 key: Some(&key),
                 ..Default::default()
             },
             // Transfer using the second key
             TxContext {
-                calls: vec![Call {
-                    target: env.erc20,
-                    value: U256::ZERO,
-                    data: MockErc20::transferCall {
-                        recipient: Address::ZERO,
-                        amount: U256::from(100_000_000_000_000u64),
-                    }
-                    .abi_encode()
-                    .into(),
-                }],
+                calls: vec![calls::transfer(env.erc20, Address::ZERO, U256::from(10000000u64))],
                 expected: ExpectedOutcome::Pass,
                 key: Some(&another_key),
                 ..Default::default()
@@ -658,61 +436,36 @@ async fn key_p256_key_to_authorize_p256_session() -> Result<()> {
     let session_key = KeyWith712Signer::random_session(KeyType::P256)?.unwrap();
     run_e2e(|env| {
         vec![
-            // Delegate
-            TxContext {
-                calls: vec![],
-                expected: ExpectedOutcome::Pass,
-                auth: Some(AuthKind::Auth),
-                ..Default::default()
-            },
             // Authorize the admin key (P256)
             TxContext {
-                calls: vec![Call {
-                    target: env.eoa.address(),
-                    value: U256::ZERO,
-                    data: authorizeCall { key: key.clone() }.abi_encode().into(),
-                }],
+                authorization_keys: vec![key.to_authorized()],
                 expected: ExpectedOutcome::Pass,
+                auth: Some(AuthKind::Auth),
                 ..Default::default()
             },
             // Authorize the session key and set its execution guard using
             // Delegation::setCanExecuteCall with defaults
             TxContext {
-                calls: vec![
-                    Call {
-                        target: env.eoa.address(),
-                        value: U256::ZERO,
-                        data: authorizeCall { key: session_key.clone() }.abi_encode().into(),
-                    },
-                    Call {
-                        target: env.eoa.address(),
-                        value: U256::ZERO,
-                        data: Delegation::setCanExecuteCall {
-                            keyHash: session_key.key_hash(),
-                            can: true,
-                            fnSel: DEFAULT_EXECUTE_SELECTOR,
-                            target: DEFAULT_EXECUTE_TO,
-                        }
-                        .abi_encode()
-                        .into(),
-                    },
-                ],
+                authorization_keys: vec![session_key.to_authorized()],
+                calls: vec![Call {
+                    target: Address::ZERO,
+                    value: U256::ZERO,
+                    data: Delegation::setCanExecuteCall {
+                        keyHash: session_key.key_hash(),
+                        can: true,
+                        fnSel: DEFAULT_EXECUTE_SELECTOR,
+                        target: DEFAULT_EXECUTE_TO,
+                    }
+                    .abi_encode()
+                    .into(),
+                }],
                 expected: ExpectedOutcome::Pass,
                 key: Some(&key),
                 ..Default::default()
             },
             // Transfer signed by the session key
             TxContext {
-                calls: vec![Call {
-                    target: env.erc20,
-                    value: U256::ZERO,
-                    data: MockErc20::transferCall {
-                        recipient: Address::ZERO,
-                        amount: U256::from(100_000_000_000_000u64),
-                    }
-                    .abi_encode()
-                    .into(),
-                }],
+                calls: vec![calls::transfer(env.erc20, Address::ZERO, U256::from(10000000u64))],
                 expected: ExpectedOutcome::Pass,
                 key: Some(&session_key),
                 ..Default::default()
@@ -732,44 +485,21 @@ async fn key_p256_key_to_authorize_webcryptop256() -> Result<()> {
         vec![
             // Delegate
             TxContext {
-                calls: vec![],
+                authorization_keys: vec![key.to_authorized()],
                 expected: ExpectedOutcome::Pass,
                 auth: Some(AuthKind::Auth),
                 ..Default::default()
             },
-            // Authorize the first key (P256)
-            TxContext {
-                calls: vec![Call {
-                    target: env.eoa.address(),
-                    value: U256::ZERO,
-                    data: authorizeCall { key: key.clone() }.abi_encode().into(),
-                }],
-                expected: ExpectedOutcome::Pass,
-                ..Default::default()
-            },
             // Authorize the second key (WebCryptoP256) using the first key
             TxContext {
-                calls: vec![Call {
-                    target: env.eoa.address(),
-                    value: U256::ZERO,
-                    data: authorizeCall { key: another_key.clone() }.abi_encode().into(),
-                }],
+                authorization_keys: vec![another_key.to_authorized()],
                 expected: ExpectedOutcome::Pass,
                 key: Some(&key),
                 ..Default::default()
             },
             // Transfer signed by the second key
             TxContext {
-                calls: vec![Call {
-                    target: env.erc20,
-                    value: U256::ZERO,
-                    data: MockErc20::transferCall {
-                        recipient: Address::ZERO,
-                        amount: U256::from(100_000_000_000_000u64),
-                    }
-                    .abi_encode()
-                    .into(),
-                }],
+                calls: vec![calls::transfer(env.erc20, Address::ZERO, U256::from(10000000u64))],
                 expected: ExpectedOutcome::Pass,
                 key: Some(&another_key),
                 ..Default::default()

--- a/tests/e2e/cases/simple.rs
+++ b/tests/e2e/cases/simple.rs
@@ -1,6 +1,6 @@
 //! Relay simple end-to-end test cases
 
-use crate::e2e::*;
+use crate::e2e::{common_calls as calls, *};
 use alloy::{
     hex,
     primitives::{B256, Bytes, FixedBytes, U256, address, b256, fixed_bytes},
@@ -14,35 +14,24 @@ use relay::{
         Call, Delegation::SpendPeriod, IDelegation::authorizeCall, Key, KeyType, KeyWith712Signer,
     },
 };
+use std::sync::Arc;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn auth_then_erc20_transfer() -> Result<()> {
     for key_type in [KeyType::Secp256k1, KeyType::P256, KeyType::WebAuthnP256] {
         let key = KeyWith712Signer::random_admin(key_type)?.unwrap();
 
+        // The first TX will bundle the prep/upgrade calls
         run_e2e(|env| {
             vec![
                 TxContext {
-                    calls: vec![Call {
-                        target: env.eoa.address(),
-                        value: U256::ZERO,
-                        data: authorizeCall { key: key.clone() }.abi_encode().into(),
-                    }],
+                    authorization_keys: vec![key.to_authorized()],
                     expected: ExpectedOutcome::Pass,
                     auth: Some(AuthKind::Auth),
                     ..Default::default()
                 },
                 TxContext {
-                    calls: vec![Call {
-                        target: env.erc20,
-                        value: U256::ZERO,
-                        data: MockErc20::transferCall {
-                            recipient: Address::ZERO,
-                            amount: U256::from(10),
-                        }
-                        .abi_encode()
-                        .into(),
-                    }],
+                    calls: vec![calls::transfer(env.erc20, Address::ZERO, U256::from(10))],
                     expected: ExpectedOutcome::Pass,
                     key: Some(&key),
                     ..Default::default()
@@ -56,22 +45,10 @@ async fn auth_then_erc20_transfer() -> Result<()> {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn invalid_auth_nonce() -> Result<()> {
-    run_e2e(|env| {
+    let key = KeyWith712Signer::random_admin(KeyType::P256)?.unwrap();
+    run_e2e_upgraded(&|env| {
         vec![TxContext {
-            calls: vec![Call {
-                target: env.eoa.address(),
-                value: U256::ZERO,
-                data: authorizeCall {
-                    key: Key {
-                        expiry: Default::default(),
-                        keyType: KeyType::Secp256k1,
-                        isSuperAdmin: true,
-                        publicKey: env.eoa.address().abi_encode().into(),
-                    },
-                }
-                .abi_encode()
-                .into(),
-            }],
+            authorization_keys: vec![key.to_authorized()],
             expected: ExpectedOutcome::FailSend,
             auth: Some(AuthKind::modified_nonce(123)),
             ..Default::default()
@@ -82,29 +59,17 @@ async fn invalid_auth_nonce() -> Result<()> {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn invalid_auth_signature() -> Result<()> {
+    let key = KeyWith712Signer::random_admin(KeyType::P256)?.unwrap();
     let dummy_signer =
         DynSigner::load("0x42424242428f97a5a0044266f0945389dc9e86dae88c7a8412f4603b6b78690d", None)
             .await?;
 
-    run_e2e(|env| {
+    run_e2e_upgraded(&|env| {
         vec![TxContext {
-            calls: vec![Call {
-                target: env.eoa.address(),
-                value: U256::ZERO,
-                data: authorizeCall {
-                    key: Key {
-                        expiry: Default::default(),
-                        keyType: KeyType::Secp256k1,
-                        isSuperAdmin: true,
-                        publicKey: env.eoa.address().abi_encode().into(),
-                    },
-                }
-                .abi_encode()
-                .into(),
-            }],
+            authorization_keys: vec![key.to_authorized()],
             expected: ExpectedOutcome::FailSend,
             // Signing with an unrelated key should fail during sendAction when calling eth_call
-            auth: Some(AuthKind::modified_signer(dummy_signer)),
+            auth: Some(AuthKind::modified_signer(dummy_signer.clone())),
             ..Default::default()
         }]
     })
@@ -116,7 +81,7 @@ async fn invalid_auth_quote_check() -> Result<()> {
     let env = Environment::setup_with_upgraded().await?;
     let tx = TxContext {
         calls: vec![Call {
-            target: env.eoa.address(),
+            target: Address::ZERO,
             value: U256::ZERO,
             data: authorizeCall {
                 key: Key {
@@ -154,41 +119,19 @@ async fn auth_then_two_authorizes_then_erc20_transfer() -> Result<()> {
         vec![
             TxContext {
                 expected: ExpectedOutcome::Pass,
-                calls: vec![],
                 auth: Some(AuthKind::Auth),
+                authorization_keys: vec![key1.to_authorized()],
                 ..Default::default()
             },
             TxContext {
                 expected: ExpectedOutcome::Pass,
-                calls: vec![Call {
-                    target: env.eoa.address(),
-                    value: U256::ZERO,
-                    data: authorizeCall { key: key1.clone() }.abi_encode().into(),
-                }],
-                ..Default::default()
-            },
-            TxContext {
-                expected: ExpectedOutcome::Pass,
-                calls: vec![Call {
-                    target: env.eoa.address(),
-                    value: U256::ZERO,
-                    data: authorizeCall { key: key2.clone() }.abi_encode().into(),
-                }],
+                authorization_keys: vec![key2.to_authorized()],
                 key: Some(&key1),
                 ..Default::default()
             },
             TxContext {
                 expected: ExpectedOutcome::Pass,
-                calls: vec![Call {
-                    target: env.erc20,
-                    value: U256::ZERO,
-                    data: MockErc20::transferCall {
-                        recipient: Address::ZERO,
-                        amount: U256::from(10),
-                    }
-                    .abi_encode()
-                    .into(),
-                }],
+                calls: vec![calls::transfer(env.erc20, Address::ZERO, U256::from(10))],
                 key: Some(&key2),
                 ..Default::default()
             },
@@ -206,57 +149,21 @@ async fn spend_limits() -> Result<()> {
             // delegate, auth and set spend limit
             TxContext {
                 expected: ExpectedOutcome::Pass,
-                calls: vec![
-                    Call {
-                        target: env.eoa.address(),
-                        value: U256::ZERO,
-                        data: authorizeCall { key: key1.clone() }.abi_encode().into(),
-                    },
-                    Call {
-                        target: env.eoa.address(),
-                        value: U256::ZERO,
-                        data: Delegation::setSpendLimitCall {
-                            keyHash: key1.key_hash(),
-                            token: env.erc20,
-                            period: SpendPeriod::Day,
-                            limit: U256::from(15),
-                        }
-                        .abi_encode()
-                        .into(),
-                    },
-                ],
+                authorization_keys: vec![key1.to_authorized()],
                 auth: Some(AuthKind::Auth),
                 ..Default::default()
             },
-            // succesful transfer
+            // successful transfer
             TxContext {
                 expected: ExpectedOutcome::Pass,
-                calls: vec![Call {
-                    target: env.erc20,
-                    value: U256::ZERO,
-                    data: MockErc20::transferCall {
-                        recipient: Address::ZERO,
-                        amount: U256::from(10),
-                    }
-                    .abi_encode()
-                    .into(),
-                }],
+                calls: vec![calls::daily_limit(env.erc20, U256::from(15), key1.key())],
                 key: Some(&key1),
                 ..Default::default()
             },
-            // spend limit exceeded (20 wei exp > 15 wei exp)
+            // overspend transfer should fail
             TxContext {
-                expected: ExpectedOutcome::FailSend, // todo this should fail on estimate
-                calls: vec![Call {
-                    target: env.erc20,
-                    value: U256::ZERO,
-                    data: MockErc20::transferCall {
-                        recipient: Address::ZERO,
-                        amount: U256::from(10),
-                    }
-                    .abi_encode()
-                    .into(),
-                }],
+                expected: ExpectedOutcome::FailSend,
+                calls: vec![calls::transfer(env.erc20, Address::ZERO, U256::from(100))],
                 key: Some(&key1),
                 ..Default::default()
             },

--- a/tests/e2e/cases/upgrade.rs
+++ b/tests/e2e/cases/upgrade.rs
@@ -1,8 +1,9 @@
 //! Account upgrade related end-to-end test cases
 
-use crate::e2e::environment::Environment;
+use crate::e2e::{AuthKind, environment::Environment};
 use alloy::{
-    primitives::{B256, U256},
+    eips::eip7702::SignedAuthorization,
+    primitives::{B256, TxHash, U256},
     providers::{PendingTransactionBuilder, Provider},
 };
 use eyre::WrapErr;
@@ -17,15 +18,16 @@ use std::str::FromStr;
 
 pub async fn upgrade_account(
     env: &Environment,
-    authorize_keys: Vec<AuthorizeKey>,
-) -> eyre::Result<()> {
+    authorize_keys: &[AuthorizeKey],
+    auth: AuthKind,
+) -> eyre::Result<(TxHash, SignedAuthorization)> {
     let mut response = env
         .relay_endpoint
         .prepare_upgrade_account(PrepareUpgradeAccountParameters {
             address: env.eoa.address(),
             chain_id: env.chain_id,
             capabilities: UpgradeAccountCapabilities {
-                authorize_keys,
+                authorize_keys: authorize_keys.to_vec(),
                 delegation: env.delegation,
                 fee_token: Some(env.erc20),
             },
@@ -36,19 +38,8 @@ pub async fn upgrade_account(
     let signature = env.eoa.root_signer().sign_hash(&response.digest).await?;
 
     // Sign 7702 delegation
-    let authorization = alloy::eips::eip7702::Authorization {
-        chain_id: U256::from(0),
-        address: env.delegation,
-        nonce: env.provider.get_transaction_count(env.eoa.address()).await?,
-    };
-    let authorization_hash = authorization.signature_hash();
-    let authorization = authorization.into_signed(
-        env.eoa
-            .root_signer()
-            .sign_hash(&authorization_hash)
-            .await
-            .wrap_err("Auth signing failed")?,
-    );
+    let nonce = env.provider.get_transaction_count(env.eoa.address()).await?;
+    let authorization = auth.sign(env, nonce).await?;
 
     // Upgrade account.
     let response = env
@@ -56,7 +47,7 @@ pub async fn upgrade_account(
         .upgrade_account(UpgradeAccountParameters {
             context: response.context,
             signature,
-            authorization,
+            authorization: authorization.clone(),
         })
         .await?;
 
@@ -69,10 +60,11 @@ pub async fn upgrade_account(
 
     assert!(receipt.status());
 
-    Ok(())
+    Ok((tx_hash, authorization))
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn basic_upgrade() -> eyre::Result<()> {
-    upgrade_account(&Environment::setup_with_upgraded().await?, vec![]).await
+    upgrade_account(&Environment::setup_with_upgraded().await?, &[], AuthKind::Auth).await?;
+    Ok(())
 }

--- a/tests/e2e/common_calls.rs
+++ b/tests/e2e/common_calls.rs
@@ -1,0 +1,44 @@
+use super::MockErc20;
+use alloy::{
+    primitives::{Address, U256},
+    sol_types::SolCall,
+};
+use relay::types::{
+    Call,
+    Delegation::{self, SpendPeriod},
+    Key,
+};
+
+/// ERC20 transfer call.
+pub fn transfer(erc20: Address, recipient: Address, amount: U256) -> Call {
+    Call {
+        target: erc20,
+        value: U256::ZERO,
+        data: MockErc20::transferCall { recipient, amount }.abi_encode().into(),
+    }
+}
+
+/// ERC20 mint call.
+pub fn mint(erc20: Address, a: Address, val: U256) -> Call {
+    Call {
+        target: erc20,
+        value: U256::ZERO,
+        data: MockErc20::mintCall { a, val }.abi_encode().into(),
+    }
+}
+
+/// Set a daily spend limit.
+pub fn daily_limit(token: Address, limit: U256, key: &Key) -> Call {
+    Call {
+        target: Address::ZERO,
+        value: U256::ZERO,
+        data: Delegation::setSpendLimitCall {
+            keyHash: key.key_hash(),
+            token,
+            period: SpendPeriod::Day,
+            limit,
+        }
+        .abi_encode()
+        .into(),
+    }
+}


### PR DESCRIPTION
Part 1 of porting old tests into the new API:

* `run_e2e` runs the test cases for both account initialization types with `run_e2e_upgraded` and `run_e2e_prep`.
  * `wallet_upgradeAccount` does not submit calls. So, any calls in the first `TxContext` are placed at the top of the following transaction **when dealing with an upgraded account**. This actually uncovered a bug on the contracts when you bundle spend limits and transfers.
* `TxContext` has a new field `authorization_keys`. Similar to the new API, it prepends `TxContext.calls` with `authorizeCalls` and permission setting (for now)
* added `common_calls.rs` which makes reading the test cases way easier.

Part 2 will change `process_tx` to move away from `estimateFees/sendAction` + clean-up