### PR TITLE
refactor: dont re-export entire rpc module

### DIFF
--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -46,13 +46,16 @@ use crate::{
     signers::DynSigner,
     storage::{RelayStorage, StorageApi},
     types::{
-        Account, Action, AuthorizeKeyResponse, CreateAccountParameters, CreateAccountResponse,
-        CreateAccountResponseCapabilities, ENTRYPOINT_NO_ERROR, Entry, EntryPoint, FeeTokens,
-        GetKeysParameters, KeyType, KeyWith712Signer, PREPAccount, PartialAction, PartialUserOp,
-        PrepareCallsParameters, PrepareCallsResponse, PrepareCallsResponseCapabilities,
-        PrepareUpgradeAccountParameters, Quote, SendPreparedCallsParameters,
-        SendPreparedCallsResponse, Signature, SignedQuote, UpgradeAccountParameters,
-        UpgradeAccountResponse, UserOp,
+        Account, Action, ENTRYPOINT_NO_ERROR, Entry, EntryPoint, FeeTokens, KeyType,
+        KeyWith712Signer, PREPAccount, PartialAction, PartialUserOp, Quote, Signature, SignedQuote,
+        UserOp,
+        rpc::{
+            AuthorizeKeyResponse, CreateAccountParameters, CreateAccountResponse,
+            CreateAccountResponseCapabilities, GetKeysParameters, PrepareCallsParameters,
+            PrepareCallsResponse, PrepareCallsResponseCapabilities,
+            PrepareUpgradeAccountParameters, SendPreparedCallsParameters,
+            SendPreparedCallsResponse, UpgradeAccountParameters, UpgradeAccountResponse,
+        },
     },
 };
 

--- a/src/types/key.rs
+++ b/src/types/key.rs
@@ -1,6 +1,7 @@
 use super::{
     super::signers::{DynSigner, Eip712PayLoadSigner, P256Key, P256Signer, WebAuthnSigner},
-    AuthorizeKey, U40,
+    U40,
+    rpc::AuthorizeKey,
 };
 use alloy::{
     dyn_abi::Eip712Domain,

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -30,8 +30,7 @@ pub use signed::*;
 mod quote;
 pub use quote::*;
 
-mod rpc;
-pub use rpc::*;
+pub mod rpc;
 
 mod token;
 pub use token::*;

--- a/src/types/rpc/keys.rs
+++ b/src/types/rpc/keys.rs
@@ -91,8 +91,13 @@ mod tests {
     use alloy::primitives::{Address, B256, Bytes, U256, fixed_bytes};
 
     use crate::types::{
-        AuthorizeKey, AuthorizeKeyResponse, Call, CallPermission, Delegation::SpendPeriod, Key,
-        KeyType, Permission, RevokeKey, SpendPermission, U40,
+        Call,
+        Delegation::SpendPeriod,
+        Key, KeyType, U40,
+        rpc::{
+            AuthorizeKey, AuthorizeKeyResponse, CallPermission, Permission, RevokeKey,
+            SpendPermission,
+        },
     };
 
     #[test]

--- a/src/types/rpc/permission.rs
+++ b/src/types/rpc/permission.rs
@@ -41,7 +41,7 @@ pub struct SpendPermission {
 mod tests {
     use alloy::primitives::{Address, fixed_bytes};
 
-    use crate::types::CallPermission;
+    use crate::types::rpc::CallPermission;
 
     #[test]
     fn deserialize_call_permission() {

--- a/tests/e2e/cases/calls.rs
+++ b/tests/e2e/cases/calls.rs
@@ -14,9 +14,12 @@ use relay::{
     rpc::RelayApiClient,
     signers::Eip712PayLoadSigner,
     types::{
-        AuthorizeKey, Call, KeyType, KeyWith712Signer, Meta, PrepareCallsCapabilities,
-        PrepareCallsParameters, PrepareCallsResponse, SendPreparedCallsParameters,
-        SendPreparedCallsResponse, SendPreparedCallsSignature, Signature,
+        Call, KeyType, KeyWith712Signer, Signature,
+        rpc::{
+            AuthorizeKey, Meta, PrepareCallsCapabilities, PrepareCallsParameters,
+            PrepareCallsResponse, SendPreparedCallsParameters, SendPreparedCallsResponse,
+            SendPreparedCallsSignature,
+        },
     },
 };
 use std::str::FromStr;

--- a/tests/e2e/cases/prep.rs
+++ b/tests/e2e/cases/prep.rs
@@ -14,11 +14,13 @@ use relay::{
     rpc::RelayApiClient,
     signers::Eip712PayLoadSigner,
     types::{
-        AuthorizeKey, Call, CreateAccountCapabilities, CreateAccountParameters,
-        CreateAccountResponse, KeyType, KeyWith712Signer, Meta, PREPAccount,
-        PrepareCallsCapabilities, PrepareCallsParameters, PrepareCallsResponse,
-        SendPreparedCallsParameters, SendPreparedCallsResponse, SendPreparedCallsSignature,
-        Signature,
+        Call, KeyType, KeyWith712Signer, PREPAccount, Signature,
+        rpc::{
+            AuthorizeKey, CreateAccountCapabilities, CreateAccountParameters,
+            CreateAccountResponse, Meta, PrepareCallsCapabilities, PrepareCallsParameters,
+            PrepareCallsResponse, SendPreparedCallsParameters, SendPreparedCallsResponse,
+            SendPreparedCallsSignature,
+        },
     },
 };
 use std::str::FromStr;

--- a/tests/e2e/cases/simple.rs
+++ b/tests/e2e/cases/simple.rs
@@ -12,7 +12,7 @@ use relay::{
     signers::{DynSigner, P256Signer},
     types::{
         Call, Delegation::SpendPeriod, IDelegation::authorizeCall, Key, KeyType, KeyWith712Signer,
-        UpgradeAccountCapabilities,
+        rpc::UpgradeAccountCapabilities,
     },
 };
 use std::sync::Arc;

--- a/tests/e2e/cases/upgrade.rs
+++ b/tests/e2e/cases/upgrade.rs
@@ -10,8 +10,11 @@ use eyre::WrapErr;
 use relay::{
     rpc::RelayApiClient,
     types::{
-        AuthorizeKey, CreateAccountCapabilities, Entry, KeyType, KeyWith712Signer,
-        PrepareUpgradeAccountParameters, UpgradeAccountCapabilities, UpgradeAccountParameters,
+        Entry, KeyType, KeyWith712Signer,
+        rpc::{
+            AuthorizeKey, CreateAccountCapabilities, PrepareUpgradeAccountParameters,
+            UpgradeAccountCapabilities, UpgradeAccountParameters,
+        },
     },
 };
 use std::str::FromStr;

--- a/tests/e2e/mod.rs
+++ b/tests/e2e/mod.rs
@@ -28,12 +28,14 @@ use relay::{
     rpc::RelayApiClient,
     signers::Eip712PayLoadSigner,
     types::{
-        Action, AuthorizeKey, CreateAccountCapabilities, Delegation, ENTRYPOINT_NO_ERROR, Entry,
-        Key, KeyType, KeyWith712Signer, Meta, PartialAction, PartialUserOp,
-        PrepareCallsCapabilities, PrepareCallsParameters, PrepareCallsResponse,
-        PrepareUpgradeAccountParameters, SendPreparedCallsParameters, SendPreparedCallsResponse,
-        SendPreparedCallsSignature, Signature, SignedQuote, U40, UpgradeAccountParameters, UserOp,
-        WebAuthnP256,
+        Action, Delegation, ENTRYPOINT_NO_ERROR, Entry, Key, KeyType, KeyWith712Signer,
+        PartialAction, PartialUserOp, Signature, SignedQuote, U40, UserOp, WebAuthnP256,
+        rpc::{
+            AuthorizeKey, CreateAccountCapabilities, Meta, PrepareCallsCapabilities,
+            PrepareCallsParameters, PrepareCallsResponse, PrepareUpgradeAccountParameters,
+            SendPreparedCallsParameters, SendPreparedCallsResponse, SendPreparedCallsSignature,
+            UpgradeAccountParameters,
+        },
     },
 };
 use std::str::FromStr;

--- a/tests/e2e/types.rs
+++ b/tests/e2e/types.rs
@@ -16,7 +16,7 @@ use alloy::{
 use eyre::WrapErr;
 use relay::{
     signers::{DynSigner, P256Signer},
-    types::{AuthorizeKey, Call, Key, KeyType, KeyWith712Signer},
+    types::{Call, Key, KeyType, KeyWith712Signer, rpc::AuthorizeKey},
 };
 
 /// Represents the expected outcome of a test case execution


### PR DESCRIPTION
initially we re-exported things in `types/` because it was a small module but now it's gotten really big and i think it makes sense to not re-export everything 

removes `pub use rpc::*` in `types/mod.rs`

on top of #221