### PR TITLE
refactor: ditch `Option<Vec<T>>`

### DIFF
--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -521,14 +521,13 @@ impl RelayApiServer for Relay {
             .ok_or(EstimateFeeError::UnsupportedChain(request.chain_id))?;
 
         // Generate all calls that will authorize keys and set their permissions
-        let authorize_calls =
-            request.capabilities.authorize_keys.iter().flatten().flat_map(|key| {
-                let (authorize_call, permissions_calls) = key.clone().into_calls(request.from);
-                std::iter::once(authorize_call).chain(permissions_calls)
-            });
+        let authorize_calls = request.capabilities.authorize_keys.iter().flat_map(|key| {
+            let (authorize_call, permissions_calls) = key.clone().into_calls(request.from);
+            std::iter::once(authorize_call).chain(permissions_calls)
+        });
 
         // todo: fetch them from somewhere.
-        let revoke_keys = None;
+        let revoke_keys = Vec::new();
 
         // Merges authorize calls with requested ones.
         let all_calls = authorize_calls.chain(request.calls).collect::<Vec<_>>();
@@ -600,16 +599,12 @@ impl RelayApiServer for Relay {
             context: quote,
             digest,
             capabilities: PrepareCallsResponseCapabilities {
-                authorize_keys: Some(
-                    request
-                        .capabilities
-                        .authorize_keys
-                        .into_iter()
-                        .flatten()
-                        .map(|key| key.into_response())
-                        .collect::<Vec<_>>(),
-                )
-                .filter(|keys| !keys.is_empty()),
+                authorize_keys: request
+                    .capabilities
+                    .authorize_keys
+                    .into_iter()
+                    .map(|key| key.into_response())
+                    .collect::<Vec<_>>(),
                 revoke_keys,
             },
         };
@@ -685,16 +680,13 @@ impl RelayApiServer for Relay {
             context: quote,
             digest,
             capabilities: PrepareCallsResponseCapabilities {
-                authorize_keys: Some(
-                    request
-                        .capabilities
-                        .authorize_keys
-                        .into_iter()
-                        .map(|key| key.into_response())
-                        .collect::<Vec<_>>(),
-                )
-                .filter(|keys| !keys.is_empty()),
-                revoke_keys: None,
+                authorize_keys: request
+                    .capabilities
+                    .authorize_keys
+                    .into_iter()
+                    .map(|key| key.into_response())
+                    .collect::<Vec<_>>(),
+                revoke_keys: Vec::new(),
             },
         };
 

--- a/src/types/rpc/calls.rs
+++ b/src/types/rpc/calls.rs
@@ -26,11 +26,13 @@ pub struct PrepareCallsParameters {
 #[serde(rename_all = "camelCase")]
 pub struct PrepareCallsCapabilities {
     /// Keys to authorize on the account.
-    pub authorize_keys: Option<Vec<AuthorizeKey>>,
+    #[serde(default)]
+    pub authorize_keys: Vec<AuthorizeKey>,
     /// Extra request values.
     pub meta: Meta,
     /// Keys to revoke from the account.
-    pub revoke_keys: Option<Vec<RevokeKey>>,
+    #[serde(default)]
+    pub revoke_keys: Vec<RevokeKey>,
 }
 
 /// Capabilities for `wallet_prepareCalls` response.
@@ -38,9 +40,11 @@ pub struct PrepareCallsCapabilities {
 #[serde(rename_all = "camelCase")]
 pub struct PrepareCallsResponseCapabilities {
     /// Keys that were authorized on the account.
-    pub authorize_keys: Option<Vec<AuthorizeKeyResponse>>,
+    #[serde(default)]
+    pub authorize_keys: Vec<AuthorizeKeyResponse>,
     /// Keys that were revoked from the account.
-    pub revoke_keys: Option<Vec<RevokeKey>>,
+    #[serde(default)]
+    pub revoke_keys: Vec<RevokeKey>,
 }
 
 /// Response for `wallet_prepareCalls`.

--- a/tests/e2e/cases/calls.rs
+++ b/tests/e2e/cases/calls.rs
@@ -58,8 +58,8 @@ async fn calls_with_upgraded_account() -> eyre::Result<()> {
                 chain_id: env.chain_id,
                 from: env.eoa.address(),
                 capabilities: PrepareCallsCapabilities {
-                    authorize_keys: None, // todo: add test authorize "inline"
-                    revoke_keys: None,
+                    authorize_keys: Vec::new(), // todo: add test authorize "inline"
+                    revoke_keys: Vec::new(),
                     meta: Meta {
                         fee_token: env.erc20,
                         key_hash: signer.key_hash(),

--- a/tests/e2e/cases/prep.rs
+++ b/tests/e2e/cases/prep.rs
@@ -65,8 +65,8 @@ pub async fn prep_account(
             chain_id: env.chain_id,
             from: env.eoa.address(),
             capabilities: PrepareCallsCapabilities {
-                authorize_keys: None,
-                revoke_keys: None,
+                authorize_keys: Vec::new(),
+                revoke_keys: Vec::new(),
                 meta: Meta {
                     fee_token: env.erc20,
                     key_hash: env.eoa.prep_signer().key_hash(),

--- a/tests/e2e/mod.rs
+++ b/tests/e2e/mod.rs
@@ -207,8 +207,8 @@ pub async fn prepare_calls(
             calls: tx.calls.clone(),
             chain_id: env.chain_id,
             capabilities: PrepareCallsCapabilities {
-                authorize_keys: Some(tx.authorization_keys.clone()).filter(|keys| !keys.is_empty()),
-                revoke_keys: None,
+                authorize_keys: tx.authorization_keys.clone(),
+                revoke_keys: Vec::new(),
                 meta: Meta {
                     fee_token: env.erc20,
                     key_hash: signer.key_hash(),


### PR DESCRIPTION
The `Option<Vec<T>>` for authorize/revoke keys just makes it hard to work with. the only reason the option exists is because authorize/revoke keys is optional in rpc, but `None` is treated as an empty vec anyway, so we can just use `#[serde(default)]`