### PR TITLE
refactor: use addr 0 for key auth/revoke + perms

### DIFF
--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -474,7 +474,7 @@ impl RelayApiServer for Relay {
             .authorize_keys
             .iter()
             .flat_map(|key| {
-                let (authorize_call, permissions_calls) = key.clone().into_calls(Address::ZERO);
+                let (authorize_call, permissions_calls) = key.clone().into_calls();
                 std::iter::once(authorize_call).chain(permissions_calls)
             })
             .collect::<Vec<_>>();
@@ -520,7 +520,7 @@ impl RelayApiServer for Relay {
 
         // Generate all calls that will authorize keys and set their permissions
         let authorize_calls = request.capabilities.authorize_keys.iter().flat_map(|key| {
-            let (authorize_call, permissions_calls) = key.clone().into_calls(request.from);
+            let (authorize_call, permissions_calls) = key.clone().into_calls();
             std::iter::once(authorize_call).chain(permissions_calls)
         });
 
@@ -633,7 +633,7 @@ impl RelayApiServer for Relay {
             .authorize_keys
             .iter()
             .flat_map(|key| {
-                let (authorize_call, permissions_calls) = key.clone().into_calls(request.address);
+                let (authorize_call, permissions_calls) = key.clone().into_calls();
                 std::iter::once(authorize_call).chain(permissions_calls)
             })
             .collect::<Vec<_>>();

--- a/src/types/call.rs
+++ b/src/types/call.rs
@@ -1,7 +1,7 @@
 //! ERC-7579 types.
 
 use alloy::{
-    primitives::{Address, B256, FixedBytes, U256},
+    primitives::{Address, B256, Bytes, FixedBytes, U256},
     sol,
     sol_types::SolCall,
 };
@@ -28,68 +28,56 @@ sol! {
 }
 
 impl Call {
+    /// Creates a self-call with the given data.
+    ///
+    /// The executor in ERC7821 replaces `address(0)` with `address(this)`, so we can utilize this
+    /// fact to construct self-calls, which are useful for e.g. configuring delegated accounts.
+    ///
+    /// See <https://github.com/Vectorized/solady/blob/c9e079c0ca836dcc52777a1fa7227ef28e3537b3/src/accounts/ERC7821.sol#L237-L239>.
+    pub fn self_call(data: Bytes) -> Self {
+        Self { target: Address::ZERO, data, ..Default::default() }
+    }
+
     /// Create a call to authorize a key on `eoa`.
-    pub fn authorize(eoa: Address, key: Key) -> Self {
-        Self { target: eoa, data: authorizeCall { key }.abi_encode().into(), ..Default::default() }
+    pub fn authorize(key: Key) -> Self {
+        Self::self_call(authorizeCall { key }.abi_encode().into())
     }
 
     /// Create a call to revoke a key on `eoa`.
-    pub fn revoke(eoa: Address, key_hash: B256) -> Self {
-        Self {
-            target: eoa,
-            data: revokeCall { keyHash: key_hash }.abi_encode().into(),
-            ..Default::default()
-        }
+    pub fn revoke(key_hash: B256) -> Self {
+        Self::self_call(revokeCall { keyHash: key_hash }.abi_encode().into())
     }
 
     /// Create a call to allow or disallow executing `selector` on `target` for `key_hash`.
     pub fn set_can_execute(
-        eoa: Address,
         key_hash: B256,
         target: Address,
         selector: FixedBytes<4>,
         can_execute: bool,
     ) -> Self {
-        Self {
-            target: eoa,
-            data: setCanExecuteCall {
-                keyHash: key_hash,
-                target,
-                fnSel: selector,
-                can: can_execute,
-            }
-            .abi_encode()
-            .into(),
-            ..Default::default()
-        }
+        Self::self_call(
+            setCanExecuteCall { keyHash: key_hash, target, fnSel: selector, can: can_execute }
+                .abi_encode()
+                .into(),
+        )
     }
 
     /// Create a call to set the spend limit for `key_hash` on `token` for `period`.
     pub fn set_spend_limit(
-        eoa: Address,
         key_hash: B256,
         token: Address,
         period: SpendPeriod,
         limit: U256,
     ) -> Self {
-        Self {
-            target: eoa,
-            data: setSpendLimitCall { keyHash: key_hash, token, period, limit }.abi_encode().into(),
-            ..Default::default()
-        }
+        Self::self_call(
+            setSpendLimitCall { keyHash: key_hash, token, period, limit }.abi_encode().into(),
+        )
     }
 
     /// Create a call to remove the spend limit for `key_hash` on `token` for `period`.
-    pub fn remove_spend_limit(
-        eoa: Address,
-        key_hash: B256,
-        token: Address,
-        period: SpendPeriod,
-    ) -> Self {
-        Self {
-            target: eoa,
-            data: removeSpendLimitCall { keyHash: key_hash, token, period }.abi_encode().into(),
-            ..Default::default()
-        }
+    pub fn remove_spend_limit(key_hash: B256, token: Address, period: SpendPeriod) -> Self {
+        Self::self_call(
+            removeSpendLimitCall { keyHash: key_hash, token, period }.abi_encode().into(),
+        )
     }
 }

--- a/tests/e2e/cases/prep.rs
+++ b/tests/e2e/cases/prep.rs
@@ -44,7 +44,7 @@ pub async fn prep_account(
     let init_calls = authorize_keys
         .iter()
         .flat_map(|key| {
-            let (authorize_call, permissions_calls) = key.clone().into_calls(Address::ZERO);
+            let (authorize_call, permissions_calls) = key.clone().into_calls();
             std::iter::once(authorize_call).chain(permissions_calls)
         })
         .collect::<Vec<_>>();

--- a/tests/e2e/common_calls.rs
+++ b/tests/e2e/common_calls.rs
@@ -29,16 +29,5 @@ pub fn mint(erc20: Address, a: Address, val: U256) -> Call {
 
 /// Set a daily spend limit.
 pub fn daily_limit(token: Address, limit: U256, key: &Key) -> Call {
-    Call {
-        target: Address::ZERO,
-        value: U256::ZERO,
-        data: Delegation::setSpendLimitCall {
-            keyHash: key.key_hash(),
-            token,
-            period: SpendPeriod::Day,
-            limit,
-        }
-        .abi_encode()
-        .into(),
-    }
+    Call::set_spend_limit(key.key_hash(), token, SpendPeriod::Day, limit)
 }


### PR DESCRIPTION
apparently address 0 is treated as the eoa itself, so we can just always use address 0.

https://github.com/Vectorized/solady/blob/c9e079c0ca836dcc52777a1fa7227ef28e3537b3/src/accounts/ERC7821.sol#L237-L239