### PR TITLE
Remove AWS ecr image push and reference to aws app-runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,17 +24,6 @@ jobs:
       - name: Set up Docker CLI
         uses: docker/setup-buildx-action@v3
 
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: eu-central-1
-
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
-
       - name: Login to GHCR
         uses: docker/login-action@v3
         with:
@@ -49,8 +38,6 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: |
-            ${{ steps.login-ecr.outputs.registry }}/odyssey/relay:latest
-            ${{ steps.login-ecr.outputs.registry }}/odyssey/relay:${{ github.ref_name }}
             ${{ env.GHCR_REPO }}:latest
             ${{ env.GHCR_REPO }}:${{ github.ref_name }}
           cache-from: type=gha

--- a/README.md
+++ b/README.md
@@ -116,4 +116,4 @@ End-to-end tests use [ithacaxyz/account](https://github.com/ithacaxyz/account) u
 
 ## Deploying
 
-A docker image is built and pushed to AWS ECR when a git tag (`vx.y.z`) is pushed to the repository. The image triggers an AWS AppRunner deployment.
+A docker image is built and pushed to GitHub Packages (`ghcr.io/ithacaxyz/relay`) when a git tag (`vx.y.z`) is pushed to the repository. The image triggers an Argo CD Image Updater deployment.


### PR DESCRIPTION
Both relay-staging and relay-production are now running in bare-metal cluster `ic-1`. Staging is automatically updated via ArgoCD image-updater. AWS App runners will be deleted.