### PR TITLE
fix: only support one entrypoint

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -18,6 +18,8 @@ pub struct RelayConfig {
     pub chain: ChainConfig,
     /// Quote configuration.
     pub quote: QuoteConfig,
+    /// Entrypoint address.
+    pub entrypoint: Address,
     /// Secrets.
     #[serde(skip_serializing, default)]
     pub secrets: SecretsConfig,
@@ -99,6 +101,7 @@ impl Default for RelayConfig {
                 gas: GasConfig { user_op_buffer: USER_OP_GAS_BUFFER, tx_buffer: TX_GAS_BUFFER },
                 ttl: Duration::from_secs(5),
             },
+            entrypoint: Address::ZERO,
             secrets: SecretsConfig::default(),
         }
     }
@@ -174,6 +177,12 @@ impl RelayConfig {
     /// Sets the secret key used to sign transactions.
     pub fn with_transaction_keys(mut self, secret_keys: &[String]) -> Self {
         self.secrets.transaction_keys.extend_from_slice(secret_keys);
+        self
+    }
+
+    /// Sets the entrypoint address.
+    pub fn with_entrypoint(mut self, entrypoint: Address) -> Self {
+        self.entrypoint = entrypoint;
         self
     }
 

--- a/src/eip712.rs
+++ b/src/eip712.rs
@@ -1,14 +1,11 @@
 //! EIP-712 related helpers.
 
-use crate::types::{Account, Entry, UserOp};
+use crate::types::{Entry, UserOp};
 use alloy::{
-    eips::eip7702::constants::EIP7702_DELEGATION_DESIGNATOR,
-    primitives::{Address, B256, Bytes},
+    primitives::{Address, B256},
     providers::DynProvider,
-    rpc::types::state::{AccountOverride, StateOverridesBuilder},
     sol_types::SolStruct,
 };
-use tracing::error;
 
 /// Computes the EIP-712 digest that the user must sign.
 ///
@@ -18,34 +15,11 @@ use tracing::error;
 /// Returns the eip712 digest that user will need to sign.
 pub async fn compute_eip712_digest(
     op: &UserOp,
+    entrypoint_address: Address,
     provider: &DynProvider,
-    delegation: Option<Address>,
 ) -> eyre::Result<B256> {
-    // Create the account override mapping.
-    let overrides = StateOverridesBuilder::default()
-        .apply(|overrides| {
-            let Some(delegation) = delegation else { return overrides };
-            overrides.append(
-                op.eoa,
-                AccountOverride::default()
-                    // we manually etch the 7702 designator since we do not have a signed auth item
-                    .with_code(Bytes::from(
-                        [&EIP7702_DELEGATION_DESIGNATOR, delegation.as_slice()].concat(),
-                    )),
-            )
-        })
-        .build();
-
-    // Create an account instance with the provided overrides.
-    let account = Account::new(op.eoa, provider).with_overrides(overrides.clone());
-
-    // Retrieve the entrypoint address.
-    let entrypoint_address = account.entrypoint().await.inspect_err(|err| {
-        error!(%err, "Failed to obtain entrypoint from account.");
-    })?;
-
     // Create the entrypoint instance with the same overrides.
-    let entrypoint = Entry::new(entrypoint_address, provider).with_overrides(overrides);
+    let entrypoint = Entry::new(entrypoint_address, provider);
 
     // Prepare the EIP-712 payload and domain
     let payload = op.as_eip712()?;

--- a/src/spawn.rs
+++ b/src/spawn.rs
@@ -85,6 +85,7 @@ pub async fn try_spawn(config: RelayConfig, registry: CoinRegistry) -> eyre::Res
 
     // todo: avoid all this darn cloning
     let rpc = Relay::new(
+        config.entrypoint,
         Chains::new(providers.clone(), signers, storage.clone()).await?,
         quote_signer,
         config.quote,

--- a/src/types/account.rs
+++ b/src/types/account.rs
@@ -16,8 +16,6 @@ use tracing::debug;
 sol! {
     #[sol(rpc)]
     contract Delegation {
-        address public constant ENTRY_POINT;
-
         /// A spend period.
         #[derive(Debug, Eq, PartialEq, Serialize, Deserialize)]
         #[serde(rename_all = "lowercase")]
@@ -137,25 +135,6 @@ impl<P: Provider> Account<P> {
     pub fn with_overrides(mut self, overrides: StateOverride) -> Self {
         self.overrides = overrides;
         self
-    }
-
-    /// Get the entrypoint address for this account.
-    pub async fn entrypoint(&self) -> TransportResult<Address> {
-        debug!(eoa = %self.delegation.address(), "Fetching entrypoint");
-        let entrypoint = self
-            .delegation
-            .ENTRY_POINT()
-            .call()
-            .overrides(self.overrides.clone())
-            .await
-            .map_err(TransportErrorKind::custom)?;
-        debug!(
-            eoa = %self.delegation.address(),
-            entrypoint = %entrypoint.ENTRY_POINT,
-            "Fetched entrypoint"
-        );
-
-        Ok(entrypoint.ENTRY_POINT)
     }
 
     /// Returns a list of all non expired keys as (KeyHash, Key) tuples.

--- a/tests/e2e/environment.rs
+++ b/tests/e2e/environment.rs
@@ -204,6 +204,7 @@ impl Environment {
                 .with_transaction_key(relay_private_key)
                 .with_quote_constant_rate(1.0)
                 .with_fee_tokens(&[erc20s.as_slice(), &[Address::ZERO]].concat())
+                .with_entrypoint(entrypoint)
                 .with_user_op_gas_buffer(100_000)
                 .with_tx_gas_buffer(50_000), // todo: temp
             registry,


### PR DESCRIPTION
don't fetch valid entrypoint address from accounts, instead only support 1 entrypoint

closes https://github.com/ithacaxyz/relay/issues/267