### PR TITLE
chore: rename account parameters fields

### DIFF
--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -430,7 +430,7 @@ impl RelayApiServer for Relay {
             .collect::<Vec<_>>();
 
         Ok(PrepareCreateAccountResponse {
-            account: PREPAccount::initialize(request.capabilities.delegation, init_calls),
+            context: PREPAccount::initialize(request.capabilities.delegation, init_calls),
             capabilities: request.capabilities.into_response(),
         })
     }
@@ -442,7 +442,7 @@ impl RelayApiServer for Relay {
 
         self.inner
             .storage
-            .write_prep(CreatableAccount::new(request.account, request.id_signatures))
+            .write_prep(CreatableAccount::new(request.context, request.signatures))
             .map_err(|err| from_eyre_error(err.into()))
             .await?;
 
@@ -459,7 +459,7 @@ impl RelayApiServer for Relay {
             .ok_or(EstimateFeeError::UnsupportedChain(request.chain_id))? // todo error handling
             .provider;
 
-        let (_, addresses) = AccountRegistryInstance::new(request.registry, provider)
+        let (_, addresses) = AccountRegistryInstance::new(self.inner.entrypoint, provider)
             .idInfo(request.id)
             .call()
             .await

--- a/src/types/rpc/account.rs
+++ b/src/types/rpc/account.rs
@@ -55,7 +55,7 @@ pub struct PrepareCreateAccountParameters {
 #[serde(rename_all = "camelCase")]
 pub struct PrepareCreateAccountResponse {
     /// Initializable account.
-    pub account: PREPAccount,
+    pub context: PREPAccount,
     /// Capabilities.
     pub capabilities: PrepareCreateAccountResponseCapabilities,
 }
@@ -65,9 +65,9 @@ pub struct PrepareCreateAccountResponse {
 #[serde(rename_all = "camelCase")]
 pub struct CreateAccountParameters {
     /// Initializable account.
-    pub account: PREPAccount,
+    pub context: PREPAccount,
     /// List of signatures over the PREPAddress.
-    pub id_signatures: Vec<KeyHashWithID>,
+    pub signatures: Vec<KeyHashWithID>,
 }
 
 /// Capabilities for `wallet_createAccount` request.
@@ -124,8 +124,6 @@ pub struct GetAccountsParameters {
     pub id: Address,
     /// Chain ID.
     pub chain_id: ChainId,
-    /// Entrypoint or account registry address.
-    pub registry: Address,
 }
 
 /// A response item from `wallet_getAccounts`.

--- a/tests/e2e/cases/id.rs
+++ b/tests/e2e/cases/id.rs
@@ -51,11 +51,7 @@ async fn register_id() -> eyre::Result<()> {
         // wallet_getAccounts should return the address and authorized keys from this ID
         let response = env
             .relay_endpoint
-            .get_accounts(GetAccountsParameters {
-                id,
-                chain_id: env.chain_id,
-                registry: env.entrypoint,
-            })
+            .get_accounts(GetAccountsParameters { id, chain_id: env.chain_id })
             .await?;
 
         assert_eq!(

--- a/tests/e2e/cases/prep.rs
+++ b/tests/e2e/cases/prep.rs
@@ -31,7 +31,7 @@ pub async fn prep_account(
     authorize_keys: &[AuthorizeKey],
 ) -> eyre::Result<TxHash> {
     // This will fetch a valid PREPAccount that the user will need to sign over the address
-    let PrepareCreateAccountResponse { capabilities, account: server_account } = env
+    let PrepareCreateAccountResponse { capabilities, context: server_account } = env
         .relay_endpoint
         .prepare_create_account(PrepareCreateAccountParameters {
             capabilities: PrepareCreateAccountCapabilities {
@@ -51,7 +51,10 @@ pub async fn prep_account(
 
     // Send the PREPAccount with its key identifiers and signatures
     env.relay_endpoint
-        .create_account(CreateAccountParameters { account: server_account, id_signatures })
+        .create_account(CreateAccountParameters {
+            context: server_account,
+            signatures: id_signatures,
+        })
         .await?;
 
     // todo: assert that a createAccount reference exists


### PR DESCRIPTION
* account -> context
* id_signatures -> signatures
* remove `entrypoint`, since we can now take it from the relay config.
