### PR TITLE
feat: introduce bundle entity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -343,9 +343,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "0.8.23"
+version = "0.8.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eacedba97e65cdc7ab592f2b22ef5d3ab8d60b2056bc3a6e6363577e8270ec6f"
+checksum = "7283185baefbe66136649dc316c9dcc6f0e9f1d635ae19783615919f83bc298a"
 dependencies = [
  "alloy-rlp",
  "bytes",
@@ -2134,7 +2134,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4131,7 +4131,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4312,8 +4312,10 @@ dependencies = [
  "aws-config",
  "aws-sdk-kms",
  "base64 0.22.1",
+ "bytes",
  "clap",
  "dashmap",
+ "derive_more 2.0.1",
  "dotenv",
  "eyre",
  "futures-util",
@@ -4526,7 +4528,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4539,7 +4541,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.3",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4639,7 +4641,7 @@ dependencies = [
  "security-framework 3.2.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5190,7 +5192,7 @@ dependencies = [
  "getrandom 0.3.2",
  "once_cell",
  "rustix 1.0.3",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5945,7 +5947,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,8 @@ tracing-subscriber = { version = "0.3.19", features = [
 url = { version = "2.5", features = ["serde"] }
 rand = "0.9"
 itertools = "0.14"
+derive_more = "2"
+bytes = "1"
 
 [dev-dependencies]
 alloy = { version = "0.12", features = ["eips", "provider-anvil-node"] }

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -390,6 +390,17 @@ impl RelayApiServer for Relay {
         }
 
         let tx = RelayTransaction::new(quote, self.inner.entrypoint, authorization);
+
+        // TODO: Right now we only support a single transaction per action and per bundle, so we can
+        // simply set BundleId to TxId. Eventually bundles might contain multiple transactions and
+        // this is already supported by current storage API.
+        let bundle_id = BundleId(*tx.id);
+        self.inner
+            .storage
+            .add_bundle_tx(bundle_id, tx.id)
+            .await
+            .map_err(SendActionError::internal)?;
+
         let mut rx = transactions.send_transaction(tx);
 
         // Wait for the transaction hash.

--- a/src/storage/api.rs
+++ b/src/storage/api.rs
@@ -2,7 +2,7 @@
 
 use super::StorageError;
 use crate::{
-    transactions::{PendingTransaction, TransactionStatus},
+    transactions::{PendingTransaction, TransactionStatus, TxId},
     types::{CreatableAccount, rpc::BundleId},
 };
 use alloy::primitives::Address;
@@ -25,7 +25,7 @@ pub trait StorageApi: Debug + Send + Sync {
     async fn write_pending_transaction(&self, tx: &PendingTransaction) -> Result<()>;
 
     /// Removes a pending transaction from storage.
-    async fn remove_pending_transaction(&self, tx_id: BundleId) -> Result<()>;
+    async fn remove_pending_transaction(&self, tx_id: TxId) -> Result<()>;
 
     /// Reads pending transactions for the given signer and chain id from storage.
     async fn read_pending_transactions(
@@ -35,12 +35,14 @@ pub trait StorageApi: Debug + Send + Sync {
     ) -> Result<Vec<PendingTransaction>>;
 
     /// Saves a transaction status.
-    async fn write_transaction_status(
-        &self,
-        tx: BundleId,
-        status: &TransactionStatus,
-    ) -> Result<()>;
+    async fn write_transaction_status(&self, tx: TxId, status: &TransactionStatus) -> Result<()>;
 
     /// Reads a transaction status.
-    async fn read_transaction_status(&self, tx: BundleId) -> Result<Option<TransactionStatus>>;
+    async fn read_transaction_status(&self, tx: TxId) -> Result<Option<TransactionStatus>>;
+
+    /// Adds a transaction to a bundle.
+    async fn add_bundle_tx(&self, bundle: BundleId, tx: TxId) -> Result<()>;
+
+    /// Gets all transactions in a bundle.
+    async fn get_bundle_transactions(&self, bundle: BundleId) -> Result<Vec<TxId>>;
 }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -7,7 +7,7 @@ pub use error::StorageError;
 mod memory;
 
 use crate::{
-    transactions::{PendingTransaction, TransactionStatus},
+    transactions::{PendingTransaction, TransactionStatus, TxId},
     types::{CreatableAccount, rpc::BundleId},
 };
 use alloy::primitives::Address;
@@ -41,7 +41,7 @@ impl StorageApi for RelayStorage {
         self.inner.write_pending_transaction(tx).await
     }
 
-    async fn remove_pending_transaction(&self, tx_id: BundleId) -> api::Result<()> {
+    async fn remove_pending_transaction(&self, tx_id: TxId) -> api::Result<()> {
         self.inner.remove_pending_transaction(tx_id).await
     }
 
@@ -55,16 +55,21 @@ impl StorageApi for RelayStorage {
 
     async fn write_transaction_status(
         &self,
-        tx: BundleId,
+        tx: TxId,
         status: &TransactionStatus,
     ) -> api::Result<()> {
         self.inner.write_transaction_status(tx, status).await
     }
 
-    async fn read_transaction_status(
-        &self,
-        tx: BundleId,
-    ) -> api::Result<Option<TransactionStatus>> {
+    async fn read_transaction_status(&self, tx: TxId) -> api::Result<Option<TransactionStatus>> {
         self.inner.read_transaction_status(tx).await
+    }
+
+    async fn add_bundle_tx(&self, bundle: BundleId, tx: TxId) -> api::Result<()> {
+        self.inner.add_bundle_tx(bundle, tx).await
+    }
+
+    async fn get_bundle_transactions(&self, bundle: BundleId) -> api::Result<Vec<TxId>> {
+        self.inner.get_bundle_transactions(bundle).await
     }
 }

--- a/src/transactions/mod.rs
+++ b/src/transactions/mod.rs
@@ -5,4 +5,4 @@ pub use service::*;
 mod signer;
 pub use signer::*;
 mod transaction;
-pub use transaction::{PendingTransaction, RelayTransaction, TransactionStatus};
+pub use transaction::{PendingTransaction, RelayTransaction, TransactionStatus, TxId};

--- a/src/transactions/service.rs
+++ b/src/transactions/service.rs
@@ -1,7 +1,5 @@
-use crate::types::rpc::BundleId;
-
 use super::{
-    SignerEvent, SignerHandle,
+    SignerEvent, SignerHandle, TxId,
     transaction::{RelayTransaction, TransactionStatus},
 };
 use rand::seq::IndexedRandom;
@@ -47,7 +45,7 @@ pub struct TransactionService {
     command_rx: mpsc::UnboundedReceiver<TransactionServiceMessage>,
 
     /// Subscriptions to transaction status updates.
-    subscriptions: HashMap<BundleId, mpsc::UnboundedSender<TransactionStatus>>,
+    subscriptions: HashMap<TxId, mpsc::UnboundedSender<TransactionStatus>>,
 }
 
 impl TransactionService {

--- a/src/transactions/signer.rs
+++ b/src/transactions/signer.rs
@@ -1,8 +1,8 @@
-use super::transaction::{PendingTransaction, RelayTransaction, TransactionStatus};
+use super::transaction::{PendingTransaction, RelayTransaction, TransactionStatus, TxId};
 use crate::{
     signers::DynSigner,
     storage::{RelayStorage, StorageApi, StorageError},
-    types::{ENTRYPOINT_NO_ERROR, EntryPoint, rpc::BundleId},
+    types::{ENTRYPOINT_NO_ERROR, EntryPoint},
 };
 use alloy::{
     consensus::{Transaction, TxEip1559, TxEnvelope, TypedTransaction},
@@ -85,7 +85,7 @@ pub enum SignerMessage {
 #[derive(Debug)]
 pub enum SignerEvent {
     /// Status update for a transaction.
-    TransactionStatus(BundleId, TransactionStatus),
+    TransactionStatus(TxId, TransactionStatus),
 }
 
 /// A signer responsible for signing and sending transactions on a single network.
@@ -169,7 +169,7 @@ impl Signer {
     /// Sends a transaction status update.
     async fn update_tx_status(
         &self,
-        tx: BundleId,
+        tx: TxId,
         status: TransactionStatus,
     ) -> Result<(), StorageError> {
         self.storage.write_transaction_status(tx, &status).await?;

--- a/src/types/rpc/calls.rs
+++ b/src/types/rpc/calls.rs
@@ -1,21 +1,24 @@
 //! RPC calls-related request and response types.
 
+use super::{AuthorizeKey, AuthorizeKeyResponse, Meta, RevokeKey};
 use crate::types::{Call, KeyType, SignedQuote};
 use alloy::{
     consensus::Eip658Value,
-    primitives::{Address, B256, BlockHash, BlockNumber, Bytes, ChainId, Log, TxHash},
+    primitives::{
+        Address, B256, BlockHash, BlockNumber, Bytes, ChainId, Log, TxHash, wrap_fixed_bytes,
+    },
 };
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
-use super::{AuthorizeKey, AuthorizeKeyResponse, Meta, RevokeKey};
-
-/// An identifier for a call bundle.
-///
-/// This is a unique identifier for a call bundle, which is used to track the status of the bundle.
-///
-/// Clients should treat this as an opaque value and not attempt to parse it.
-pub type BundleId = B256;
+wrap_fixed_bytes! {
+    /// An identifier for a call bundle.
+    ///
+    /// This is a unique identifier for a call bundle, which is used to track the status of the bundle.
+    ///
+    /// Clients should treat this as an opaque value and not attempt to parse it.
+    pub struct BundleId<32>;
+}
 
 /// Request parameters for `wallet_prepareCalls`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -97,8 +100,9 @@ pub struct SendPreparedCallsSignature {
 /// Response for `wallet_sendPreparedCalls`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SendPreparedCallsResponse {
-    /// Bundle identifier.
-    pub id: BundleId,
+    /// Transaction hash.
+    /// TODO: use [`BundleId`] instead
+    pub id: TxHash,
 }
 
 /// The status code of a call bundle.


### PR DESCRIPTION
Adds `wrap_fixed_bytes!` invocations definiting `BundleId` and `TxId` as standalone types to highlight that those are different from each other and tx hash.

- `TxId` is a way how we identify transactions internally. Every `TxId` corresponds to a single transaction being processed by a `TransactionService`. We store `TxId -> TransactionStatus` mapping to check the state of a transaction
- `BundleId` is ERC-5792 id which might correspond to one or more transactions (`TxId`s).

Right now we are still returning `TxHash` from `sendPreparedCalls` as I assume it would be a breaking change to start returning `BundleId`s instead, however, database is already populated with the bundle -> tx mapping, for now only adding 1 tx per bundle (but supporting more).
