### PR TITLE
refactor: rm `sendAction`

### DIFF
--- a/src/types/action.rs
+++ b/src/types/action.rs
@@ -3,7 +3,7 @@
 use alloy::primitives::ChainId;
 use serde::{Deserialize, Serialize};
 
-use super::{PartialUserOp, UserOp};
+use super::PartialUserOp;
 
 /// A partial action which differs from [`Action`] in that it contains a [`PartialUserOp`].
 ///
@@ -13,16 +13,6 @@ use super::{PartialUserOp, UserOp};
 pub struct PartialAction {
     /// The user op.
     pub op: PartialUserOp,
-    /// The destination chain ID.
-    pub chain_id: ChainId,
-}
-
-/// An action.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct Action {
-    /// The user op.
-    pub op: UserOp,
     /// The destination chain ID.
     pub chain_id: ChainId,
 }


### PR DESCRIPTION
removes `sendAction` from the public rpc and makes it a private function on `Relay`. additionally, changes the signature slightly, since we have all the info we need in `SignedQuote`.

a note here would be that `SignedQuote` kind of is a weird name now... same with `Quote`. we should consider renaming it (as it is really a quote + a user op and more)

Closes #216 