### PR TITLE
feat: optional nonce

### DIFF
--- a/src/types/op.rs
+++ b/src/types/op.rs
@@ -1,6 +1,6 @@
 use super::Call;
 use alloy::{
-    primitives::{B256, Keccak256, U256},
+    primitives::{Address, B256, Bytes, Keccak256, U256},
     sol,
     sol_types::SolValue,
     uint,
@@ -93,24 +93,26 @@ sol! {
         /// Excluded from signature.
         bytes initData;
     }
+}
 
-    /// A partial [`UserOp`] used for fee estimation.
-    #[derive(Debug, Serialize, Deserialize)]
-    #[serde(rename_all = "camelCase")]
-    struct PartialUserOp {
-        /// The user's address.
-        address eoa;
-        /// An encoded array of calls, using ERC7579 batch execution encoding.
-        /// `abi.encode(calls)`, where `calls` is an array of type `Call[]`.
-        /// This allows for more efficient safe forwarding to the EOA.
-        bytes executionData;
-        /// Per delegated EOA.
-        uint256 nonce;
-        /// Optional data for `initPREP` on the delegation.
-        ///
-        /// Excluded from signature.
-        bytes initData;
-    }
+/// A partial [`UserOp`] used for fee estimation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PartialUserOp {
+    /// The user's address.
+    pub eoa: Address,
+    /// An encoded array of calls, using ERC7579 batch execution encoding.
+    ///
+    /// The format is `abi.encode(calls)`, where `calls` is an array of type `Call[]`.
+    ///
+    /// This allows for more efficient safe forwarding to the EOA.
+    pub execution_data: Bytes,
+    /// Per delegated EOA.
+    pub nonce: Option<U256>,
+    /// Optional data for `initPREP` on the delegation.
+    ///
+    /// Excluded from signature.
+    pub init_data: Option<Bytes>,
 }
 
 mod eip712 {

--- a/src/types/rpc/mod.rs
+++ b/src/types/rpc/mod.rs
@@ -27,5 +27,5 @@ pub struct Meta {
     /// Key (hash) that will be used to sign the request.
     pub key_hash: B256,
     /// Nonce.
-    pub nonce: U256,
+    pub nonce: Option<U256>,
 }

--- a/tests/e2e/cases/calls.rs
+++ b/tests/e2e/cases/calls.rs
@@ -61,7 +61,7 @@ async fn calls_with_upgraded_account() -> eyre::Result<()> {
                     meta: Meta {
                         fee_token: env.erc20,
                         key_hash: signer.key_hash(),
-                        nonce: U256::from(tx_num + user_op_nonce),
+                        nonce: Some(U256::from(tx_num + user_op_nonce)),
                     },
                 },
             })

--- a/tests/e2e/cases/prep.rs
+++ b/tests/e2e/cases/prep.rs
@@ -80,7 +80,7 @@ pub async fn prep_account(
                     fee_token: env.erc20,
                     key_hash: env.eoa.prep_signer().key_hash(),
                     // this will be the first UserOP
-                    nonce: U256::from(0),
+                    nonce: Some(U256::from(0)),
                 },
             },
         })

--- a/tests/e2e/mod.rs
+++ b/tests/e2e/mod.rs
@@ -188,7 +188,7 @@ pub async fn prepare_calls(
                 meta: Meta {
                     fee_token: env.fee_token,
                     key_hash: signer.key_hash(),
-                    nonce: U256::from(tx_num),
+                    nonce: Some(U256::from(tx_num)),
                 },
             },
         })


### PR DESCRIPTION
i've moved `PartialUserOp` out of `sol!` so we can make some fields optional. this is still technically just temporary until we address #215, but this allows us to make `nonce` optional.

if the nonce is not specified, we just fetch the next nonce for the sequence key `0`. this should work for now, but if we want replayability on the userops, we should use a multichain sequence key.

closes #207 