### PR TITLE
chore: return `authorize_keys` on `getAccounts` for undeployed accounts

### DIFF
--- a/src/types/storage.rs
+++ b/src/types/storage.rs
@@ -11,7 +11,7 @@ pub struct CreatableAccount {
 
 impl CreatableAccount {
     /// Return a new [`CreateAccount`].
-    pub fn new(account: PREPAccount, id_signature: Vec<KeyHashWithID>) -> Self {
-        Self { prep: account, id_signatures: id_signature }
+    pub fn new(account: PREPAccount, id_signatures: Vec<KeyHashWithID>) -> Self {
+        Self { prep: account, id_signatures }
     }
 }


### PR DESCRIPTION
follow-up to https://github.com/ithacaxyz/relay/pull/285
> right now, If the account is only in storage, it will return an empty keys: Vec<AuthorizedKeyResponse>. will handle on a follow-up 