### PR TITLE
fix: dont do any account initialization in `prepareCalls` for preops

### DIFF
--- a/src/types/rpc/calls.rs
+++ b/src/types/rpc/calls.rs
@@ -51,6 +51,8 @@ pub struct PrepareCallsCapabilities {
     ///
     /// See [`UserOp::encodedPreOps`].
     pub pre_ops: Vec<UserOp>,
+    /// Whether the call bundle is to be considered a preop.
+    pub pre_op: bool,
 }
 
 /// Capabilities for `wallet_prepareCalls` response.

--- a/tests/e2e/cases/calls.rs
+++ b/tests/e2e/cases/calls.rs
@@ -64,6 +64,7 @@ async fn calls_with_upgraded_account() -> eyre::Result<()> {
                         nonce: Some(U256::from(tx_num + user_op_nonce)),
                     },
                     pre_ops: Vec::new(),
+                    pre_op: false,
                 },
             })
             .await?;

--- a/tests/e2e/cases/id.rs
+++ b/tests/e2e/cases/id.rs
@@ -11,7 +11,7 @@ use relay::{
 async fn register_id() -> eyre::Result<()> {
     let mut env = AccountConfig::Prep.setup_environment().await?;
     let authorized_key = env.eoa.prep_signer().to_authorized();
-    prep_account(&mut env, &[], &[authorized_key], vec![]).await?;
+    prep_account(&mut env, &[], &[authorized_key], &[], 0).await?;
 
     if let EoaKind::Prep { admin_key, account } = env.eoa {
         let admin_key_hash = admin_key.key_hash();

--- a/tests/e2e/cases/prep.rs
+++ b/tests/e2e/cases/prep.rs
@@ -1,9 +1,15 @@
 //! Prepare calls related end-to-end test cases
 
-use crate::e2e::{MockErc20, environment::Environment, eoa::EoaKind, send_prepared_calls};
+use crate::e2e::{
+    MockErc20, TxContext, build_pre_ops,
+    environment::{Environment, mint_erc20s},
+    eoa::EoaKind,
+    send_prepared_calls,
+};
 use alloy::{
-    primitives::{Address, B256, PrimitiveSignature, TxHash, U256},
+    primitives::{Address, B256, PrimitiveSignature, TxHash, TxKind, U256},
     providers::{PendingTransactionBuilder, Provider},
+    rpc::types::TransactionRequest,
     sol_types::{SolCall, SolValue},
 };
 use eyre::Context;
@@ -11,7 +17,7 @@ use relay::{
     rpc::RelayApiClient,
     signers::{DynSigner, Eip712PayLoadSigner},
     types::{
-        Call, KeyHashWithID, Signature, UserOp,
+        Call, KeyHashWithID, Signature,
         rpc::{
             AuthorizeKey, CreateAccountParameters, GetAccountsParameters, Meta,
             PrepareCallsCapabilities, PrepareCallsParameters, PrepareCallsResponse,
@@ -21,11 +27,12 @@ use relay::{
     },
 };
 
-pub async fn prep_account(
+pub async fn prep_account<'a>(
     env: &mut Environment,
     calls: &[Call],
     authorize_keys: &[AuthorizeKey],
-    pre_ops: Vec<UserOp>,
+    pre_ops: &[TxContext<'a>],
+    tx_num: usize,
 ) -> eyre::Result<TxHash> {
     // This will fetch a valid PREPAccount that the user will need to sign over the address
     let PrepareCreateAccountResponse {
@@ -45,6 +52,18 @@ pub async fn prep_account(
         .await?;
 
     assert!(prep_address == context.account.address);
+
+    // Mint ERC20 tokens into the account
+    mint_erc20s(&[env.erc20, env.erc20_alt], &[prep_address], &env.provider).await?;
+    env.provider
+        .send_transaction(TransactionRequest {
+            to: Some(TxKind::Call(prep_address)),
+            value: Some(U256::from(100e18)),
+            ..Default::default()
+        })
+        .await?
+        .get_receipt()
+        .await?;
 
     let signatures = match &mut env.eoa {
         EoaKind::Upgraded(_dyn_signer) => unreachable!(),
@@ -80,6 +99,7 @@ pub async fn prep_account(
         assert!(response.iter().any(|r| r.address == prep_address));
     }
 
+    let pre_ops = build_pre_ops(env, pre_ops, tx_num).await?;
     let PrepareCallsResponse { context, digest, capabilities: _ } = env
         .relay_endpoint
         .prepare_calls(PrepareCallsParameters {
@@ -96,6 +116,7 @@ pub async fn prep_account(
                     nonce: Some(U256::from(0)),
                 },
                 pre_ops,
+                pre_op: false,
             },
         })
         .await?;
@@ -148,7 +169,8 @@ async fn basic_prep() -> eyre::Result<()> {
         }],
         // todo: add test where key is not admin and should have permissions
         &[eoa_authorized],
-        vec![],
+        &[],
+        0,
     )
     .await?;
 


### PR DESCRIPTION
This PR addresses several issues when trying to use `preOps` in the same transaction as account creation:

- Each preop would also contain calls to register the admin key with the account registry, which would fail, since the first `preOp` to do so would occupy the ID
- We simulated `preOps` using `prepareCalls` before creating the account using `createAccount`, which would complain that the account did not exist (which was true)
- For prep tests we mint erc20's to the account *after* the first call bundle is sent to the relay, but this makes it impossible to test cases where the first call bundle involves a transfer of that token, so that logic was moved to right after `wallet_prepareAccount`

The PR solves this with a combination of moving some parts of the testing harness around and adding a `pre_op: bool` flag to `prepareCalls`'s capabilities, indicating whether the call bundle is to be used as a `preOp` or a regular user op.