### PR TITLE
chore: refactor `authorization_keys` on `e2e::TxContext`

### DIFF
--- a/tests/e2e/cases/porto.rs
+++ b/tests/e2e/cases/porto.rs
@@ -13,7 +13,7 @@ async fn behavior_delegation() -> Result<()> {
         vec![
             // Authorize key (delegation provided in the call)
             TxContext {
-                authorization_keys: vec![key.to_authorized()],
+                authorization_keys: vec![&key],
                 expected: ExpectedOutcome::Pass,
                 auth: Some(AuthKind::Auth),
                 ..Default::default()
@@ -40,14 +40,14 @@ async fn execution_guard_spend_limit_and_guard() -> Result<()> {
         vec![
             // Authorize admin key
             TxContext {
-                authorization_keys: vec![key.to_authorized()],
+                authorization_keys: vec![&key],
                 expected: ExpectedOutcome::Pass,
                 auth: Some(AuthKind::Auth),
                 ..Default::default()
             },
             // Authorize another key, set execution guard and spend limit (1.5 ETH) for it
             TxContext {
-                authorization_keys: vec![another_key.to_authorized()],
+                authorization_keys: vec![&another_key],
                 calls: vec![
                     Call {
                         target: Address::ZERO,
@@ -94,7 +94,7 @@ async fn behavior_spend_limits() -> Result<()> {
     run_e2e(|env| {
         vec![
             TxContext {
-                authorization_keys: vec![key.to_authorized()],
+                authorization_keys: vec![&key],
                 expected: ExpectedOutcome::Pass,
                 auth: Some(AuthKind::Auth),
                 ..Default::default()
@@ -137,7 +137,7 @@ async fn execution_guard_target_scope() -> Result<()> {
         vec![
             // Authorize admin key
             TxContext {
-                authorization_keys: vec![key.to_authorized()],
+                authorization_keys: vec![&key],
                 expected: ExpectedOutcome::Pass,
                 auth: Some(AuthKind::Auth),
                 ..Default::default()
@@ -145,7 +145,7 @@ async fn execution_guard_target_scope() -> Result<()> {
             // Authorize another key and set execution guard with a target scope (only env.erc20
             // allowed)
             TxContext {
-                authorization_keys: vec![another_key.to_authorized()],
+                authorization_keys: vec![&another_key],
                 calls: vec![Call {
                     target: Address::ZERO,
                     value: U256::ZERO,
@@ -191,7 +191,7 @@ async fn execution_guard_target_scope_selector() -> Result<()> {
         vec![
             // Authorize admin key
             TxContext {
-                authorization_keys: vec![key.to_authorized()],
+                authorization_keys: vec![&key],
                 expected: ExpectedOutcome::Pass,
                 auth: Some(AuthKind::Auth),
                 ..Default::default()
@@ -199,7 +199,7 @@ async fn execution_guard_target_scope_selector() -> Result<()> {
             // Authorize another key and set execution guard with target and selector (for
             // "transfer")
             TxContext {
-                authorization_keys: vec![another_key.to_authorized()],
+                authorization_keys: vec![&another_key],
                 calls: vec![Call {
                     target: Address::ZERO,
                     value: U256::ZERO,
@@ -244,7 +244,7 @@ async fn send_default() -> Result<()> {
         vec![
             // Delegate (empty calls with auth)
             TxContext {
-                authorization_keys: vec![key.to_authorized()],
+                authorization_keys: vec![&key],
                 expected: ExpectedOutcome::Pass,
                 auth: Some(AuthKind::Auth),
                 ..Default::default()
@@ -275,14 +275,14 @@ async fn execution_guard_default() -> Result<()> {
         vec![
             // Authorize admin key with delegation
             TxContext {
-                authorization_keys: vec![key.to_authorized()],
+                authorization_keys: vec![&key],
                 expected: ExpectedOutcome::Pass,
                 auth: Some(AuthKind::Auth),
                 ..Default::default()
             },
             // Authorize and set execution guard using default values for selector and target
             TxContext {
-                authorization_keys: vec![another_key.to_authorized()],
+                authorization_keys: vec![&another_key],
                 calls: vec![Call {
                     target: Address::ZERO,
                     value: U256::ZERO,
@@ -322,7 +322,7 @@ async fn prepare_send_prepared_default() -> Result<()> {
             TxContext {
                 expected: ExpectedOutcome::Pass,
                 auth: Some(AuthKind::Auth),
-                authorization_keys: vec![key.to_authorized()],
+                authorization_keys: vec![&key],
                 ..Default::default()
             },
             // Prepared transfer call (simulating prepare then sendPrepared)
@@ -346,7 +346,7 @@ async fn delegated_false_eoa_key_to_authorize_p256() -> Result<()> {
         vec![
             // Send authorize call (EOA signs; delegation parameter provided)
             TxContext {
-                authorization_keys: vec![key.to_authorized()],
+                authorization_keys: vec![&key],
                 expected: ExpectedOutcome::Pass,
                 auth: Some(AuthKind::Auth),
                 ..Default::default()
@@ -372,7 +372,7 @@ async fn delegated_true_eoa_key_to_authorize_p256() -> Result<()> {
         vec![
             // Authorize the new key (signed by EOA)
             TxContext {
-                authorization_keys: vec![key.to_authorized()],
+                authorization_keys: vec![&key],
                 expected: ExpectedOutcome::Pass,
                 auth: Some(AuthKind::Auth),
                 ..Default::default()
@@ -399,14 +399,14 @@ async fn key_p256_key_to_authorize_p256() -> Result<()> {
         vec![
             // Authorize first key
             TxContext {
-                authorization_keys: vec![key.to_authorized()],
+                authorization_keys: vec![&key],
                 expected: ExpectedOutcome::Pass,
                 auth: Some(AuthKind::Auth),
                 ..Default::default()
             },
             // Authorize a second (P256) key using the first key
             TxContext {
-                authorization_keys: vec![another_key.to_authorized()],
+                authorization_keys: vec![&another_key],
                 expected: ExpectedOutcome::Pass,
                 key: Some(&key),
                 ..Default::default()
@@ -434,7 +434,7 @@ async fn key_p256_key_to_authorize_p256_session() -> Result<()> {
         vec![
             // Authorize the admin key (P256)
             TxContext {
-                authorization_keys: vec![key.to_authorized()],
+                authorization_keys: vec![&key],
                 expected: ExpectedOutcome::Pass,
                 auth: Some(AuthKind::Auth),
                 ..Default::default()
@@ -442,7 +442,7 @@ async fn key_p256_key_to_authorize_p256_session() -> Result<()> {
             // Authorize the session key and set its execution guard using
             // Delegation::setCanExecuteCall with defaults
             TxContext {
-                authorization_keys: vec![session_key.to_authorized()],
+                authorization_keys: vec![&session_key],
                 calls: vec![Call {
                     target: Address::ZERO,
                     value: U256::ZERO,
@@ -481,14 +481,14 @@ async fn key_p256_key_to_authorize_webcryptop256() -> Result<()> {
         vec![
             // Delegate
             TxContext {
-                authorization_keys: vec![key.to_authorized()],
+                authorization_keys: vec![&key],
                 expected: ExpectedOutcome::Pass,
                 auth: Some(AuthKind::Auth),
                 ..Default::default()
             },
             // Authorize the second key (WebCryptoP256) using the first key
             TxContext {
-                authorization_keys: vec![another_key.to_authorized()],
+                authorization_keys: vec![&another_key],
                 expected: ExpectedOutcome::Pass,
                 key: Some(&key),
                 ..Default::default()
@@ -514,7 +514,7 @@ async fn session_key_pre_op() -> Result<()> {
         vec![
             // Authorize the admin key (P256)
             TxContext {
-                authorization_keys: vec![key.to_authorized()],
+                authorization_keys: vec![&key],
                 expected: ExpectedOutcome::Pass,
                 auth: Some(AuthKind::Auth),
                 ..Default::default()
@@ -523,7 +523,7 @@ async fn session_key_pre_op() -> Result<()> {
                 expected: ExpectedOutcome::Pass,
                 // Bundle session key authorization as a pre-op
                 pre_ops: vec![TxContext {
-                    authorization_keys: vec![session_key.to_authorized()],
+                    authorization_keys: vec![&session_key],
                     calls: vec![Call {
                         target: Address::ZERO,
                         value: U256::ZERO,
@@ -560,12 +560,12 @@ async fn session_key_pre_op_prep_single_tx() -> Result<()> {
     let session_key = KeyWith712Signer::random_session(KeyType::P256)?.unwrap();
     run_e2e_prep(|env| {
         vec![TxContext {
-            authorization_keys: vec![key.to_authorized()],
+            authorization_keys: vec![&key],
             auth: Some(AuthKind::Auth),
             expected: ExpectedOutcome::Pass,
             // Bundle session key authorization as a pre-op
             pre_ops: vec![TxContext {
-                authorization_keys: vec![session_key.to_authorized()],
+                authorization_keys: vec![&session_key],
                 calls: vec![Call::set_can_execute(
                     session_key.key_hash(),
                     DEFAULT_EXECUTE_TO,

--- a/tests/e2e/cases/simple.rs
+++ b/tests/e2e/cases/simple.rs
@@ -17,7 +17,7 @@ async fn auth_then_erc20_transfer() -> Result<()> {
         run_e2e(|env| {
             vec![
                 TxContext {
-                    authorization_keys: vec![key.to_authorized()],
+                    authorization_keys: vec![&key],
                     expected: ExpectedOutcome::Pass,
                     auth: Some(AuthKind::Auth),
                     ..Default::default()
@@ -40,7 +40,7 @@ async fn invalid_auth_nonce() -> Result<()> {
     let key = KeyWith712Signer::random_admin(KeyType::WebAuthnP256)?.unwrap();
     run_e2e_upgraded(|_env| {
         vec![TxContext {
-            authorization_keys: vec![key.to_authorized()],
+            authorization_keys: vec![&key],
             expected: ExpectedOutcome::FailSend,
             auth: Some(AuthKind::modified_nonce(123)),
             ..Default::default()
@@ -58,7 +58,7 @@ async fn invalid_auth_signature() -> Result<()> {
 
     run_e2e_upgraded(|_env| {
         vec![TxContext {
-            authorization_keys: vec![key.to_authorized()],
+            authorization_keys: vec![&key],
             expected: ExpectedOutcome::FailSend,
             // Signing with an unrelated key should fail during sendAction when calling eth_call
             auth: Some(AuthKind::modified_signer(dummy_signer.clone())),
@@ -78,12 +78,12 @@ async fn auth_then_two_authorizes_then_erc20_transfer() -> Result<()> {
             TxContext {
                 expected: ExpectedOutcome::Pass,
                 auth: Some(AuthKind::Auth),
-                authorization_keys: vec![key1.to_authorized()],
+                authorization_keys: vec![&key1],
                 ..Default::default()
             },
             TxContext {
                 expected: ExpectedOutcome::Pass,
-                authorization_keys: vec![key2.to_authorized()],
+                authorization_keys: vec![&key2],
                 key: Some(&key1),
                 ..Default::default()
             },
@@ -107,7 +107,7 @@ async fn spend_limits() -> Result<()> {
             // delegate, auth and set spend limit
             TxContext {
                 expected: ExpectedOutcome::Pass,
-                authorization_keys: vec![key1.to_authorized()],
+                authorization_keys: vec![&key1],
                 auth: Some(AuthKind::Auth),
                 ..Default::default()
             },
@@ -132,13 +132,13 @@ async fn spend_limits() -> Result<()> {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn native_transfer() -> Result<()> {
-    for key_type in [KeyType::Secp256k1, KeyType::P256, KeyType::WebAuthnP256] {
+    for key_type in [KeyType::Secp256k1, KeyType::WebAuthnP256] {
         let key = KeyWith712Signer::random_admin(key_type)?.unwrap();
 
         run_e2e(|_env| {
             vec![
                 TxContext {
-                    authorization_keys: vec![key.to_authorized()],
+                    authorization_keys: vec![&key],
                     expected: ExpectedOutcome::Pass,
                     auth: Some(AuthKind::Auth),
                     ..Default::default()
@@ -158,13 +158,13 @@ async fn native_transfer() -> Result<()> {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn spend_limits_bundled() -> Result<()> {
-    let key1 = KeyWith712Signer::random_admin(KeyType::P256)?.unwrap();
+    let key1 = KeyWith712Signer::random_admin(KeyType::WebAuthnP256)?.unwrap();
 
     run_e2e(|env| {
         vec![
             TxContext {
                 expected: ExpectedOutcome::Pass,
-                authorization_keys: vec![key1.to_authorized()],
+                authorization_keys: vec![&key1],
                 auth: Some(AuthKind::Auth),
                 ..Default::default()
             },
@@ -192,13 +192,13 @@ async fn spend_limits_bundled() -> Result<()> {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn spend_limits_bundle_failure() -> Result<()> {
-    let key1 = KeyWith712Signer::random_admin(KeyType::P256)?.unwrap();
+    let key1 = KeyWith712Signer::random_admin(KeyType::WebAuthnP256)?.unwrap();
 
     run_e2e(|env| {
         vec![
             TxContext {
                 expected: ExpectedOutcome::Pass,
-                authorization_keys: vec![key1.to_authorized()],
+                authorization_keys: vec![&key1],
                 auth: Some(AuthKind::Auth),
                 ..Default::default()
             },

--- a/tests/e2e/eoa.rs
+++ b/tests/e2e/eoa.rs
@@ -1,21 +1,12 @@
-use alloy::{
-    primitives::{Address, B256, PrimitiveSignature, U256},
-    sol_types::SolCall,
-};
-use relay::{
-    signers::{DynSigner, Eip712PayLoadSigner},
-    types::{
-        Call, CreatableAccount, IDelegation::authorizeCall, KeyHashWithID, KeyType,
-        KeyWith712Signer, PREPAccount,
-    },
-};
+use alloy::primitives::Address;
+use relay::{signers::DynSigner, types::CreatableAccount};
 
 /// Kind of EOA: PREP or Upgraded.
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug)]
 pub enum EoaKind {
     Upgraded(DynSigner),
-    Prep { admin_key: KeyWith712Signer, account: CreatableAccount },
+    Prep(Option<CreatableAccount>),
 }
 
 impl EoaKind {
@@ -24,47 +15,9 @@ impl EoaKind {
         Self::Upgraded(signer)
     }
 
-    /// Create a new [`EoaKind`] with [`PREPAccount`].
-    pub async fn create_prep(
-        admin_key: KeyWith712Signer,
-        delegation: Address,
-    ) -> eyre::Result<Self> {
-        let init_calls = vec![Call {
-            target: Address::ZERO,
-            value: U256::ZERO,
-            data: authorizeCall { key: admin_key.key().clone() }.abi_encode().into(),
-        }];
-
-        let prep = PREPAccount::initialize(delegation, init_calls);
-        let key_hash = admin_key.key_hash();
-        let hash = admin_key.id_digest(prep.address);
-
-        let (id, signature) = match admin_key.keyType {
-            KeyType::P256 => {
-                panic!("P256 can only be a session key.")
-            }
-            KeyType::WebAuthnP256 => {
-                let ephemeral = DynSigner::load(&B256::random().to_string(), None).await?;
-                (ephemeral.address(), ephemeral.sign_payload_hash(hash).await?)
-            }
-            KeyType::Secp256k1 => (
-                Address::from_slice(&admin_key.publicKey[12..]),
-                admin_key.sign_payload_hash(hash).await?,
-            ),
-            _ => unreachable!(),
-        };
-
-        Ok(Self::Prep {
-            admin_key,
-            account: CreatableAccount::new(
-                prep,
-                vec![KeyHashWithID {
-                    hash: key_hash,
-                    id,
-                    signature: PrimitiveSignature::from_raw(&signature).unwrap(),
-                }],
-            ),
-        })
+    /// Create a new [`EoaKind`] with [`CreatableAccount`].
+    pub fn create_prep() -> Self {
+        Self::Prep(None)
     }
 
     /// Returns a reference to the inner [`DynSigner`] when dealing with an upgraded account.
@@ -81,28 +34,23 @@ impl EoaKind {
         }
     }
 
-    /// Returns a reference to the inner [`KeyWith712Signer`] when dealing with a PREP account.
-    ///
-    /// # Panics
-    ///
-    /// This will panic if it's not a PREP account.
-    pub fn prep_signer(&self) -> &KeyWith712Signer {
-        match self {
-            EoaKind::Upgraded(_dyn_signer) => panic!("eoa is not a prep account"),
-            EoaKind::Prep { admin_key, .. } => admin_key,
-        }
-    }
-
     /// Whether self is a PREP account.
     pub fn is_prep(&self) -> bool {
         matches!(self, Self::Prep { .. })
     }
 
     /// Returns [`Address`].
+    ///
+    /// # Panics
+    ///
+    /// It will panic if the account has not been yet created when dealing with
+    /// [`CreatableAccount`].
     pub fn address(&self) -> Address {
         match self {
             EoaKind::Upgraded(dyn_signer) => dyn_signer.address(),
-            EoaKind::Prep { account, .. } => account.prep.address,
+            EoaKind::Prep(account) => {
+                account.as_ref().expect("prep not calculated yet").prep.address
+            }
         }
     }
 }

--- a/tests/e2e/mod.rs
+++ b/tests/e2e/mod.rs
@@ -33,7 +33,7 @@ use relay::{
     types::{
         Delegation, ENTRYPOINT_NO_ERROR,
         EntryPoint::UserOpExecuted,
-        KeyType, KeyWith712Signer, Signature, SignedQuote,
+        KeyWith712Signer, Signature, SignedQuote,
         rpc::{
             Meta, PrepareCallsCapabilities, PrepareCallsParameters, PrepareCallsResponse,
             SendPreparedCallsParameters, SendPreparedCallsSignature,
@@ -194,8 +194,8 @@ pub async fn prepare_calls(
             calls: tx.calls.clone(),
             chain_id: env.chain_id,
             capabilities: PrepareCallsCapabilities {
-                authorize_keys: tx.authorization_keys.clone(),
-                revoke_keys: Vec::new(),
+                authorize_keys: tx.authorization_keys(),
+                revoke_keys: vec![],
                 meta: Meta {
                     fee_token: env.fee_token,
                     key_hash: signer.key_hash(),


### PR DESCRIPTION
Needed some changes to clean-up the usage of IDs with PREP. A `PREPAccount` is no longer created during environment setup, and is only created with the list of `authorized_key` coming from the first `TxContext`.

1) `EoaKind::Prep` no longer has a `admin key: KeyWith712Signer`. This was too confusing, messy and unnecessary.
2) `KeyWith712Signer` now takes a `id_signer: Option<DynSigner>`. This enables every key to sign a prep address and provide its ID (for AccountRegistry tests)
3) `TxContext::authorization_keys` is now a list of `KeyWith712Signer`.
4) Adds a `id_signature` for all `authorization_keys` in `fn prep_account`, not just the one from the environment (which no longer exists as of 1)). 


`KeyWith712Signer` is becoming more of a test type. And its usage is actually quite minimal on the relay itself (`estimateFees`). Will probably handle it in a follow-up this week. 