### PR TITLE
feat: add accounts to `AccountRegistry` outside of prep initialization

### DIFF
--- a/src/error/keys.rs
+++ b/src/error/keys.rs
@@ -1,4 +1,5 @@
 use super::invalid_params;
+use crate::types::KeyHash;
 use alloy::primitives::{Address, PrimitiveSignature};
 use thiserror::Error;
 
@@ -31,12 +32,16 @@ pub enum KeysError {
         /// The ID in the request.
         got: Address,
     },
+    /// Missing key id signature.
+    #[error("missing key id signature for key hash {0}")]
+    MissingKeyID(KeyHash),
 }
 
 impl From<KeysError> for jsonrpsee::types::error::ErrorObject<'static> {
     fn from(err: KeysError) -> Self {
         match err {
             KeysError::UnsupportedKeyType
+            | KeysError::MissingKeyID { .. }
             | KeysError::MissingAdminKey
             | KeysError::OnlyAdminKeyAllowed
             | KeysError::TakenKeyId { .. }

--- a/src/types/account.rs
+++ b/src/types/account.rs
@@ -339,7 +339,7 @@ impl PREPAccount {
                     authorize_key: AuthorizeKey {
                         key: authorize.key,
                         permissions: vec![],
-                        id_signature: None,
+                        signature: None,
                     },
                 })
             })

--- a/tests/e2e/cases/id.rs
+++ b/tests/e2e/cases/id.rs
@@ -52,7 +52,7 @@ async fn register_and_unregister_id() -> eyre::Result<()> {
                 address: account.prep.address,
                 keys: vec![AuthorizeKeyResponse {
                     hash: admin_key_hash,
-                    authorize_key: admin_key.to_authorized(),
+                    authorize_key: admin_key.to_authorized(None).await?,
                 }]
             }]
         );

--- a/tests/e2e/cases/prep.rs
+++ b/tests/e2e/cases/prep.rs
@@ -47,7 +47,10 @@ pub async fn prep_account<'a>(
         .relay_endpoint
         .prepare_create_account(PrepareCreateAccountParameters {
             capabilities: PrepareCreateAccountCapabilities {
-                authorize_keys: authorize_keys.iter().map(|k| k.to_authorized()).collect(),
+                authorize_keys: try_join_all(
+                    authorize_keys.iter().map(async |k| k.to_authorized(None).await),
+                )
+                .await?,
                 delegation: env.delegation,
             },
             chain_id: env.chain_id,

--- a/tests/e2e/cases/transactions.rs
+++ b/tests/e2e/cases/transactions.rs
@@ -42,7 +42,7 @@ impl MockAccount {
             .relay_endpoint
             .prepare_create_account(PrepareCreateAccountParameters {
                 capabilities: PrepareCreateAccountCapabilities {
-                    authorize_keys: vec![key.to_authorized()],
+                    authorize_keys: vec![key.to_authorized(None).await?],
                     delegation: env.delegation,
                 },
                 chain_id: env.chain_id,

--- a/tests/e2e/cases/upgrade.rs
+++ b/tests/e2e/cases/upgrade.rs
@@ -69,10 +69,12 @@ pub async fn upgrade_account(
 
 #[tokio::test(flavor = "multi_thread")]
 async fn basic_upgrade() -> eyre::Result<()> {
+    let env = Environment::setup_with_upgraded().await?;
     let key = KeyWith712Signer::random_admin(KeyType::WebAuthnP256)?.unwrap();
+
     upgrade_account(
-        &Environment::setup_with_upgraded().await?,
-        &[key.to_authorized()],
+        &env,
+        &[key.to_authorized(Some(env.eoa.address())).await?],
         AuthKind::Auth,
         vec![],
     )
@@ -91,7 +93,7 @@ async fn invalid_auth_quote_check() -> eyre::Result<()> {
             address: env.eoa.address(),
             chain_id: env.chain_id,
             capabilities: UpgradeAccountCapabilities {
-                authorize_keys: vec![key.to_authorized()],
+                authorize_keys: vec![key.to_authorized(Some(env.eoa.address())).await?],
                 delegation: env.delegation,
                 fee_token: env.erc20,
                 pre_ops: vec![],

--- a/tests/e2e/mod.rs
+++ b/tests/e2e/mod.rs
@@ -194,7 +194,7 @@ pub async fn prepare_calls(
             calls: tx.calls.clone(),
             chain_id: env.chain_id,
             capabilities: PrepareCallsCapabilities {
-                authorize_keys: tx.authorization_keys(),
+                authorize_keys: tx.authorization_keys(Some(env.eoa.address())).await?,
                 revoke_keys: tx.revoke_keys(),
                 meta: Meta {
                     fee_token: env.fee_token,


### PR DESCRIPTION
on top of https://github.com/ithacaxyz/relay/pull/292

Accounts were only being registered during the PREP intialization. This PR ensures that every authorize of an admin key OR webauthn must come with a ID signature, so it can be added to `AccountRegistry`.

`AuthorizeKey` takes an extra optional argument `signature`
* `Some(KeyHash)` -> if it's an admin OR webauthn key AND we know the EOA address (prep or upgraded) 
* `None` -> if we're calling `prepareAccount` (we don't know the prep address) OR it's a session key which is NOT webauthn


Follow-up will integrate `AccountRegistry::appendAccount`