### PR TITLE
chore: unify rpc signatures under `KeySignature`

### DIFF
--- a/src/error/keys.rs
+++ b/src/error/keys.rs
@@ -1,6 +1,6 @@
 use super::invalid_params;
 use crate::types::KeyHash;
-use alloy::primitives::{Address, PrimitiveSignature};
+use alloy::primitives::{Address, Bytes};
 use thiserror::Error;
 
 /// Errors related to authorization keys.
@@ -23,7 +23,7 @@ pub enum KeysError {
     TakenKeyId(Address),
     /// Invalid key identifier signature.
     #[error("invalid key identifier signature: {0}")]
-    InvalidKeyIdSignature(PrimitiveSignature),
+    InvalidKeyIdSignature(Bytes),
     /// Unexpected key identifier.
     #[error("invalid key identifier: expected {expected}, got {got}")]
     UnexpectedKeyId {

--- a/src/types/key.rs
+++ b/src/types/key.rs
@@ -151,11 +151,18 @@ impl Key {
     /// The key hash.
     ///
     /// The hash is computed as `keccak256(abi.encode(key.keyType, keccak256(key.publicKey)))`.
-    pub fn key_hash(&self) -> B256 {
+    pub fn hash(key_type: KeyType, public_key: &[u8]) -> B256 {
         let mut hasher = Keccak256::new();
-        hasher.update(B256::with_last_byte(self.keyType as u8));
-        hasher.update(keccak256(self.publicKey.as_ref()));
+        hasher.update(B256::with_last_byte(key_type as u8));
+        hasher.update(keccak256(public_key));
         hasher.finalize()
+    }
+
+    /// The key hash.
+    ///
+    /// The hash is computed as `keccak256(abi.encode(key.keyType, keccak256(key.publicKey)))`.
+    pub fn key_hash(&self) -> B256 {
+        Self::hash(self.keyType, &self.publicKey)
     }
 
     /// Get the seed slot for the given key.

--- a/src/types/rpc/account.rs
+++ b/src/types/rpc/account.rs
@@ -1,6 +1,6 @@
 //! RPC account-related request and response types.
 
-use super::{AuthorizeKey, AuthorizeKeyResponse, SendPreparedCallsResponse};
+use super::{AuthorizeKey, AuthorizeKeyResponse, KeySignature, SendPreparedCallsResponse};
 use crate::{
     error::{AuthError, KeysError},
     types::{Key, KeyHashWithID, KeyID, PREPAccount, SignedQuote, UserOp},
@@ -88,39 +88,44 @@ pub struct CreateAccountContext {
 pub struct CreateAccountParameters {
     /// Initializable account.
     pub context: CreateAccountContext,
-    /// List of signatures over the PREPAddress.
-    pub signatures: Vec<KeyHashWithID>,
+    /// List of key id signatures over the PREPAddress.
+    pub signatures: Vec<KeySignature>,
 }
 
 impl CreateAccountParameters {
-    /// Validates the PREPAccount and key identifier signatures.
-    pub fn validate(&self) -> RpcResult<()> {
+    /// Validates [`CreateAccountParameters`] and returns the derived list of [`KeyHashWithID`].
+    pub fn validate_and_get_key_ids(&self) -> RpcResult<Vec<KeyHashWithID>> {
         // Ensure PREPAccount is well built, since it might not come from the relay.
         if !self.context.account.is_valid() {
             return Err(AuthError::InvalidPrep(self.context.account.clone()).into());
         }
 
-        // Ensure that every key identifier signature is valid and recovers the same id.
-        self.validate_signatures()
-    }
-
-    /// Verifies all signatures against the [`PREPAccount`] address and key identifiers.
-    pub fn validate_signatures(&self) -> RpcResult<()> {
         if self.signatures.is_empty() {
             return Err(KeysError::MissingAdminKey.into());
         }
 
-        for KeyHashWithID { hash, id, signature } in &self.signatures {
-            let digest = Key::id_digest_from_hash(*hash, self.context.account.address);
-            let expected = signature
-                .recover_address_from_prehash(&digest)
-                .map_err(|_| KeysError::InvalidKeyIdSignature(*signature))?;
+        self.key_identifiers()
+    }
 
-            if *id != expected {
-                return Err(KeysError::UnexpectedKeyId { expected, got: *id }.into());
-            }
-        }
-        Ok(())
+    /// Validates all signatures and returns the derived list of [`KeyHashWithID`].
+    fn key_identifiers(&self) -> RpcResult<Vec<KeyHashWithID>> {
+        self.signatures
+            .iter()
+            .map(|KeySignature { public_key, key_type, value }| {
+                let hash = Key::hash(*key_type, public_key);
+                let digest = Key::id_digest_from_hash(hash, self.context.account.address);
+
+                PrimitiveSignature::from_raw(value)
+                    .and_then(|signature| {
+                        signature.recover_address_from_prehash(&digest).map(|id| KeyHashWithID {
+                            hash,
+                            id,
+                            signature,
+                        })
+                    })
+                    .map_err(|_| KeysError::InvalidKeyIdSignature(value.clone()).into())
+            })
+            .collect()
     }
 }
 

--- a/src/types/rpc/calls.rs
+++ b/src/types/rpc/calls.rs
@@ -1,12 +1,10 @@
 //! RPC calls-related request and response types.
 
-use super::{AuthorizeKey, AuthorizeKeyResponse, Meta, RevokeKey};
-use crate::types::{Call, KeyType, SignedQuote, UserOp};
+use super::{AuthorizeKey, AuthorizeKeyResponse, KeySignature, Meta, RevokeKey};
+use crate::types::{Call, SignedQuote, UserOp};
 use alloy::{
     consensus::Eip658Value,
-    primitives::{
-        Address, B256, BlockHash, BlockNumber, Bytes, ChainId, Log, TxHash, wrap_fixed_bytes,
-    },
+    primitives::{Address, B256, BlockHash, BlockNumber, ChainId, Log, TxHash, wrap_fixed_bytes},
 };
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
@@ -88,21 +86,8 @@ pub struct PrepareCallsResponse {
 pub struct SendPreparedCallsParameters {
     /// The [`SignedQuote`] of the prepared call bundle.
     pub context: SignedQuote,
-    /// Signature values.
-    pub signature: SendPreparedCallsSignature,
-}
-
-/// Signature.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct SendPreparedCallsSignature {
-    /// Public key that generated the signature.
-    pub public_key: Bytes,
-    /// Type of key that generated the signature.
-    #[serde(rename = "type")]
-    pub key_type: KeyType,
-    /// Signature value.
-    pub value: Bytes,
+    /// UserOp key signature.
+    pub signature: KeySignature,
 }
 
 /// Response for `wallet_sendPreparedCalls`.

--- a/src/types/rpc/keys.rs
+++ b/src/types/rpc/keys.rs
@@ -130,6 +130,19 @@ impl RevokeKey {
     }
 }
 
+/// Key Signature.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct KeySignature {
+    /// Public key that generated the signature.
+    pub public_key: Bytes,
+    /// Type of key that generated the signature.
+    #[serde(rename = "type")]
+    pub key_type: KeyType,
+    /// Signature value.
+    pub value: Bytes,
+}
+
 #[cfg(test)]
 mod tests {
     use alloy::primitives::{Address, B256, Bytes, U256, fixed_bytes};

--- a/tests/e2e/cases/transactions.rs
+++ b/tests/e2e/cases/transactions.rs
@@ -16,11 +16,11 @@ use relay::{
     signers::Eip712PayLoadSigner,
     transactions::{RelayTransaction, TransactionStatus},
     types::{
-        Call, KeyHashWithID, KeyType, KeyWith712Signer, Signature,
+        Call, KeyType, KeyWith712Signer, Signature,
         rpc::{
-            CreateAccountParameters, Meta, PrepareCallsCapabilities, PrepareCallsParameters,
-            PrepareCallsResponse, PrepareCreateAccountCapabilities, PrepareCreateAccountParameters,
-            PrepareCreateAccountResponse,
+            CreateAccountParameters, KeySignature, Meta, PrepareCallsCapabilities,
+            PrepareCallsParameters, PrepareCallsResponse, PrepareCreateAccountCapabilities,
+            PrepareCreateAccountParameters, PrepareCreateAccountResponse,
         },
     },
 };
@@ -55,7 +55,11 @@ impl MockAccount {
         env.relay_endpoint
             .create_account(CreateAccountParameters {
                 context,
-                signatures: vec![KeyHashWithID { hash: key.key_hash(), id: key.id(), signature }],
+                signatures: vec![KeySignature {
+                    public_key: key.publicKey.clone(),
+                    key_type: key.keyType,
+                    value: signature.as_bytes().into(),
+                }],
             })
             .await
             .unwrap();

--- a/tests/e2e/mod.rs
+++ b/tests/e2e/mod.rs
@@ -35,8 +35,8 @@ use relay::{
         EntryPoint::UserOpExecuted,
         KeyWith712Signer, Signature, SignedQuote,
         rpc::{
-            Meta, PrepareCallsCapabilities, PrepareCallsParameters, PrepareCallsResponse,
-            SendPreparedCallsParameters, SendPreparedCallsSignature,
+            KeySignature, Meta, PrepareCallsCapabilities, PrepareCallsParameters,
+            PrepareCallsResponse, SendPreparedCallsParameters,
         },
     },
 };
@@ -238,7 +238,7 @@ pub async fn send_prepared_calls(
         .relay_endpoint
         .send_prepared_calls(SendPreparedCallsParameters {
             context: quote,
-            signature: SendPreparedCallsSignature {
+            signature: KeySignature {
                 public_key: signer.publicKey.clone(),
                 key_type: signer.keyType,
                 value: signature,


### PR DESCRIPTION
Additionally, `wallet_createAccount`  returns a list `KeyHashWithID`, so the client can double check on their end before funding the account.