### PR TITLE
chore: expect `innerSignature` on `KeySignature` instead

### DIFF
--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -784,7 +784,14 @@ impl RelayApiServer for Relay {
         let op = &mut request.context.ty_mut().op;
 
         // Fill UserOp with the user signature.
-        op.signature = request.signature.value;
+        let key_hash = request.signature.key_hash();
+        op.signature = Signature {
+            innerSignature: request.signature.value,
+            keyHash: key_hash,
+            prehash: false,
+        }
+        .abi_encode_packed()
+        .into();
 
         // Set `paymentAmount`. It is not included into the signature so we need to enforce it here.
         op.paymentAmount = op.paymentMaxAmount;

--- a/src/types/rpc/keys.rs
+++ b/src/types/rpc/keys.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     error::KeysError,
-    types::{Call, Key, KeyID, KeyType},
+    types::{Call, Key, KeyHash, KeyID, KeyType},
 };
 
 use super::Permission;
@@ -141,6 +141,13 @@ pub struct KeySignature {
     pub key_type: KeyType,
     /// Signature value.
     pub value: Bytes,
+}
+
+impl KeySignature {
+    /// Returns the associated [`KeyHash`].
+    pub fn key_hash(&self) -> KeyHash {
+        Key::hash(self.key_type, &self.public_key)
+    }
 }
 
 #[cfg(test)]

--- a/tests/e2e/cases/calls.rs
+++ b/tests/e2e/cases/calls.rs
@@ -7,7 +7,7 @@ use crate::e2e::{
 use alloy::{
     primitives::{Address, U256},
     providers::{PendingTransactionBuilder, Provider},
-    sol_types::{SolCall, SolValue},
+    sol_types::SolCall,
 };
 use eyre::Context;
 use futures_util::future::try_join_all;
@@ -15,7 +15,7 @@ use relay::{
     rpc::RelayApiClient,
     signers::Eip712PayLoadSigner,
     types::{
-        Call, KeyType, KeyWith712Signer, Signature,
+        Call, KeyType, KeyWith712Signer,
         rpc::{Meta, PrepareCallsCapabilities, PrepareCallsParameters, PrepareCallsResponse},
     },
 };
@@ -71,15 +71,7 @@ async fn calls_with_upgraded_account() -> eyre::Result<()> {
             .await?;
 
         // Sign UserOp digest
-        // todo: innerSignature once estimateFee (or equivalent) is aware of the key instead of just
-        // key type.
-        let signature = Signature {
-            innerSignature: signer.sign_payload_hash(digest).await?,
-            keyHash: signer.key_hash(),
-            prehash: false,
-        }
-        .abi_encode_packed()
-        .into();
+        let signature = signer.sign_payload_hash(digest).await?;
 
         // Submit signed call
         let tx_hash = send_prepared_calls(&env, signer, signature, context).await?;

--- a/tests/e2e/cases/prep.rs
+++ b/tests/e2e/cases/prep.rs
@@ -10,7 +10,7 @@ use alloy::{
     primitives::{Address, TxHash, TxKind, U256},
     providers::{PendingTransactionBuilder, Provider},
     rpc::types::TransactionRequest,
-    sol_types::{SolCall, SolValue},
+    sol_types::SolCall,
 };
 use eyre::Context;
 use futures_util::future::try_join_all;
@@ -18,7 +18,7 @@ use relay::{
     rpc::RelayApiClient,
     signers::Eip712PayLoadSigner,
     types::{
-        Call, CreatableAccount, KeyType, KeyWith712Signer, Signature,
+        Call, CreatableAccount, KeyType, KeyWith712Signer,
         rpc::{
             CreateAccountParameters, GetAccountsParameters, GetKeysParameters, KeySignature, Meta,
             PrepareCallsCapabilities, PrepareCallsParameters, PrepareCallsResponse,
@@ -143,15 +143,7 @@ pub async fn prep_account<'a>(
         .await?;
 
     // Sign UserOp digest
-    // todo: innerSignature once estimateFee (or equivalent) is aware of the key instead of just
-    // key type.
-    let signature = Signature {
-        innerSignature: prep_signer.sign_payload_hash(digest).await?,
-        keyHash: prep_signer.key_hash(),
-        prehash: false,
-    }
-    .abi_encode_packed()
-    .into();
+    let signature = prep_signer.sign_payload_hash(digest).await?;
 
     // Submit signed call
     let tx_hash = send_prepared_calls(env, prep_signer, signature, context).await?;

--- a/tests/e2e/cases/transactions.rs
+++ b/tests/e2e/cases/transactions.rs
@@ -87,13 +87,7 @@ impl MockAccount {
             .await
             .unwrap();
 
-        let signature = Signature {
-            innerSignature: key.sign_payload_hash(digest).await?,
-            keyHash: key.key_hash(),
-            prehash: false,
-        }
-        .abi_encode_packed()
-        .into();
+        let signature = key.sign_payload_hash(digest).await?;
 
         let tx_hash = send_prepared_calls(env, &key, signature, context).await.unwrap();
 

--- a/tests/e2e/mod.rs
+++ b/tests/e2e/mod.rs
@@ -22,7 +22,6 @@ use alloy::{
     eips::eip7702::{SignedAuthorization, constants::EIP7702_DELEGATION_DESIGNATOR},
     primitives::{Address, B256, Bytes, TxHash, U256},
     providers::{PendingTransactionBuilder, Provider},
-    sol_types::SolValue,
 };
 use eyre::{Context, Result};
 use futures_util::future::try_join_all;
@@ -33,7 +32,7 @@ use relay::{
     types::{
         Delegation, ENTRYPOINT_NO_ERROR,
         EntryPoint::UserOpExecuted,
-        KeyWith712Signer, Signature, SignedQuote,
+        KeyWith712Signer, SignedQuote,
         rpc::{
             KeySignature, Meta, PrepareCallsCapabilities, PrepareCallsParameters,
             PrepareCallsResponse, SendPreparedCallsParameters,
@@ -216,13 +215,7 @@ pub async fn prepare_calls(
     }
 
     let PrepareCallsResponse { context, digest, .. } = response?;
-    let signature = Signature {
-        innerSignature: signer.sign_payload_hash(digest).await.wrap_err("Signing failed")?,
-        keyHash: signer.key_hash(),
-        prehash: false,
-    }
-    .abi_encode_packed()
-    .into();
+    let signature = signer.sign_payload_hash(digest).await.wrap_err("Signing failed")?;
 
     Ok(Some((signature, context)))
 }


### PR DESCRIPTION
Now expects `innerSignature` on `KeySignature` for `wallet_sendPreparedCalls`

on top of https://github.com/ithacaxyz/relay/pull/300

closes https://github.com/ithacaxyz/relay/issues/205