### PR TITLE
fix: check onchain state first on `wallet_getAccounts`

### DIFF
--- a/src/types/account_registry.rs
+++ b/src/types/account_registry.rs
@@ -1,4 +1,4 @@
-use super::KeyHash;
+use super::{KeyHash, KeyID};
 use crate::error::RelayError;
 use alloy::{primitives::Address, providers::DynProvider, sol};
 
@@ -57,5 +57,18 @@ impl AccountRegistry::AccountRegistryCalls {
                     })
                     .collect()
             })
+    }
+
+    /// Returns all acounts of the requested [`KeyID`].
+    pub async fn accounts(
+        id: KeyID,
+        entrypoint: Address,
+        provider: DynProvider,
+    ) -> Result<Option<Vec<Address>>, RelayError> {
+        Ok(Self::id_infos(vec![id], entrypoint, provider)
+            .await?
+            .pop()
+            .expect("should exist")
+            .map(|(_, accounts)| accounts))
     }
 }


### PR DESCRIPTION
* Only read accounts from storage if the onchain mapping does not exist.
* Only return read accounts from storage if the account has NOT been deployed onchain.

It's possible that the original key has been revoked onchain, and we don't want to return it as a response. Example scenario we want to avoid here.

1. `AccA` is deployed with `key1` and `key2`.
2. `AccA` revokes `key1`.
3. `wallet_getAccounts(key1)` would return empty onchain but would return `AccA { key2 }` from storage.

Revamped the test 
