### PR TITLE
feat: metric for coingecko fetcher updates

### DIFF
--- a/src/price/fetchers/coingecko.rs
+++ b/src/price/fetchers/coingecko.rs
@@ -5,12 +5,13 @@ use crate::{
 };
 use alloy::primitives::{Address, ChainId};
 use alloy_chains::Chain;
+use metrics::counter;
 use reqwest::get;
 use std::{
     collections::HashMap,
     str::FromStr,
     sync::Arc,
-    time::{Duration, Instant},
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 use tokio::{sync::mpsc, time::interval};
 use tracing::{error, trace, warn};
@@ -160,6 +161,9 @@ impl CoinGecko {
                         price,
                     ))
                 });
+
+                counter!("coingecko.last_update")
+                    .absolute(SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs());
 
                 let _ = self.update_tx.send(PriceOracleMessage::Update {
                     fetcher: PriceFetcher::CoinGecko,


### PR DESCRIPTION
Based on #308 
Closes https://github.com/ithacaxyz/relay/issues/302

Adds a simple metric that records timestamp of last coingecko price update. We can fire alerts if this metric is not updated for a while 