### PR TITLE
fix: dont fail when init call is not authorize call

### DIFF
--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -269,7 +269,7 @@ impl Relay {
                         if let Some(account) =
                             self.inner.storage.read_prep(&request.address).await?
                         {
-                            return account.prep.authorized_keys().map_err(RelayError::AbiError);
+                            return Ok(account.prep.authorized_keys());
                         }
                     }
                 }

--- a/src/types/account.rs
+++ b/src/types/account.rs
@@ -362,16 +362,13 @@ impl PREPAccount {
     }
 
     /// Return the list of authorized keys as [`AuthorizeKeyResponse`].
-    pub fn authorized_keys(&self) -> Result<Vec<AuthorizeKeyResponse>, alloy::sol_types::Error> {
-        // `wallet_prepareCreateAccount` and `wallet_createAccount` ensure that we only have
-        // authorize calls on admin keys oatn PREPAccount init calls. So, we can safely
-        // decode all of them as authorizeCalls
+    pub fn authorized_keys(&self) -> Vec<AuthorizeKeyResponse> {
         self.init_calls
             .iter()
             .filter(|call| call.to == Address::ZERO)
-            .map(|call| {
-                let authorize = authorizeCall::abi_decode(&call.data, false)?;
-                Ok(AuthorizeKeyResponse {
+            .filter_map(|call| {
+                let authorize = authorizeCall::abi_decode(&call.data, false).ok()?;
+                Some(AuthorizeKeyResponse {
                     hash: authorize.key.key_hash(),
                     authorize_key: AuthorizeKey {
                         key: authorize.key,


### PR DESCRIPTION
It is entirely possible to add permissions in `wallet_prepareCreateAccount`, thus making this decoding fail. Since this is now used in `wallet_prepareCalls`, this can block arbitrary execution