### PR TITLE
fix: pass user `user_op_signer` to `prep_account`

### DIFF
--- a/tests/e2e/cases/id.rs
+++ b/tests/e2e/cases/id.rs
@@ -17,7 +17,7 @@ async fn register_and_unregister_id() -> eyre::Result<()> {
 
     let admin_key = KeyWith712Signer::random_admin(KeyType::WebAuthnP256)?.unwrap();
     let backup_key = KeyWith712Signer::random_admin(KeyType::WebAuthnP256)?.unwrap();
-    prep_account(&mut env, &[], &[&admin_key, &backup_key], &[], 0).await?;
+    prep_account(&mut env, &[], &admin_key, &[&admin_key, &backup_key], &[], 0).await?;
 
     if let EoaKind::Prep(ref account) = env.eoa {
         let account = account.clone().unwrap();

--- a/tests/e2e/types.rs
+++ b/tests/e2e/types.rs
@@ -140,8 +140,18 @@ impl TxContext<'_> {
         env: &mut Environment,
         tx_num: usize,
     ) -> Result<(), eyre::Error> {
-        let tx_hash =
-            prep_account(env, &self.calls, &self.authorization_keys, &self.pre_ops, tx_num).await;
+        // If a signer is not defined, takes the first authorized key from the tx context.
+        let op_signer = self.key.as_ref().unwrap_or(&self.authorization_keys[0]);
+
+        let tx_hash = prep_account(
+            env,
+            &self.calls,
+            op_signer,
+            &self.authorization_keys,
+            &self.pre_ops,
+            tx_num,
+        )
+        .await;
 
         // Check test expectations
         let op_nonce = U256::ZERO; // first transaction


### PR DESCRIPTION
Before preops, we were using the first authorized key in the prep account to sign the user op.

However, with preops this may no longer be the case. So we need to define the actual user op signer.

Added a negative test that would wrongly pass without this change.