### PR TITLE
feat: add `RelaySettings` to `health` endpoint

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -48,7 +48,8 @@ pub struct ChainConfig {
 }
 
 /// Quote configuration.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct QuoteConfig {
     /// Sets a constant rate for the price oracle. Used for testing.
     pub constant_rate: Option<f64>,
@@ -63,7 +64,7 @@ pub struct QuoteConfig {
 }
 
 /// Gas estimate configuration.
-#[derive(Debug, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct GasConfig {
     /// Extra buffer added to UserOp gas estimates.
     pub user_op_buffer: u64,

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -11,8 +11,9 @@
 use crate::{
     eip712::compute_eip712_data,
     types::{
-        AccountRegistry::AccountRegistryCalls, Call, Key, KeyHash, KeyHashWithID,
-        rpc::CreateAccountContext,
+        AccountRegistry::AccountRegistryCalls,
+        Call, Key, KeyHash, KeyHashWithID,
+        rpc::{CreateAccountContext, RelaySettings},
     },
     version::RELAY_SHORT_VERSION,
 };
@@ -61,7 +62,7 @@ use crate::{
 pub trait RelayApi {
     /// Checks the health of the relay and returns its version.
     #[method(name = "health", aliases = ["health"])]
-    async fn health(&self) -> RpcResult<String>;
+    async fn health(&self) -> RpcResult<RelaySettings>;
 
     /// Get all supported fee tokens by chain.
     #[method(name = "feeTokens", aliases = ["wallet_feeTokens"])]
@@ -362,8 +363,12 @@ impl Relay {
 
 #[async_trait]
 impl RelayApiServer for Relay {
-    async fn health(&self) -> RpcResult<String> {
-        Ok(RELAY_SHORT_VERSION.to_string())
+    async fn health(&self) -> RpcResult<RelaySettings> {
+        Ok(RelaySettings {
+            version: RELAY_SHORT_VERSION.to_string(),
+            entrypoint: self.inner.entrypoint,
+            quote_config: self.inner.quote_config.clone(),
+        })
     }
 
     async fn fee_tokens(&self) -> RpcResult<FeeTokens> {

--- a/src/types/rpc/mod.rs
+++ b/src/types/rpc/mod.rs
@@ -12,6 +12,9 @@ pub use keys::*;
 mod permission;
 pub use permission::*;
 
+mod settings;
+pub use settings::*;
+
 use alloy::primitives::{Address, B256, U256};
 use serde::{Deserialize, Serialize};
 

--- a/src/types/rpc/settings.rs
+++ b/src/types/rpc/settings.rs
@@ -1,0 +1,15 @@
+use crate::config::QuoteConfig;
+use alloy::primitives::Address;
+use serde::{Deserialize, Serialize};
+
+/// The Relay settings.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RelaySettings {
+    /// Relay version.
+    pub version: String,
+    /// The entrypoint address.
+    pub entrypoint: Address,
+    /// Quote related configuration.
+    pub quote_config: QuoteConfig,
+}


### PR DESCRIPTION
this way porto can cross check with the relay defined entrypoint address