### PR TITLE
feat: stress testing script

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,10 @@ edition = "2024"
 path = "src/bin/relay.rs"
 name = "relay"
 
+[[bin]]
+path = "src/bin/stress.rs"
+name = "stress"
+
 [dependencies]
 alloy = { version = "0.13", features = [
     "getrandom",

--- a/src/bin/stress.rs
+++ b/src/bin/stress.rs
@@ -1,0 +1,287 @@
+//! Relay stress testing tool.
+
+use alloy::{
+    network::EthereumWallet,
+    primitives::{Address, ChainId, U256, bytes},
+    providers::{
+        DynProvider, PendingTransactionBuilder, Provider, ProviderBuilder,
+        fillers::{CachedNonceManager, ChainIdFiller, GasFiller, NonceFiller},
+    },
+};
+use clap::Parser;
+use eyre::Context;
+use futures_util::{StreamExt, stream::FuturesUnordered};
+use jsonrpsee::http_client::{HttpClient, HttpClientBuilder};
+use relay::{
+    rpc::RelayApiClient,
+    signers::{DynSigner, Eip712PayLoadSigner},
+    types::{
+        Call,
+        IERC20::IERC20Instance,
+        KeyType, KeyWith712Signer,
+        rpc::{
+            CreateAccountParameters, KeySignature, Meta, PrepareCallsCapabilities,
+            PrepareCallsParameters, PrepareCallsResponse, PrepareCreateAccountCapabilities,
+            PrepareCreateAccountParameters, PrepareCreateAccountResponse,
+        },
+    },
+};
+use tokio::{sync::Semaphore, time::Instant};
+use tracing::{error, info, level_filters::LevelFilter};
+use tracing_subscriber::{EnvFilter, fmt, layer::SubscriberExt, util::SubscriberInitExt};
+use url::Url;
+
+#[derive(Debug)]
+struct StressAccount {
+    address: Address,
+    key: KeyWith712Signer,
+}
+
+impl StressAccount {
+    fn new(address: Address, key: KeyWith712Signer) -> Self {
+        Self { address, key }
+    }
+}
+
+impl StressAccount {
+    async fn run(
+        self,
+        chain_id: ChainId,
+        fee_token: Address,
+        relay_client: HttpClient,
+        provider: DynProvider,
+    ) -> eyre::Result<()> {
+        loop {
+            let prepare_start = Instant::now();
+            let PrepareCallsResponse { context, digest, .. } = relay_client
+                .prepare_calls(PrepareCallsParameters {
+                    calls: vec![Call { to: Address::ZERO, value: U256::ZERO, data: bytes!("") }],
+                    chain_id,
+                    from: self.address,
+                    capabilities: PrepareCallsCapabilities {
+                        authorize_keys: vec![],
+                        meta: Meta { fee_token, key_hash: self.key.key_hash(), nonce: None },
+                        revoke_keys: vec![],
+                        pre_ops: vec![],
+                        pre_op: false,
+                    },
+                })
+                .await
+                .expect("prepare calls failed");
+            let signature =
+                self.key.sign_payload_hash(digest).await.expect("failed to sign bundle digest");
+
+            info!(
+                %digest,
+                account = %self.address,
+                total_elapsed = ?prepare_start.elapsed(),
+                elapsed = ?prepare_start.elapsed(),
+                "Prepared bundle"
+            );
+            let send_start = Instant::now();
+            let bundle_id = relay_client
+                .send_prepared_calls(relay::types::rpc::SendPreparedCallsParameters {
+                    context,
+                    signature: KeySignature {
+                        public_key: self.key.publicKey.clone(),
+                        key_type: self.key.keyType,
+                        value: signature,
+                        prehash: false,
+                    },
+                })
+                .await
+                .expect("send prepared calls failed");
+            info!(
+                %digest,
+                account = %self.address,
+                bundle_id = %bundle_id.id,
+                total_elapsed = ?prepare_start.elapsed(),
+                elapsed = ?send_start.elapsed(),
+                "Sent bundle"
+            );
+            let receipt = PendingTransactionBuilder::new(provider.root().clone(), bundle_id.id)
+                .get_receipt()
+                .await
+                .expect("Failed to get receipt");
+            info!(
+                %digest,
+                account = %self.address,
+                bundle_id = %bundle_id.id,
+                total_elapsed = ?prepare_start.elapsed(),
+                tx_hash = %receipt.transaction_hash,
+                "Bundle confirmed"
+            );
+        }
+    }
+}
+
+struct StressTester {
+    relay_client: HttpClient,
+    provider: DynProvider,
+    args: Args,
+    accounts: Vec<StressAccount>,
+}
+
+impl StressTester {
+    async fn new(args: Args) -> eyre::Result<Self> {
+        let relay_client = HttpClientBuilder::new().build(&args.relay_url)?;
+        let signer = DynSigner::load(&args.private_key, None).await?;
+        let provider = ProviderBuilder::new()
+            .disable_recommended_fillers()
+            .filler(NonceFiller::new(CachedNonceManager::default()))
+            .filler(GasFiller)
+            .filler(ChainIdFiller::new(Some(args.chain_id)))
+            .wallet(EthereumWallet::from(signer.0))
+            .on_http(args.rpc_url.clone())
+            .erased();
+
+        info!(
+            "Connected to relay at {}, version {}",
+            &args.relay_url,
+            relay_client.health().await?.version
+        );
+
+        let supports_fee_token =
+            relay_client.fee_tokens().await?.contains(args.chain_id, &args.fee_token);
+        if !supports_fee_token {
+            eyre::bail!("fee token {} is not supported on chain {}", args.fee_token, args.chain_id);
+        }
+
+        info!("Initializing {} accounts", args.accounts);
+        let sema = Semaphore::new(10);
+        let accounts = futures_util::future::try_join_all((0..args.accounts).map(|_| async {
+            let key = KeyWith712Signer::random_admin(KeyType::WebAuthnP256)?
+                .expect("failed to create key for account");
+            let PrepareCreateAccountResponse { capabilities: _, digests: _, context, address } =
+                relay_client
+                    .prepare_create_account(PrepareCreateAccountParameters {
+                        capabilities: PrepareCreateAccountCapabilities {
+                            authorize_keys: vec![key.to_authorized(None).await?],
+                            delegation: args.delegation,
+                        },
+                        chain_id: args.chain_id,
+                    })
+                    .await
+                    .wrap_err("failed to prepare create account")?;
+
+            relay_client
+                .create_account(CreateAccountParameters {
+                    context,
+                    signatures: vec![KeySignature {
+                        public_key: key.publicKey.clone(),
+                        key_type: key.keyType,
+                        value: key.id_sign(address).await?.as_bytes().into(),
+                        prehash: false,
+                    }],
+                })
+                .await
+                .wrap_err("failed to create account")?;
+            info!(account = %address, "Account initialized");
+
+            let permit = sema.acquire().await.wrap_err("semaphore closed")?;
+            info!(account = %address, "Funding account");
+            IERC20Instance::new(args.fee_token, &provider)
+                .transfer(address, args.fee_token_amount)
+                .send()
+                .await
+                .wrap_err("funding account failed")?
+                .get_receipt()
+                .await
+                .wrap_err("failed to get receipt for account funding")?;
+            info!(account = %address, "Account funded");
+            drop(permit);
+
+            Ok::<_, eyre::Error>(StressAccount::new(address, key))
+        }))
+        .await?;
+        info!("Initialized {} accounts", args.accounts);
+
+        Ok(Self { relay_client, provider, args, accounts })
+    }
+
+    async fn spawn(self) -> eyre::Result<()> {
+        let tester = self;
+        tokio::spawn(async move { tester.run().await }).await?
+    }
+
+    async fn run(self) -> eyre::Result<()> {
+        info!("Starting stress test");
+
+        // we use a semaphore to limit the number of concurrent funding transactions, since mempools
+        // have limits per account, and sending too many might cause txs to get
+        // dropped/rejected/stuck
+        let mut tasks = FuturesUnordered::new();
+        for account in self.accounts.into_iter() {
+            let client = self.relay_client.clone();
+            let provider = self.provider.clone();
+            tasks.push(tokio::spawn(async move {
+                account.run(self.args.chain_id, self.args.fee_token, client, provider).await
+            }));
+        }
+
+        while let Some(finished) = tasks.next().await {
+            match finished {
+                Ok(_) => info!("An account finished stress test"),
+                Err(err) => error!("an account failed stress test: {}", err),
+            }
+        }
+
+        info!("Stress test ended");
+        Ok(())
+    }
+}
+
+#[derive(Debug, Parser)]
+#[command(author, about = "Relay stress tester", long_about = None)]
+struct Args {
+    /// Relay URL to connect to.
+    #[arg(long = "relay-url", value_name = "RELAY_URL", required = true)]
+    relay_url: String,
+    /// RPC URL of the chain we are testing on.
+    #[arg(long = "rpc-url", value_name = "RPC_URL", required = true)]
+    rpc_url: Url,
+    /// Chain ID of the chain to test on.
+    #[arg(long = "chain-id", value_name = "CHAIN_ID", required = true)]
+    chain_id: ChainId,
+    /// Private key of the account to use for testing.
+    ///
+    /// This account should have sufficient fee tokens to cover the gas costs of the userops.
+    #[arg(long = "private-key", value_name = "PRIVATE_KEY", required = true, env = "PK")]
+    private_key: String,
+    /// Address of the fee token to use for testing.
+    #[arg(long = "fee-token", value_name = "ADDRESS", required = true)]
+    fee_token: Address,
+    /// Amount of fee tokens to fund each account with in wei.
+    #[arg(long = "fee-token-amount", value_name = "AMOUNT", default_value_t = U256::from(1000000000000000000u128))]
+    fee_token_amount: U256,
+    /// Number of accounts to create and test with.
+    #[arg(long = "accounts", value_name = "COUNT", default_value_t = 1000)]
+    accounts: usize,
+    /// Address of the delegation contract to use for testing.
+    #[arg(long = "delegation", value_name = "ADDRESS", required = true)]
+    delegation: Address,
+}
+
+impl Args {
+    async fn run(self) -> eyre::Result<()> {
+        let tester = StressTester::new(self).await?;
+
+        tester.spawn().await
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::registry()
+        .with(fmt::layer())
+        .with(
+            EnvFilter::builder().with_default_directive(LevelFilter::INFO.into()).from_env_lossy(),
+        )
+        .init();
+
+    let args = Args::parse();
+    if let Err(err) = args.run().await {
+        eprintln!("Error: {err:?}");
+        std::process::exit(1);
+    }
+}

--- a/src/types/erc20.rs
+++ b/src/types/erc20.rs
@@ -4,5 +4,6 @@ sol! {
     #[sol(rpc)]
     interface IERC20 {
         function decimals() external view returns (uint8);
+        function transfer(address to, uint256 amount) external returns (bool);
     }
 }


### PR DESCRIPTION
Adds a simple load testing script. Currently, the strategy is just to

1. Create n accounts
2. Fund the accounts
3. In a loop, the accounts will
   1. Prepare a bundle that just has a noop call
   2. Send the bundle
   3. Wait for tx inclusion

The script will run until all accounts have stopped working (i.e. crashed). We can later extend this with different strategies, if we want to/need to.

The script relies on a pre-funded account. This account must have enough eth to transfer to all the test accounts, and enough fee tokens to send to all test accounts.

Help output:

```
Relay stress tester

Usage: stress [OPTIONS] --relay-url <RELAY_URL> --rpc-url <RPC_URL> --chain-id <CHAIN_ID> --private-key <PRIVATE_KEY> --fee-token <ADDRESS> --delegation <ADDRESS>

Options:
      --relay-url <RELAY_URL>
          Relay URL to connect to

      --rpc-url <RPC_URL>
          RPC URL of the chain we are testing on

      --chain-id <CHAIN_ID>
          Chain ID of the chain to test on

      --private-key <PRIVATE_KEY>
          Private key of the account to use for testing.
                                                                                                                  This account should have sufficient fee tokens to cover the gas costs of the userops.

          [env: PK=]

      --fee-token <ADDRESS>
          Address of the fee token to use for testing

      --fee-token-amount <AMOUNT>
          Amount of fee tokens to fund each account with in wei

          [default: 1000000000000000000]

      --accounts <COUNT>
          Number of accounts to create and test with

          [default: 1000]

      --delegation <ADDRESS>
          Address of the delegation contract to use for testing

  -h, --help
          Print help (see a summary with '-h')
```

Example that runs against the staging relay with 100 accounts:

```
cargo r --bin stress -- --relay-url https://relay-staging.ithaca.xyz --private-key <snip> --chain-id 911867 --fee-token 0x706Aa5C8e5cC2c67Da21ee220718f6f6B154E75c --delegation 0x63e0B807c3E872152645103462BD403D4e48fE7e --rpc-url https://odyssey.ithaca.xyz --accounts 100
```

The reason I eagerly initialize the test accounts, as opposed to lazily doing so, is that I don't think it makes sense to fund the account in-line as we are stress testing, as it will just reduce load. This obviously has the caveat that it is not really stressing `wallet_prepareCreateAccount` and `wallet_createAccount`, but I think this is fine, as they are unlikely to be bottlenecks, unless the database is having issues. The database is stressed more during normal operations however, as sending a transaction also possibly incurs at least 2 inserts and one update.

Closes #315 