### PR TITLE
feat: estimate fee by setting `userOp.paymentAmount` to 1

### DIFF
--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -402,6 +402,7 @@ impl RelayApiServer for Relay {
             .append(
                 request.op.eoa,
                 AccountOverride::default()
+                    .with_balance(U256::MAX.div_ceil(2.try_into().unwrap()))
                     .with_state_diff(account_key.storage_slots())
                     // we manually etch the 7702 designator since we do not have a signed auth item
                     .with_code_opt(authorization_address.map(|addr| {
@@ -427,6 +428,10 @@ impl RelayApiServer for Relay {
             executionData: request.op.execution_data.clone(),
             nonce,
             paymentToken: token.address,
+            // this will force the simulation to go through payment code paths, and get a better
+            // estimation.
+            paymentAmount: U256::from(1),
+            paymentMaxAmount: U256::from(1),
             // we intentionally do not use the maximum amount of gas since the contracts add a small
             // overhead when checking if there is sufficient gas for the op
             combinedGas: U256::from(100_000_000),

--- a/tests/e2e/cases/transactions.rs
+++ b/tests/e2e/cases/transactions.rs
@@ -50,6 +50,9 @@ impl MockAccount {
             .await
             .unwrap();
 
+        // Using ETH for payments
+        env.provider.anvil_set_balance(address, U256::from(100e18)).await?;
+
         let signature = key.id_sign(address).await.unwrap();
 
         env.relay_endpoint
@@ -79,7 +82,7 @@ impl MockAccount {
                 from: address,
                 capabilities: PrepareCallsCapabilities {
                     authorize_keys: vec![],
-                    meta: Meta { fee_token: env.erc20, key_hash: key.key_hash(), nonce: None },
+                    meta: Meta { fee_token: Address::ZERO, key_hash: key.key_hash(), nonce: None },
                     pre_ops: vec![],
                     pre_op: false,
                     revoke_keys: vec![],
@@ -113,7 +116,11 @@ impl MockAccount {
                 from: self.address,
                 capabilities: PrepareCallsCapabilities {
                     authorize_keys: vec![],
-                    meta: Meta { fee_token: env.erc20, key_hash: self.key.key_hash(), nonce: None },
+                    meta: Meta {
+                        fee_token: Address::ZERO,
+                        key_hash: self.key.key_hash(),
+                        nonce: None,
+                    },
                     pre_ops: vec![],
                     pre_op: false,
                     revoke_keys: vec![],

--- a/tests/e2e/environment.rs
+++ b/tests/e2e/environment.rs
@@ -211,7 +211,7 @@ impl Environment {
                 .with_quote_constant_rate(1.0)
                 .with_fee_tokens(&[erc20s.as_slice(), &[Address::ZERO]].concat())
                 .with_entrypoint(entrypoint)
-                .with_user_op_gas_buffer(100_000) // todo: temp
+                .with_user_op_gas_buffer(40_000) // todo: temp
                 .with_tx_gas_buffer(50_000) // todo: temp
                 .with_database_url(std::env::var("DATABASE_URL").ok()),
             registry,


### PR DESCRIPTION
Most tests were able to pass with 10k user op gas buffer. 

The `session_key_pre_op` required 40k so that's all we can decrease to. I wouldn't change the staging relay just yet.

The caveat is that the user would need to have ERC20 if he wants to pay with it. It's not the case with ETH, because we can easily state override it (PR includes it). But overriding ERC20 is trickier.

The preops should be constructed with ETH as `paymentToken`
