### PR TITLE
feat: allow session keys in `initData`

### DIFF
--- a/src/error/keys.rs
+++ b/src/error/keys.rs
@@ -15,9 +15,6 @@ pub enum KeysError {
     /// Missing at least one admin authorization key.
     #[error("should have at least one admin authorization key")]
     MissingAdminKey,
-    /// Should only have admin authorization keys.
-    #[error("should only have admin authorization keys")]
-    OnlyAdminKeyAllowed,
     /// Unknown key hash.
     #[error("key hash {0} is unknown")]
     UnknownKeyHash(KeyHash),
@@ -50,7 +47,6 @@ impl From<KeysError> for jsonrpsee::types::error::ErrorObject<'static> {
             | KeysError::P256SessionKeyOnly
             | KeysError::MissingKeyID { .. }
             | KeysError::MissingAdminKey
-            | KeysError::OnlyAdminKeyAllowed
             | KeysError::TakenKeyId { .. }
             | KeysError::UnexpectedKeyId { .. }
             | KeysError::UnknownKeyHash { .. }

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -539,11 +539,6 @@ impl RelayApiServer for Relay {
             return Err(KeysError::MissingAdminKey)?;
         }
 
-        // Creating account should only have admin keys.
-        if request.capabilities.authorize_keys.iter().any(|key| !key.key.isSuperAdmin) {
-            return Err(KeysError::OnlyAdminKeyAllowed)?;
-        }
-
         // Generate all calls that will authorize keys and set their permissions
         let init_calls =
             self.authorize_into_calls(request.capabilities.authorize_keys.clone(), None)?;


### PR DESCRIPTION
pros:
* porto only needs to prompt for the passkey once during sign-up

cons:
* session key is bundled with the PREP `initData` (both authorize and permission calls). 