### PR TITLE
feat: `--max-connections`

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -70,6 +70,9 @@ pub struct Args {
     /// The database URL for the relay.
     #[arg(long = "database-url", value_name = "URL", env = "RELAY_DB_URL")]
     pub database_url: Option<String>,
+    /// The maximum number of concurrent connections the relay can handle.
+    #[arg(long = "max-connections", value_name = "NUM", default_value_t = 1000)]
+    pub max_connections: u32,
 }
 
 impl Args {
@@ -92,6 +95,7 @@ impl Args {
             .with_address(self.address)
             .with_port(self.port)
             .with_metrics_port(self.metrics_port)
+            .with_max_connections(self.max_connections)
             .with_quote_ttl(self.quote_ttl)
             .with_rate_ttl(self.rate_ttl)
             .with_entrypoint(self.entrypoint)
@@ -138,6 +142,7 @@ mod tests {
                     address: IpAddr::V4(Ipv4Addr::LOCALHOST),
                     port: get_available_port().unwrap(),
                     metrics_port: get_available_port().unwrap(),
+                    max_connections: Default::default(),
                     entrypoint: Default::default(),
                     endpoints: Default::default(),
                     quote_ttl: Default::default(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -36,6 +36,8 @@ pub struct ServerConfig {
     pub port: u16,
     /// The port to serve the metrics on.
     pub metrics_port: u16,
+    /// The maximum number of concurrent connections the relay can handle.
+    pub max_connections: u32,
 }
 
 /// Chain configuration.
@@ -100,6 +102,7 @@ impl Default for RelayConfig {
                 address: IpAddr::V4(Ipv4Addr::LOCALHOST),
                 port: 9119,
                 metrics_port: 9000,
+                max_connections: 1000,
             },
             chain: ChainConfig { endpoints: vec![], fee_tokens: vec![] },
             quote: QuoteConfig {
@@ -131,6 +134,12 @@ impl RelayConfig {
     /// Sets the port to serve the metrics on.
     pub fn with_metrics_port(mut self, port: u16) -> Self {
         self.server.metrics_port = port;
+        self
+    }
+
+    /// Sets the maximum number of concurrent connections the relay can handle.
+    pub fn with_max_connections(mut self, max_connections: u32) -> Self {
+        self.server.max_connections = max_connections;
         self
     }
 

--- a/src/spawn.rs
+++ b/src/spawn.rs
@@ -161,6 +161,7 @@ pub async fn try_spawn(config: RelayConfig, registry: CoinRegistry) -> eyre::Res
     // start server
     let server = Server::builder()
         .http_only()
+        .max_connections(config.server.max_connections)
         .set_http_middleware(
             ServiceBuilder::new()
                 .layer(cors)


### PR DESCRIPTION
Adds a `--max-connections` flag to set the maximum number of concurrent connections on the RPC serve. The default for `jsonrpsee` is 100. Default for us is 1k