### PR TITLE
fix: dont try to advance queue if no signer available

### DIFF
--- a/src/transactions/service.rs
+++ b/src/transactions/service.rs
@@ -274,6 +274,7 @@ impl TransactionService {
                 sent = true;
             } else {
                 self.queue.push_front(tx);
+                break;
             }
         }
 


### PR DESCRIPTION
Currently if we're at capacity, we try to advance the queue forever, and the signers are never polled - so no capacity is ever freed - causing a deadlock