### PR TITLE
chore: dont record aliases in metrics

### DIFF
--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -47,6 +47,7 @@ where
                 .as_error_code()
                 .is_none_or(|code| code != jsonrpsee::types::error::METHOD_NOT_FOUND_CODE)
             {
+                let method = method.replace("wallet_", "relay_");
                 counter!(
                     "rpc.call.count",
                     "method" => method.clone(),


### PR DESCRIPTION
Currently if someone hits e.g. `wallet_health` and `relay_health`, we end up with two separately labelled metrics. This just replaces `wallet_*` with `relay_*` so we have one set of metrics for each method