### PR TITLE
fix: correctly log otel init

### DIFF
--- a/src/bin/relay.rs
+++ b/src/bin/relay.rs
@@ -17,8 +17,6 @@ fn init_tracing_subscriber() -> Option<OtelGuard> {
     );
 
     if let Some(cfg) = OtelConfig::load() {
-        debug!(endpoint = %cfg.endpoint, "initializing opentelemetry");
-
         let guard = cfg.provider();
         registry.with(guard.layer()).init();
         Some(guard)
@@ -36,6 +34,9 @@ async fn main() {
     }
 
     let _guard = init_tracing_subscriber();
+    if _guard.is_some() {
+        debug!("opentelemetry initialized");
+    }
 
     let args = Args::parse();
     if let Err(err) = args.run().await {

--- a/src/transactions/metrics.rs
+++ b/src/transactions/metrics.rs
@@ -43,7 +43,7 @@ pub struct SignerMetrics {
     pub gas_spent: Gauge,
     /// Native spent on transactions.
     pub native_spent: Gauge,
-    /// SIgner nonce.
+    /// Signer nonce.
     pub nonce: Counter,
 }
 


### PR DESCRIPTION
This was erroneously logged before the tracing subscriber was initialized (so it never showed up in logs)

Also drive by on a typo