### PR TITLE
test: use pinned fork block number for tests

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -57,10 +57,12 @@ jobs:
       - uses: taiki-e/install-action@nextest
 
       - name: Set odyssey environment
+        # when updating deployed address, also update TEST_FORK_BLOCK_NUMBER_PINNED
         if: ${{ matrix.variant == 'odyssey_fork' }}
         run: |
           echo "TEST_CI_FORK=1" >> $GITHUB_ENV
           echo "TEST_FORK_URL=https://odyssey-devnet.ithaca.xyz" >> $GITHUB_ENV
+          echo "TEST_FORK_BLOCK_NUMBER_PINNED=239180" >> $GITHUB_ENV
           echo "TEST_ENTRYPOINT=0xcceed8216fe5b0a8438f5c4c8ce959e0823dec8d" >> $GITHUB_ENV
           echo "TEST_DELEGATION=0xe09d7f4fbd33c6fc734e07d69e40d23f995b43c9" >> $GITHUB_ENV
 

--- a/tests/e2e/cases/transactions.rs
+++ b/tests/e2e/cases/transactions.rs
@@ -33,7 +33,9 @@ use tokio::sync::mpsc;
 
 /// The pinned block number used for heavier fork tests.
 /// By pinning the number we can re-use the cached rpc read-only data via foundry.
-const FORK_TEST_BLOCK_NUMBER: i64 = 238246;
+fn pinned_test_fork_block_number() -> Option<i64> {
+    std::env::var("TEST_FORK_BLOCK_NUMBER_PINNED").ok().and_then(|s| s.parse().ok())
+}
 
 /// An account that can be used to send userops.
 struct MockAccount {
@@ -220,7 +222,7 @@ async fn test_basic_concurrent() -> eyre::Result<()> {
     let env = Environment::setup(EnvironmentConfig {
         is_prep: true,
         block_time: Some(1.0),
-        fork_block_number: Some(FORK_TEST_BLOCK_NUMBER),
+        fork_block_number: pinned_test_fork_block_number(),
         ..Default::default()
     })
     .await
@@ -432,7 +434,7 @@ async fn pause_out_of_funds() -> eyre::Result<()> {
             max_transactions_per_signer: 5,
             ..Default::default()
         },
-        fork_block_number: Some(FORK_TEST_BLOCK_NUMBER),
+        fork_block_number: pinned_test_fork_block_number(),
         ..Default::default()
     })
     .await
@@ -503,7 +505,7 @@ async fn resume_paused() -> eyre::Result<()> {
             max_transactions_per_signer: 5,
             ..Default::default()
         },
-        fork_block_number: Some(FORK_TEST_BLOCK_NUMBER),
+        fork_block_number: pinned_test_fork_block_number(),
         ..Default::default()
     })
     .await


### PR DESCRIPTION
towards #426

in theory this should speed up ci after this is merged

recent number obtained from https://odyssey-devnet.ithaca.xyz/