### PR TITLE
test: use determinsitic seed for large account tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4574,6 +4574,7 @@ version = "0.1.0"
 dependencies = [
  "alloy",
  "alloy-chains",
+ "alloy-primitives",
  "async-trait",
  "aws-config",
  "aws-sdk-kms",
@@ -4791,6 +4792,9 @@ name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+dependencies = [
+ "rand 0.8.5",
+]
 
 [[package]]
 name = "rustc-hex"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,6 +96,7 @@ sqlx = { version = "0.8.3", features = [
 
 [dev-dependencies]
 alloy = { version = "0.14", features = ["eips", "provider-anvil-node"], default-features = false }
+alloy-primitives = { version = "1.0.0", features = ["rand"] }
 derive_more = { version = "2", features = ["debug"] }
 dotenvy = "0.15"
 itertools = "0.14"

--- a/src/types/key.rs
+++ b/src/types/key.rs
@@ -298,7 +298,13 @@ impl KeyWith712Signer {
 
     /// Returns a random admin [`Self`] from a [`KeyType`].
     pub fn random_admin(key_type: KeyType) -> eyre::Result<Option<Self>> {
-        let mock_key = B256::random();
+        Self::mock_admin_with_key(key_type, B256::random())
+    }
+
+    /// Returns a admin [`Self`] from a [`KeyType`].
+    ///
+    /// This is intended for testing.
+    pub fn mock_admin_with_key(key_type: KeyType, mock_key: B256) -> eyre::Result<Option<Self>> {
         let expiry = U40::ZERO;
         let super_admin = true;
 


### PR DESCRIPTION
uses a determinsitic seed so that we get reproducible keys, this is beneficial for fork tests because then this should always use the cache.

once we have the cache, next step will be increasing concurrency, locally this reduced duration for the basic_concurrent test from >2mins to 18s