### PR TITLE
chore: detect otel resource attrs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3937,12 +3937,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "opentelemetry-semantic-conventions"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fb3a2f78c2d55362cd6c313b8abedfbc0142ab3c2676822068fd2ab7d51f9b7"
-
-[[package]]
 name = "opentelemetry-stdout"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4596,7 +4590,6 @@ dependencies = [
  "metrics-exporter-prometheus",
  "opentelemetry",
  "opentelemetry-otlp",
- "opentelemetry-semantic-conventions",
  "opentelemetry-stdout",
  "opentelemetry_sdk",
  "p256",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ alloy = { version = "0.14", features = [
     "transports",
     "network",
     "json-rpc",
-    "reqwest-rustls-tls"
+    "reqwest-rustls-tls",
 ], default-features = false }
 alloy-chains = "0.2"
 async-trait = "0.1"
@@ -54,9 +54,6 @@ metrics = "0.24.0"
 metrics-exporter-prometheus = "0.16"
 opentelemetry = { version = "0.28.0", features = ["trace"] }
 opentelemetry-otlp = { version = "0.28.0" }
-opentelemetry-semantic-conventions = { version = "0.28.0", features = [
-    "semconv_experimental",
-] }
 opentelemetry-stdout = { version = "0.28.0", features = ["trace"] }
 opentelemetry_sdk = { version = "0.28.0", default-features = false, features = [
     "trace",
@@ -95,7 +92,10 @@ sqlx = { version = "0.8.3", features = [
 ] }
 
 [dev-dependencies]
-alloy = { version = "0.14", features = ["eips", "provider-anvil-node"], default-features = false }
+alloy = { version = "0.14", features = [
+    "eips",
+    "provider-anvil-node",
+], default-features = false }
 alloy-primitives = { version = "1.0.0", features = ["rand"] }
 derive_more = { version = "2", features = ["debug"] }
 dotenvy = "0.15"

--- a/src/otlp.rs
+++ b/src/otlp.rs
@@ -2,12 +2,10 @@
 
 use std::str::FromStr;
 
-use opentelemetry::{KeyValue, trace::TracerProvider};
+use opentelemetry::trace::TracerProvider;
 use opentelemetry_otlp::WithExportConfig;
-use opentelemetry_sdk::{Resource, trace::SdkTracerProvider};
-use opentelemetry_semantic_conventions::{
-    SCHEMA_URL,
-    attribute::{SERVICE_NAME, SERVICE_VERSION},
+use opentelemetry_sdk::{
+    Resource, resource::SdkProvidedResourceDetector, trace::SdkTracerProvider,
 };
 use tracing::level_filters::LevelFilter;
 use tracing_subscriber::Layer;
@@ -66,15 +64,7 @@ impl OtelConfig {
     }
 
     fn resource(&self) -> Resource {
-        Resource::builder()
-            .with_schema_url(
-                [
-                    KeyValue::new(SERVICE_NAME, env!("CARGO_PKG_NAME")),
-                    KeyValue::new(SERVICE_VERSION, env!("CARGO_PKG_VERSION")),
-                ],
-                SCHEMA_URL,
-            )
-            .build()
+        Resource::builder().with_detector(Box::new(SdkProvidedResourceDetector)).build()
     }
 
     /// Creates an OpenTelemetry provider from this configuration.


### PR DESCRIPTION
Switches out hardcoded attributes for https://docs.rs/opentelemetry_sdk/latest/opentelemetry_sdk/resource/struct.SdkProvidedResourceDetector.html allowing us to set the attributes using environment variables - this allows us to distinguish between eg staging/prod.