### PR TITLE
feat: more otel attrs

### DIFF
--- a/src/metrics/transport.rs
+++ b/src/metrics/transport.rs
@@ -3,11 +3,18 @@ use alloy::{
     transports::{TransportError, TransportFut},
 };
 use futures_util::FutureExt;
+use opentelemetry::trace::SpanKind;
 use tower::{Layer, Service};
 use tracing::{Level, field, span};
 use tracing_futures::Instrument;
 
-/// A layer that adds additional span information to requests on a given transport.
+/// A layer that wraps requests in spans with OpenTelemetry attributes.
+///
+/// The OpenTelemetry attributes adhere to the OpenTelemtry conventions.
+///
+/// See:
+/// - <https://opentelemetry.io/docs/specs/semconv/rpc/json-rpc/>
+/// - <https://opentelemetry.io/docs/specs/semconv/rpc/rpc-spans/>
 #[derive(Debug, Clone)]
 pub struct TraceLayer;
 
@@ -44,13 +51,26 @@ where
     }
 
     fn call(&mut self, request: RequestPacket) -> Self::Future {
-        let span = span!(Level::INFO, "call", rpc.method = field::Empty);
+        let span = span!(
+            Level::INFO,
+            "call",
+            otel.kind = ?SpanKind::Client,
+            otel.name = field::Empty,
+            rpc.jsonrpc.version = "2.0",
+            rpc.system = "jsonrpc",
+            rpc.jsonrpc.request_id = field::Empty,
+            rpc.method = field::Empty
+        );
 
         // todo: what do we do with batches
         if let RequestPacket::Single(ref req) = request {
+            span.record("otel.name", format!("alloy.transport/{}", req.method()));
             span.record("rpc.method", req.method());
+            span.record("rpc.jsonrpc.request_id", req.id().to_string());
         }
 
+        // todo: set `rpc.jsonrpc.error_code` and span status. this requires helpers in alloy to get
+        // jsonrpc error codes from responses
         self.inner.call(request).instrument(span).boxed()
     }
 }

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -513,7 +513,6 @@ impl Relay {
 
 #[async_trait]
 impl RelayApiServer for Relay {
-    #[instrument(skip_all, parent = None)]
     async fn health(&self) -> RpcResult<RelaySettings> {
         Ok(RelaySettings {
             version: RELAY_SHORT_VERSION.to_string(),
@@ -522,12 +521,10 @@ impl RelayApiServer for Relay {
         })
     }
 
-    #[instrument(skip_all, parent = None)]
     async fn fee_tokens(&self) -> RpcResult<FeeTokens> {
         Ok(self.inner.fee_tokens.clone())
     }
 
-    #[instrument(skip_all, parent = None)]
     async fn prepare_create_account(
         &self,
         request: PrepareCreateAccountParameters,
@@ -565,7 +562,6 @@ impl RelayApiServer for Relay {
         })
     }
 
-    #[instrument(skip_all, parent = None)]
     async fn create_account(
         &self,
         request: CreateAccountParameters,
@@ -596,7 +592,6 @@ impl RelayApiServer for Relay {
         Ok(keys)
     }
 
-    #[instrument(skip_all, parent = None)]
     async fn get_accounts(
         &self,
         request: GetAccountsParameters,
@@ -647,12 +642,10 @@ impl RelayApiServer for Relay {
         .await
     }
 
-    #[instrument(skip_all, parent = None)]
     async fn get_keys(&self, request: GetKeysParameters) -> RpcResult<Vec<AuthorizeKeyResponse>> {
         Ok(self.get_keys(request).await?)
     }
 
-    #[instrument(skip_all, parent = None)]
     async fn prepare_calls(
         &self,
         request: PrepareCallsParameters,
@@ -765,7 +758,6 @@ impl RelayApiServer for Relay {
         Ok(response)
     }
 
-    #[instrument(skip_all, parent = None)]
     async fn prepare_upgrade_account(
         &self,
         request: PrepareUpgradeAccountParameters,
@@ -838,7 +830,6 @@ impl RelayApiServer for Relay {
         Ok(response)
     }
 
-    #[instrument(skip_all, parent = None)]
     async fn send_prepared_calls(
         &self,
         mut request: SendPreparedCallsParameters,
@@ -883,7 +874,6 @@ impl RelayApiServer for Relay {
         Ok(response)
     }
 
-    #[instrument(skip_all, parent = None)]
     async fn upgrade_account(
         &self,
         mut request: UpgradeAccountParameters,
@@ -918,7 +908,6 @@ impl RelayApiServer for Relay {
         Ok(response)
     }
 
-    #[instrument(skip_all, parent = None)]
     async fn get_calls_status(&self, id: BundleId) -> RpcResult<CallsStatus> {
         let tx_ids = self.inner.storage.get_bundle_transactions(id).await?;
         let tx_statuses =


### PR DESCRIPTION
Adds more otel span attributes like span kind and json-rpc specific attributes. This also renames the spans (by setting `otel.name`) which makes traces easier to reason about at a glance. There's still some improvements we can make here, some are noted in a todo, but another one we can do is attach spans in the signer tasks to their originating spans, see https://opentelemetry.io/docs/specs/semconv/rpc/json-rpc/