### PR TITLE
fix: flatten `CallReceipt` status

### DIFF
--- a/src/types/rpc/calls.rs
+++ b/src/types/rpc/calls.rs
@@ -146,6 +146,7 @@ pub struct CallReceipt {
     /// The logs generated in the transaction.
     pub logs: Vec<Log>,
     /// The status of the transaction.
+    #[serde(flatten)]
     pub status: Eip658Value,
     /// The block hash the transaction was included in.
     pub block_hash: Option<BlockHash>,


### PR DESCRIPTION
Currently the serialized representation of `CallReceipt` return status as:

```json
{
  "status": {
    "status": "0x1"
  }
}
```

This flattens it instead, so it matches `TransactionReceipt` more closely. Note that this is technically breaking