### PR TITLE
feat: add `delegation` address to `health` endpoint

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -21,8 +21,8 @@ pub struct RelayConfig {
     pub quote: QuoteConfig,
     /// Transaction service configuration.
     pub transactions: TransactionServiceConfig,
-    /// Entrypoint address.
-    pub entrypoint: Address,
+    /// Entrypoint and delegation supported contract addresses.
+    pub contracts: Vec<EntryWithDelegation>,
     /// Secrets.
     #[serde(skip_serializing, default)]
     pub secrets: SecretsConfig,
@@ -126,6 +126,15 @@ impl Default for TransactionServiceConfig {
     }
 }
 
+/// Entrypoint and delegation contract addresses.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EntryWithDelegation {
+    /// Entrypoint address.
+    pub entrypoint: Address,
+    /// Delegation address.
+    pub delegation: Address,
+}
+
 impl Default for RelayConfig {
     fn default() -> Self {
         Self {
@@ -147,7 +156,7 @@ impl Default for RelayConfig {
                 rate_ttl: Duration::from_secs(300),
             },
             transactions: TransactionServiceConfig::default(),
-            entrypoint: Address::ZERO,
+            contracts: Default::default(),
             secrets: SecretsConfig::default(),
             database_url: None,
         }
@@ -246,8 +255,8 @@ impl RelayConfig {
     }
 
     /// Sets the entrypoint address.
-    pub fn with_entrypoint(mut self, entrypoint: Address) -> Self {
-        self.entrypoint = entrypoint;
+    pub fn with_contracts(mut self, contracts: Vec<EntryWithDelegation>) -> Self {
+        self.contracts = contracts;
         self
     }
 

--- a/src/serde/contracts.rs
+++ b/src/serde/contracts.rs
@@ -1,0 +1,18 @@
+//! Helpers for serialization and deserialization of entrypoint and delegation address pairs.
+
+use crate::config::EntryWithDelegation;
+use alloy::primitives::Address;
+use eyre::WrapErr;
+use std::str::FromStr;
+
+/// Parse a string in the format "0xENTRYPOINT,0xDELEGATION" into an [`EntryWithDelegation`].
+pub fn parse_entrypoint_with_delegation(s: &str) -> eyre::Result<EntryWithDelegation> {
+    let parts: Vec<&str> = s.split(',').collect();
+    if parts.len() != 2 {
+        return Err(eyre::eyre!("Expected format ENTRYPOINT,DELEGATION"));
+    }
+    let entrypoint = Address::from_str(parts[0]).wrap_err("Entrypoint address parse failed.")?;
+    let delegation = Address::from_str(parts[1]).wrap_err("Delegation address parse failed.")?;
+
+    Ok(EntryWithDelegation { entrypoint, delegation })
+}

--- a/src/serde/mod.rs
+++ b/src/serde/mod.rs
@@ -1,5 +1,6 @@
 //! Serde helpers.
 
+pub mod contracts;
 pub mod duration;
 pub mod fn_selector;
 pub mod key_role;

--- a/src/types/account.rs
+++ b/src/types/account.rs
@@ -25,6 +25,9 @@ sol! {
     #[sol(rpc)]
     #[derive(Debug)]
     contract Delegation {
+        /// The entry point address.
+        address public immutable ENTRY_POINT;
+
         /// A spend period.
         #[derive(Eq, PartialEq, Serialize, Deserialize)]
         #[serde(rename_all = "lowercase")]

--- a/src/types/rpc/settings.rs
+++ b/src/types/rpc/settings.rs
@@ -1,4 +1,4 @@
-use crate::config::QuoteConfig;
+use crate::config::{EntryWithDelegation, QuoteConfig};
 use alloy::primitives::Address;
 use serde::{Deserialize, Serialize};
 
@@ -8,8 +8,8 @@ use serde::{Deserialize, Serialize};
 pub struct RelaySettings {
     /// Relay version.
     pub version: String,
-    /// The entrypoint address.
-    pub entrypoint: Address,
+    /// The entrypoint and delegation supported addresses.
+    pub contracts: Vec<EntryWithDelegation>,
     /// The fee recipient address.
     pub fee_recipient: Address,
     /// Quote related configuration.

--- a/tests/e2e/environment.rs
+++ b/tests/e2e/environment.rs
@@ -17,7 +17,7 @@ use eyre::{self, ContextCompat, WrapErr};
 use futures_util::future::join_all;
 use jsonrpsee::http_client::{HttpClient, HttpClientBuilder};
 use relay::{
-    config::{RelayConfig, TransactionServiceConfig},
+    config::{EntryWithDelegation, RelayConfig, TransactionServiceConfig},
     signers::DynSigner,
     spawn::{RETRY_LAYER, RelayHandle, try_spawn},
     types::{
@@ -248,7 +248,7 @@ impl Environment {
                 )
                 .with_quote_constant_rate(1.0)
                 .with_fee_tokens(&[erc20s.as_slice(), &[Address::ZERO]].concat())
-                .with_entrypoint(entrypoint)
+                .with_contracts(vec![EntryWithDelegation { entrypoint, delegation }])
                 .with_user_op_gas_buffer(40_000) // todo: temp
                 .with_tx_gas_buffer(50_000) // todo: temp
                 .with_transaction_service_config(config.transaction_service_config)


### PR DESCRIPTION
Similarly to the `entrypoint`, Porto can get the latest/supported delegation that the relay expects.

Would need changes to infra as well