### PR TITLE
feat: fee recipient

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -46,6 +46,12 @@ pub struct Args {
     /// Must be a valid HTTP or HTTPS URL pointing to an Ethereum JSON-RPC endpoint.
     #[arg(long = "endpoint", value_name = "RPC_ENDPOINT", required = true)]
     pub endpoints: Vec<Url>,
+    /// The fee recipient address.
+    ///
+    /// Defaults to the zero address, which means the fees will be accrued by the entrypoint
+    /// contract.
+    #[arg(long = "fee-recipient", value_name = "ADDRESS", default_value_t = Address::ZERO)]
+    pub fee_recipient: Address,
     /// The lifetime of a fee quote.
     #[arg(long, value_name = "SECONDS", value_parser = parse_duration_secs, default_value = "5")]
     pub quote_ttl: Duration,
@@ -92,6 +98,7 @@ impl Args {
             .with_transaction_keys(&self.secret_keys)
             .with_endpoints(&self.endpoints)
             .with_fee_tokens(&self.fee_tokens)
+            .with_fee_recipient(self.fee_recipient)
             .with_address(self.address)
             .with_port(self.port)
             .with_metrics_port(self.metrics_port)
@@ -145,6 +152,7 @@ mod tests {
                     max_connections: Default::default(),
                     entrypoint: Default::default(),
                     endpoints: Default::default(),
+                    fee_recipient: Default::default(),
                     quote_ttl: Default::default(),
                     rate_ttl: Default::default(),
                     quote_secret_key: key.to_string(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -50,6 +50,11 @@ pub struct ChainConfig {
     pub endpoints: Vec<Url>,
     /// A fee token the relay accepts.
     pub fee_tokens: Vec<Address>,
+    /// The fee recipient address.
+    ///
+    /// Defaults to `Address::ZERO`, which means the fees will be accrued by the entrypoint
+    /// contract.
+    pub fee_recipient: Address,
 }
 
 /// Quote configuration.
@@ -130,7 +135,11 @@ impl Default for RelayConfig {
                 metrics_port: 9000,
                 max_connections: 1000,
             },
-            chain: ChainConfig { endpoints: vec![], fee_tokens: vec![] },
+            chain: ChainConfig {
+                endpoints: vec![],
+                fee_tokens: vec![],
+                fee_recipient: Address::ZERO,
+            },
             quote: QuoteConfig {
                 constant_rate: None,
                 gas: GasConfig { user_op_buffer: USER_OP_GAS_BUFFER, tx_buffer: TX_GAS_BUFFER },
@@ -209,6 +218,12 @@ impl RelayConfig {
     /// Extends the list of RPC endpoints (as URLs) for the chain transactions.
     pub fn with_endpoints(mut self, endpoints: &[Url]) -> Self {
         self.chain.endpoints.extend_from_slice(endpoints);
+        self
+    }
+
+    /// Sets the fee recipient address.
+    pub fn with_fee_recipient(mut self, fee_recipient: Address) -> Self {
+        self.chain.fee_recipient = fee_recipient;
         self
     }
 

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -155,6 +155,7 @@ impl Relay {
         quote_config: QuoteConfig,
         price_oracle: PriceOracle,
         fee_tokens: FeeTokens,
+        fee_recipient: Address,
         storage: RelayStorage,
         asset_info: AssetInfoServiceHandle,
     ) -> Self {
@@ -162,6 +163,7 @@ impl Relay {
             entrypoint,
             chains,
             fee_tokens,
+            fee_recipient,
             quote_signer,
             quote_config,
             price_oracle,
@@ -241,6 +243,7 @@ impl Relay {
             executionData: request.op.execution_data.clone(),
             nonce,
             paymentToken: token.address,
+            paymentRecipient: self.inner.fee_recipient,
             // we intentionally do not use the maximum amount of gas since the contracts add a small
             // overhead when checking if there is sufficient gas for the op
             combinedGas: U256::from(100_000_000),
@@ -522,6 +525,7 @@ impl RelayApiServer for Relay {
         Ok(RelaySettings {
             version: RELAY_SHORT_VERSION.to_string(),
             entrypoint: self.inner.entrypoint,
+            fee_recipient: self.inner.fee_recipient,
             quote_config: self.inner.quote_config.clone(),
         })
     }
@@ -1011,6 +1015,8 @@ struct RelayInner {
     chains: Chains,
     /// Supported fee tokens.
     fee_tokens: FeeTokens,
+    /// The fee recipient address.
+    fee_recipient: Address,
     /// The signer used to sign quotes.
     quote_signer: DynSigner,
     /// Quote related configuration.

--- a/src/spawn.rs
+++ b/src/spawn.rs
@@ -157,6 +157,7 @@ pub async fn try_spawn(config: RelayConfig, registry: CoinRegistry) -> eyre::Res
         config.quote,
         price_oracle,
         FeeTokens::new(&registry, &config.chain.fee_tokens, providers).await?,
+        config.chain.fee_recipient,
         storage.clone(),
         asset_info_handle,
     )

--- a/src/types/rpc/settings.rs
+++ b/src/types/rpc/settings.rs
@@ -10,6 +10,8 @@ pub struct RelaySettings {
     pub version: String,
     /// The entrypoint address.
     pub entrypoint: Address,
+    /// The fee recipient address.
+    pub fee_recipient: Address,
     /// Quote related configuration.
     pub quote_config: QuoteConfig,
 }


### PR DESCRIPTION
Adds a `--fee-recipient` and related config to `relay.toml` to configure `paymentRecipient` in `UserOp`s.

The default is that it will be accrued by the entrypoint. This address is also exposed in `relay_health`.

Closes #457 