### PR TITLE
fix: remove `TEST_CI_FORK`

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -62,7 +62,6 @@ jobs:
         # when updating deployed address, also update TEST_FORK_BLOCK_NUMBER_PINNED
         if: ${{ matrix.variant == 'odyssey_fork' }}
         run: |
-          echo "TEST_CI_FORK=1" >> $GITHUB_ENV
           echo "TEST_FORK_URL=https://odyssey-devnet.ithaca.xyz" >> $GITHUB_ENV
           echo "TEST_FORK_BLOCK_NUMBER_PINNED=591698" >> $GITHUB_ENV
           echo "TEST_ENTRYPOINT=0x1692bc8d0c73a7540ecb572e85c0775e68c55d25" >> $GITHUB_ENV

--- a/tests/e2e/cases/prep.rs
+++ b/tests/e2e/cases/prep.rs
@@ -156,12 +156,6 @@ pub async fn prep_account<'a>(
 
 #[tokio::test(flavor = "multi_thread")]
 async fn basic_prep() -> eyre::Result<()> {
-    if std::env::var("TEST_CI_FORK").is_ok() {
-        // Test WILL run on a local envirnonment but it will be skipped in the odyssey_fork CI run.
-        eprintln!("Test skipped until the new contracts are deployed.");
-        return Ok(());
-    }
-
     let mut env = Environment::setup_with_prep().await?;
     let to = env.erc20;
     let eoa_authorized = KeyWith712Signer::random_admin(KeyType::Secp256k1)?.unwrap();

--- a/tests/e2e/config.rs
+++ b/tests/e2e/config.rs
@@ -23,12 +23,6 @@ impl TestConfig {
         // Apply native or ERC20 payment method
         env = self.payment.apply(env);
 
-        // Once contracts are deployed, this should go away
-        if env.eoa.is_prep() && std::env::var("TEST_CI_FORK").is_ok() {
-            eprintln!("Skipping configuration: {:?} with {:?}", self.account, self.payment);
-            return Ok(());
-        }
-
         // Generate transactions from test case
         let txs = build_txs(&env);
 


### PR DESCRIPTION
sigh, there are tests that dont go through here, so any PREP issues were still being caught by the CI, but still bad