### PR TITLE
feat: add delegation proxy to health checkpoint

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -41,6 +41,9 @@ pub struct Args {
     /// The address of the entrypoint.
     #[arg(long = "entrypoint", value_name = "ENTRYPOINT")]
     pub entrypoint: Address,
+    /// The address of the delegation proxy.
+    #[arg(long = "delegation-proxy", value_name = "DELEGATION")]
+    pub delegation_proxy: Address,
     /// The RPC endpoint of a chain to send transactions to.
     ///
     /// Must be a valid HTTP or HTTPS URL pointing to an Ethereum JSON-RPC endpoint.
@@ -106,6 +109,7 @@ impl Args {
             .with_quote_ttl(self.quote_ttl)
             .with_rate_ttl(self.rate_ttl)
             .with_entrypoint(self.entrypoint)
+            .with_delegation_proxy(self.delegation_proxy)
             .with_user_op_gas_buffer(self.user_op_gas_buffer)
             .with_tx_gas_buffer(self.tx_gas_buffer)
             .with_database_url(self.database_url)
@@ -151,6 +155,7 @@ mod tests {
                     metrics_port: get_available_port().unwrap(),
                     max_connections: Default::default(),
                     entrypoint: Default::default(),
+                    delegation_proxy: Default::default(),
                     endpoints: Default::default(),
                     fee_recipient: Default::default(),
                     quote_ttl: Default::default(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -23,6 +23,8 @@ pub struct RelayConfig {
     pub transactions: TransactionServiceConfig,
     /// Entrypoint address.
     pub entrypoint: Address,
+    /// Delegation proxy address.
+    pub delegation_proxy: Address,
     /// Secrets.
     #[serde(skip_serializing, default)]
     pub secrets: SecretsConfig,
@@ -148,6 +150,7 @@ impl Default for RelayConfig {
             },
             transactions: TransactionServiceConfig::default(),
             entrypoint: Address::ZERO,
+            delegation_proxy: Address::ZERO,
             secrets: SecretsConfig::default(),
             database_url: None,
         }
@@ -248,6 +251,12 @@ impl RelayConfig {
     /// Sets the entrypoint address.
     pub fn with_entrypoint(mut self, entrypoint: Address) -> Self {
         self.entrypoint = entrypoint;
+        self
+    }
+
+    /// Sets the delegation address.
+    pub fn with_delegation_proxy(mut self, delegation_proxy: Address) -> Self {
+        self.delegation_proxy = delegation_proxy;
         self
     }
 

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -150,6 +150,7 @@ impl Relay {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         entrypoint: Address,
+        delegation_proxy: Address,
         chains: Chains,
         quote_signer: DynSigner,
         quote_config: QuoteConfig,
@@ -161,6 +162,7 @@ impl Relay {
     ) -> Self {
         let inner = RelayInner {
             entrypoint,
+            delegation_proxy,
             chains,
             fee_tokens,
             fee_recipient,
@@ -526,6 +528,7 @@ impl RelayApiServer for Relay {
             version: RELAY_SHORT_VERSION.to_string(),
             entrypoint: self.inner.entrypoint,
             fee_recipient: self.inner.fee_recipient,
+            delegation_proxy: self.inner.delegation_proxy,
             quote_config: self.inner.quote_config.clone(),
         })
     }
@@ -1011,6 +1014,8 @@ impl RelayApiServer for Relay {
 struct RelayInner {
     /// The entrypoint address.
     entrypoint: Address,
+    /// The delegation proxy address.
+    delegation_proxy: Address,
     /// The chains supported by the relay.
     chains: Chains,
     /// Supported fee tokens.

--- a/src/spawn.rs
+++ b/src/spawn.rs
@@ -152,6 +152,7 @@ pub async fn try_spawn(config: RelayConfig, registry: CoinRegistry) -> eyre::Res
     // todo: avoid all this darn cloning
     let rpc = Relay::new(
         config.entrypoint,
+        config.delegation_proxy,
         chains.clone(),
         quote_signer,
         config.quote,

--- a/src/types/rpc/settings.rs
+++ b/src/types/rpc/settings.rs
@@ -12,6 +12,8 @@ pub struct RelaySettings {
     pub entrypoint: Address,
     /// The fee recipient address.
     pub fee_recipient: Address,
+    /// The delegation proxy address.
+    pub delegation_proxy: Address,
     /// Quote related configuration.
     pub quote_config: QuoteConfig,
 }


### PR DESCRIPTION
just to unblock so it can be bumped to prod

Lets do the thing below in another iteration
> https://github.com/ithacaxyz/relay/issues/456 ... likely these need to come in pairs if we want to add delegation address as well

not just pairs, it needs to check over the entrypoint, delegation_proxy and delegation

