### PR TITLE
feat: attach signer service spans to rpc span

### DIFF
--- a/src/serde/mod.rs
+++ b/src/serde/mod.rs
@@ -4,3 +4,4 @@ pub mod duration;
 pub mod fn_selector;
 pub mod key_role;
 pub mod timestamp;
+pub mod trace_context;

--- a/src/serde/trace_context.rs
+++ b/src/serde/trace_context.rs
@@ -1,0 +1,26 @@
+//! Helpers for serializing and deserializing [`Context`].
+
+use opentelemetry::{Context, global};
+use serde::{self, Deserialize, Deserializer, Serialize, Serializer};
+use std::collections::HashMap;
+
+/// Serializes [`Context`] as a `HashMap<String, String>`.
+pub fn serialize<S>(ctx: &Context, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let mut carrier = HashMap::new();
+    global::get_text_map_propagator(|propagator| {
+        propagator.inject_context(ctx, &mut carrier);
+    });
+    carrier.serialize(serializer)
+}
+
+/// Deserializes a `HashMap<String, String>` into a [`Context`].
+pub fn deserialize<'de, D>(deserializer: D) -> Result<Context, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let carrier = HashMap::<String, String>::deserialize(deserializer)?;
+    Ok(global::get_text_map_propagator(|propagator| propagator.extract(&carrier)))
+}

--- a/src/transactions/transaction.rs
+++ b/src/transactions/transaction.rs
@@ -6,6 +6,7 @@ use alloy::{
     sol_types::{SolCall, SolValue},
 };
 use chrono::{DateTime, Utc};
+use opentelemetry::Context;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
@@ -30,6 +31,9 @@ pub struct RelayTransaction {
     pub entrypoint: Address,
     /// EIP-7702 [`SignedAuthorization`] to attach, if any.
     pub authorization: Option<SignedAuthorization>,
+    /// Trace context for the transaction.
+    #[serde(with = "crate::serde::trace_context")]
+    pub trace_context: Context,
 }
 
 impl RelayTransaction {
@@ -39,7 +43,13 @@ impl RelayTransaction {
         entrypoint: Address,
         authorization: Option<SignedAuthorization>,
     ) -> Self {
-        Self { id: TxId(quote.ty().digest()), quote, entrypoint, authorization }
+        Self {
+            id: TxId(quote.ty().digest()),
+            quote,
+            entrypoint,
+            authorization,
+            trace_context: Context::current(),
+        }
     }
 
     /// Builds a [`TypedTransaction`] for this quote given a nonce.


### PR DESCRIPTION
Links spans processing a tx to the span of the RPC call that created the tx. This creates a link you can use to navigate between spans in Grafana.

Ref https://opentelemetry.io/docs/specs/semconv/messaging/messaging-spans/ for attributes

Closes #458 