### PR TITLE
feat: handle `AccountRegistry` contract

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -63,9 +63,10 @@ jobs:
         if: ${{ matrix.variant == 'odyssey_fork' }}
         run: |
           echo "TEST_FORK_URL=https://odyssey-devnet.ithaca.xyz" >> $GITHUB_ENV
-          echo "TEST_FORK_BLOCK_NUMBER_PINNED=620240" >> $GITHUB_ENV
+          echo "TEST_FORK_BLOCK_NUMBER_PINNED=673681" >> $GITHUB_ENV
           echo "TEST_ENTRYPOINT=0x1aabbc3023dcd83e049e65cdc13f1a72e8a04ddb" >> $GITHUB_ENV
           echo "TEST_DELEGATION=0x1b183b70b499563effe71152c724aeda5249dd77" >> $GITHUB_ENV
+          echo "TEST_ACCOUNT_REGISTRY=0x4c648b1c3ddc2b858e3a98137219743e3ea19b50" >> $GITHUB_ENV
 
       - name: Set database URL
         if: ${{ matrix.variant == 'pg' }}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -44,6 +44,9 @@ pub struct Args {
     /// The address of the delegation proxy.
     #[arg(long = "delegation-proxy", value_name = "DELEGATION")]
     pub delegation_proxy: Address,
+    /// The address of the account registry.
+    #[arg(long = "account-registry", value_name = "ACCOUNT_REGISTRY")]
+    pub account_registry: Address,
     /// The RPC endpoint of a chain to send transactions to.
     ///
     /// Must be a valid HTTP or HTTPS URL pointing to an Ethereum JSON-RPC endpoint.
@@ -110,6 +113,7 @@ impl Args {
             .with_rate_ttl(self.rate_ttl)
             .with_entrypoint(self.entrypoint)
             .with_delegation_proxy(self.delegation_proxy)
+            .with_account_registry(self.account_registry)
             .with_user_op_gas_buffer(self.user_op_gas_buffer)
             .with_tx_gas_buffer(self.tx_gas_buffer)
             .with_database_url(self.database_url)
@@ -156,6 +160,7 @@ mod tests {
                     max_connections: Default::default(),
                     entrypoint: Default::default(),
                     delegation_proxy: Default::default(),
+                    account_registry: Default::default(),
                     endpoints: Default::default(),
                     fee_recipient: Default::default(),
                     quote_ttl: Default::default(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -25,6 +25,8 @@ pub struct RelayConfig {
     pub entrypoint: Address,
     /// Delegation proxy address.
     pub delegation_proxy: Address,
+    /// Account registry address.
+    pub account_registry: Address,
     /// Secrets.
     #[serde(skip_serializing, default)]
     pub secrets: SecretsConfig,
@@ -151,6 +153,7 @@ impl Default for RelayConfig {
             transactions: TransactionServiceConfig::default(),
             entrypoint: Address::ZERO,
             delegation_proxy: Address::ZERO,
+            account_registry: Address::ZERO,
             secrets: SecretsConfig::default(),
             database_url: None,
         }
@@ -257,6 +260,12 @@ impl RelayConfig {
     /// Sets the delegation address.
     pub fn with_delegation_proxy(mut self, delegation_proxy: Address) -> Self {
         self.delegation_proxy = delegation_proxy;
+        self
+    }
+
+    /// Sets the account registry address.
+    pub fn with_account_registry(mut self, account_registry: Address) -> Self {
+        self.account_registry = account_registry;
         self
     }
 

--- a/src/spawn.rs
+++ b/src/spawn.rs
@@ -153,6 +153,7 @@ pub async fn try_spawn(config: RelayConfig, registry: CoinRegistry) -> eyre::Res
     let rpc = Relay::new(
         config.entrypoint,
         config.delegation_proxy,
+        config.account_registry,
         chains.clone(),
         quote_signer,
         config.quote,

--- a/src/types/account_registry.rs
+++ b/src/types/account_registry.rs
@@ -37,10 +37,10 @@ impl AccountRegistry::AccountRegistryCalls {
     /// it's returned as `None`.
     pub async fn id_infos(
         ids: Vec<Address>,
-        entrypoint: Address,
+        account_registry: Address,
         provider: DynProvider,
     ) -> Result<Vec<Option<(KeyHash, Vec<Address>)>>, RelayError> {
-        AccountRegistry::AccountRegistryInstance::new(entrypoint, provider)
+        AccountRegistry::AccountRegistryInstance::new(account_registry, provider)
             .idInfos(ids.clone())
             .call()
             .await
@@ -62,10 +62,10 @@ impl AccountRegistry::AccountRegistryCalls {
     /// Returns all acounts of the requested [`KeyID`].
     pub async fn accounts(
         id: KeyID,
-        entrypoint: Address,
+        account_registry: Address,
         provider: DynProvider,
     ) -> Result<Option<Vec<Address>>, RelayError> {
-        Ok(Self::id_infos(vec![id], entrypoint, provider)
+        Ok(Self::id_infos(vec![id], account_registry, provider)
             .await?
             .pop()
             .expect("should exist")

--- a/src/types/call.rs
+++ b/src/types/call.rs
@@ -83,13 +83,13 @@ impl Call {
 
     /// Create a call to register an account.
     pub fn register_account(
-        registry: Address,
+        account_registry: Address,
         signature: Bytes,
         data: Bytes,
         account: Address,
     ) -> Self {
         Self {
-            to: registry,
+            to: account_registry,
             value: U256::ZERO,
             data: AccountRegistry::registerCall { signature, data, account }.abi_encode().into(),
         }

--- a/src/types/key.rs
+++ b/src/types/key.rs
@@ -429,10 +429,10 @@ pub struct KeyHashWithID {
 }
 
 impl KeyHashWithID {
-    /// Converts self to [`Call`] given a registry and PREP account address.
-    pub fn to_call(&self, registry: Address, account: Address) -> Call {
+    /// Converts self to [`Call`] given a account registry and PREP account address.
+    pub fn to_call(&self, account_registry: Address, account: Address) -> Call {
         Call::register_account(
-            registry,
+            account_registry,
             self.signature.as_bytes().into(),
             self.hash.into(),
             account,

--- a/src/types/rpc/keys.rs
+++ b/src/types/rpc/keys.rs
@@ -48,7 +48,7 @@ impl AuthorizeKey {
     /// registry.
     pub fn into_calls(
         mut self,
-        registry: Address,
+        account_registry: Address,
         account: Option<Address>,
     ) -> Result<(Call, Vec<Call>), KeysError> {
         let mut calls = Vec::new();
@@ -75,7 +75,7 @@ impl AuthorizeKey {
                 };
 
                 calls.push(Call::register_account(
-                    registry,
+                    account_registry,
                     id_signature,
                     self.key.key_hash().into(),
                     account,
@@ -310,16 +310,16 @@ mod tests {
     #[test]
     fn test_revoke_key_into_calls() {
         let key_id = KeyID::random();
-        let entrypoint = Address::random();
+        let registry = Address::random();
         let hash = B256::random();
 
         let revoke = RevokeKey { hash, id: None };
-        assert_eq!(revoke.into_calls(entrypoint), vec![Call::revoke(hash)]);
+        assert_eq!(revoke.into_calls(registry), vec![Call::revoke(hash)]);
 
         let revoke = RevokeKey { hash, id: Some(key_id) };
         assert_eq!(
-            revoke.into_calls(entrypoint),
-            vec![Call::unregister_account(entrypoint, key_id), Call::revoke(hash)]
+            revoke.into_calls(registry),
+            vec![Call::unregister_account(registry, key_id), Call::revoke(hash)]
         );
     }
 }

--- a/src/types/rpc/settings.rs
+++ b/src/types/rpc/settings.rs
@@ -14,6 +14,8 @@ pub struct RelaySettings {
     pub fee_recipient: Address,
     /// The delegation proxy address.
     pub delegation_proxy: Address,
+    /// The account registry address.
+    pub account_registry: Address,
     /// Quote related configuration.
     pub quote_config: QuoteConfig,
 }

--- a/tests/e2e/cases/id.rs
+++ b/tests/e2e/cases/id.rs
@@ -31,12 +31,14 @@ async fn register_and_unregister_id() -> eyre::Result<()> {
     )
     .await?;
 
+    let account_registry = env.relay_endpoint.health().await?.account_registry;
+
     if let EoaKind::Prep(ref account) = env.eoa {
         let account = account.clone().unwrap();
 
         let (key_hash, addresses) = AccountRegistryCalls::id_infos(
             vec![admin_key.id()],
-            env.entrypoint,
+            account_registry,
             env.provider.clone(),
         )
         .await?
@@ -83,7 +85,7 @@ async fn register_and_unregister_id() -> eyre::Result<()> {
         assert!(
             AccountRegistryCalls::id_infos(
                 vec![admin_key.id()],
-                env.entrypoint,
+                account_registry,
                 env.provider.clone()
             )
             .await?
@@ -96,7 +98,7 @@ async fn register_and_unregister_id() -> eyre::Result<()> {
         assert!(
             AccountRegistryCalls::id_infos(
                 vec![backup_key.id()],
-                env.entrypoint,
+                account_registry,
                 env.provider.clone()
             )
             .await?

--- a/tests/e2e/cases/porto.rs
+++ b/tests/e2e/cases/porto.rs
@@ -504,7 +504,6 @@ async fn session_key_pre_op() -> Result<()> {
                     authorization_keys: vec![&session_key],
                     calls: vec![
                         calls::daily_limit(env.fee_token, U256::from(1e18), session_key.key()),
-                        calls::can_execute_all(env.entrypoint, session_key.key_hash()),
                         calls::can_execute_all(env.erc20, session_key.key_hash()),
                         calls::daily_limit(env.erc20, U256::from(10000000u64), session_key.key()),
                     ],

--- a/tests/e2e/cases/simple.rs
+++ b/tests/e2e/cases/simple.rs
@@ -234,7 +234,6 @@ async fn spend_limits_bundle_failure() -> Result<()> {
             pre_ops: vec![TxContext {
                 authorization_keys: vec![&session_key],
                 calls: vec![
-                    calls::can_execute_all(env.entrypoint, session_key.key_hash()),
                     calls::can_execute_all(env.erc20, session_key.key_hash()),
                     calls::daily_limit(env.erc20, U256::from(15), session_key.key()),
                 ],


### PR DESCRIPTION
closes https://github.com/ithacaxyz/relay/issues/491 

* adds `account_registry` to cli, config and settings
* adds `TEST_ACCOUNT_REGISTRY` to test environment
* on `prepareCalls` 
  * if it's a Preop of the first PREP userop.
    * set `AccountRegistry::register` permission to every authorized session_key.
  * if it's the first PREP userop
    * adds the `AccountRegistry::register` call