### PR TITLE
fix: remove never ending span

### DIFF
--- a/src/transactions/signer.rs
+++ b/src/transactions/signer.rs
@@ -822,6 +822,7 @@ impl SignerTask {
 impl Future for SignerTask {
     type Output = ();
 
+    #[instrument(name = "signer", skip_all, fields(address = ?self.signer.address(), chain_id = self.signer.chain_id()))]
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let instant = Instant::now();
 


### PR DESCRIPTION
This trace never ends, and so it ultimately looks like a span that is as long as the runtime of the relay, which is no bueno.

@klkvr is there a specific thing you wanted to trace?