### PR TITLE
perf: lower poll interval

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,8 +1,13 @@
 //! Relay constants.
 
+use std::time::Duration;
+
 /// Extra buffer added to UserOp gas estimates to cover execution overhead
 /// and ensure sufficient gas is provided.
 pub const USER_OP_GAS_BUFFER: u64 = 25_000;
+
+/// The default poll interval used by the relay clients.
+pub const DEFAULT_POLL_INTERVAL: Duration = Duration::from_millis(300);
 
 /// Extra buffer added to transaction gas estimates to pass the contract 63/64 check.
 pub const TX_GAS_BUFFER: u64 = 1_000_000; // todo: temporarily bumped to 1m from 50k to unblock

--- a/src/spawn.rs
+++ b/src/spawn.rs
@@ -4,6 +4,7 @@ use crate::{
     chains::Chains,
     cli::Args,
     config::RelayConfig,
+    constants::DEFAULT_POLL_INTERVAL,
     metrics::{self, RpcMetricsService, TraceLayer},
     price::{PriceFetcher, PriceOracle, PriceOracleConfig},
     rpc::{Relay, RelayApiServer},
@@ -118,6 +119,7 @@ pub async fn try_spawn(config: RelayConfig, registry: CoinRegistry) -> eyre::Res
                 .layer(RETRY_LAYER.clone())
                 .connect(url.as_str())
                 .await
+                .map(|client| client.with_poll_interval(DEFAULT_POLL_INTERVAL))
                 .map(|client| ProviderBuilder::new().on_client(client).erased())
         }),
     )


### PR DESCRIPTION
introduces a const and sets the poll intervall to 300ms for clients

HTTP clients will operate on this to
* (re)fetch receipt
* find the new head

if we run with HTTP providers this should be fairly low but will result in more request load which is fine, 300ms for 2s blocktime seems reasonable