### PR TITLE
chore: bump default max connections

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,7 +1,7 @@
 //! # Relay CLI
 use crate::{
     config::RelayConfig,
-    constants::{TX_GAS_BUFFER, USER_OP_GAS_BUFFER},
+    constants::{DEFAULT_RPC_DEFAULT_MAX_CONNECTIONS, TX_GAS_BUFFER, USER_OP_GAS_BUFFER},
     spawn::try_spawn_with_args,
 };
 use alloy::primitives::Address;
@@ -12,7 +12,6 @@ use std::{
     time::Duration,
 };
 use url::Url;
-use crate::constants::DEFAULT_RPC_DEFAULT_MAX_CONNECTIONS;
 
 /// The Ithaca relayer service sponsors transactions for EIP-7702 accounts.
 #[derive(Debug, Parser)]

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -10,7 +10,7 @@ pub const USER_OP_GAS_BUFFER: u64 = 25_000;
 pub const DEFAULT_POLL_INTERVAL: Duration = Duration::from_millis(300);
 
 /// Default number of incoming RPC connections.
-pub const DEFAULT_RPC_DEFAULT_MAX_CONNECTIONS: u32 = 5000;
+pub const DEFAULT_RPC_DEFAULT_MAX_CONNECTIONS: u32 = 5_000;
 
 /// Extra buffer added to transaction gas estimates to pass the contract 63/64 check.
 pub const TX_GAS_BUFFER: u64 = 1_000_000; // todo: temporarily bumped to 1m from 50k to unblock


### PR DESCRIPTION
increases the number of allows connections to 5k

we have some requests that can be open for some time (waiting for receipt), so we should bump this default a bit

ref https://github.com/ithacaxyz/infrastructure/issues/223