### PR TITLE
feat: fetch delegation impl from proxy

### DIFF
--- a/src/chains.rs
+++ b/src/chains.rs
@@ -62,10 +62,9 @@ impl Chains {
         self.chains.get(&chain_id).cloned()
     }
 
-    /// Get the first provider in the collection.
-    // NOTE: TEMPORARY PLEASE DELETE THIS AFTER https://github.com/ithacaxyz/relay/pull/331
-    pub fn first(&self) -> Option<(&ChainId, &Chain)> {
-        self.chains.iter().next()
+    /// Get an iterator over the supported chain IDs.
+    pub fn chain_ids_iter(&self) -> impl Iterator<Item = &ChainId> {
+        self.chains.keys()
     }
 }
 

--- a/src/types/account.rs
+++ b/src/types/account.rs
@@ -132,6 +132,9 @@ sol! {
 
         /// The entrypoint address.
         address public ENTRY_POINT;
+
+        /// The implementation address.
+        address public implementation;
     }
 }
 

--- a/src/types/rpc/settings.rs
+++ b/src/types/rpc/settings.rs
@@ -14,6 +14,10 @@ pub struct RelaySettings {
     pub fee_recipient: Address,
     /// The delegation proxy address.
     pub delegation_proxy: Address,
+    /// The delegation implementation address.
+    ///
+    /// This is directly fetched from the proxy.
+    pub delegation_implementation: Address,
     /// The account registry address.
     pub account_registry: Address,
     /// Quote related configuration.

--- a/tests/e2e/environment.rs
+++ b/tests/e2e/environment.rs
@@ -256,6 +256,7 @@ impl Environment {
                 .with_quote_constant_rate(1.0)
                 .with_fee_tokens(&[erc20s.as_slice(), &[Address::ZERO]].concat())
                 .with_entrypoint(entrypoint)
+                .with_delegation_proxy(delegation)
                 .with_account_registry(account_registry)
                 .with_user_op_gas_buffer(40_000) // todo: temp
                 .with_tx_gas_buffer(50_000) // todo: temp
@@ -430,10 +431,17 @@ async fn get_or_deploy_contracts<P: Provider + WalletProvider>(
     )
     .await?;
 
-    let mut delegation = deploy_contract(
+    let delegation = deploy_contract(
         &provider,
         &contracts_path.join("Delegation.sol/Delegation.json"),
         Some(entrypoint.abi_encode().into()),
+    )
+    .await?;
+
+    let mut delegation_proxy = deploy_contract(
+        &provider,
+        &contracts_path.join("EIP7702Proxy.sol/EIP7702Proxy.json"),
+        Some((delegation, Address::ZERO).abi_encode().into()),
     )
     .await?;
 
@@ -451,7 +459,8 @@ async fn get_or_deploy_contracts<P: Provider + WalletProvider>(
 
     // Delegation
     if let Ok(address) = std::env::var("TEST_DELEGATION") {
-        delegation = Address::from_str(&address).wrap_err("Delegation address parse failed.")?
+        delegation_proxy =
+            Address::from_str(&address).wrap_err("Delegation address parse failed.")?
     }
 
     // Account Registry
@@ -484,7 +493,7 @@ async fn get_or_deploy_contracts<P: Provider + WalletProvider>(
 
         erc20s.push(erc20)
     }
-    Ok((delegation, entrypoint, account_registry, erc20s))
+    Ok((delegation_proxy, entrypoint, account_registry, erc20s))
 }
 
 async fn deploy_contract<P: Provider>(


### PR DESCRIPTION
Adds the delegation implementation address to the health endpoint. This fetches the implementation from the proxy, which both serves as an actual health check, and also ensures that we never misconfigure it. We just fetch from the first available chain, since they should be the same across all chains (for now at least)