### PR TITLE
fix: include `kind` in `Token`

### DIFF
--- a/src/types/token.rs
+++ b/src/types/token.rs
@@ -17,7 +17,6 @@ pub struct Token {
     /// Token symbol as defined in the contract.
     pub symbol: String,
     /// Coin kind.
-    #[serde(skip_serializing)]
     pub kind: CoinKind,
     /// Rate of 1 whole token against the native chain token, expressed in the native token's
     /// smallest indivisible unit.


### PR DESCRIPTION
We depend on being able to deserialize the response of `relay_feeTokens` in the stress test script. Currently this is not possible because `kind` is not serialized.