### PR TITLE
fix: ensure that transaction always reaches database

### DIFF
--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -421,7 +421,7 @@ impl Relay {
         let bundle_id = BundleId(*tx.id);
         self.inner.storage.add_bundle_tx(bundle_id, chain_id, tx.id).await?;
 
-        span!(
+        let span = span!(
             Level::INFO, "send tx",
             otel.kind = ?SpanKind::Producer,
             messaging.system = "pg",
@@ -429,8 +429,9 @@ impl Relay {
             messaging.operation.name = "send",
             messaging.operation.type = "send",
             messaging.message.id = %tx.id
-        )
-        .in_scope(|| transactions.send_transaction(tx));
+        );
+        let _enter = span.enter();
+        transactions.send_transaction(tx).await?;
 
         Ok(bundle_id)
     }


### PR DESCRIPTION
First part of solution for https://github.com/ithacaxyz/relay/pull/527#issuecomment-2822446329

Right now if service is restarted while queued transactions are being written to database, those transactions will get lost and never confirmed.

With this PR `send_transaction` will only send transaction to service after it was persisted.

