### PR TITLE
fix: persist transactions before sending

### DIFF
--- a/src/storage/api.rs
+++ b/src/storage/api.rs
@@ -27,8 +27,8 @@ pub trait StorageApi: Debug + Send + Sync {
     /// Reads all account addresses associated with a ID.
     async fn read_accounts_from_id(&self, id: &KeyID) -> Result<Vec<Address>>;
 
-    /// Writes a pending transaction to storage.
-    async fn write_pending_transaction(&self, tx: &PendingTransaction) -> Result<()>;
+    /// Replaces previously queued transaction with a pending transaction.
+    async fn replace_queued_tx_with_pending(&self, tx: &PendingTransaction) -> Result<()>;
 
     /// Pushes a new [`TxEnvelope`] to [`PendingTransaction::sent`].
     async fn add_pending_envelope(&self, tx_id: TxId, envelope: &TxEnvelope) -> Result<()>;
@@ -63,7 +63,4 @@ pub trait StorageApi: Debug + Send + Sync {
 
     /// Reads queued transactions for the given chain.
     async fn read_queued_transactions(&self, chain_id: u64) -> Result<Vec<RelayTransaction>>;
-
-    /// Removes a transaction from the queue. No-op if transaction is not in the queue.
-    async fn remove_from_queue(&self, tx: &RelayTransaction) -> Result<()>;
 }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -50,8 +50,8 @@ impl StorageApi for RelayStorage {
         self.inner.read_accounts_from_id(id).await
     }
 
-    async fn write_pending_transaction(&self, tx: &PendingTransaction) -> api::Result<()> {
-        self.inner.write_pending_transaction(tx).await
+    async fn replace_queued_tx_with_pending(&self, tx: &PendingTransaction) -> api::Result<()> {
+        self.inner.replace_queued_tx_with_pending(tx).await
     }
 
     async fn add_pending_envelope(&self, tx_id: TxId, envelope: &TxEnvelope) -> api::Result<()> {
@@ -104,9 +104,5 @@ impl StorageApi for RelayStorage {
 
     async fn read_queued_transactions(&self, chain_id: u64) -> api::Result<Vec<RelayTransaction>> {
         self.inner.read_queued_transactions(chain_id).await
-    }
-
-    async fn remove_from_queue(&self, tx: &RelayTransaction) -> api::Result<()> {
-        self.inner.remove_from_queue(tx).await
     }
 }

--- a/src/storage/pg.rs
+++ b/src/storage/pg.rs
@@ -94,7 +94,14 @@ impl StorageApi for PgStorage {
     }
 
     #[instrument(skip_all)]
-    async fn write_pending_transaction(&self, tx: &PendingTransaction) -> Result<()> {
+    async fn replace_queued_tx_with_pending(&self, tx: &PendingTransaction) -> Result<()> {
+        let mut db_tx = self.pool.begin().await.map_err(eyre::Error::from)?;
+
+        sqlx::query!("delete from queued_txs where tx_id = $1", tx.tx.id.as_slice())
+            .execute(&mut *db_tx)
+            .await
+            .map_err(eyre::Error::from)?;
+
         sqlx::query!(
             "insert into pending_txs (chain_id, sender, tx_id, tx, envelopes, received_at) values ($1, $2, $3, $4, $5, $6)",
             tx.chain_id() as i64, // yikes!
@@ -104,9 +111,11 @@ impl StorageApi for PgStorage {
             serde_json::to_value(&tx.sent)?,
             tx.received_at.naive_utc(),
         )
-        .execute(&self.pool)
+        .execute(&mut *db_tx)
         .await
         .map_err(eyre::Error::from)?;
+
+        db_tx.commit().await.map_err(eyre::Error::from)?;
 
         Ok(())
     }
@@ -304,15 +313,5 @@ impl StorageApi for PgStorage {
             .into_iter()
             .map(|row| serde_json::from_value(row.tx))
             .collect::<std::result::Result<_, _>>()?)
-    }
-
-    #[instrument(skip(self))]
-    async fn remove_from_queue(&self, tx: &RelayTransaction) -> Result<()> {
-        sqlx::query!("delete from queued_txs where tx_id = $1", tx.id.as_slice())
-            .execute(&self.pool)
-            .await
-            .map_err(eyre::Error::from)?;
-
-        Ok(())
     }
 }

--- a/src/transactions/signer.rs
+++ b/src/transactions/signer.rs
@@ -317,35 +317,37 @@ impl Signer {
         Ok(())
     }
 
+    /// Signs a given transaction.
+    #[instrument(skip_all)]
+    async fn sign_transaction(&self, tx: TypedTransaction) -> Result<TxEnvelope, SignerError> {
+        Ok(NetworkWallet::<Ethereum>::sign_transaction_from(&self.wallet, self.address(), tx)
+            .await?)
+    }
+
     /// Broadcasts a given transaction.
     #[instrument(skip_all)]
-    async fn send_transaction(&self, tx: TypedTransaction) -> Result<TxEnvelope, SignerError> {
-        // Sign the transaction.
-        let signed =
-            NetworkWallet::<Ethereum>::sign_transaction_from(&self.wallet, self.address(), tx)
-                .await?;
-
+    async fn send_transaction(&self, tx: &TxEnvelope) -> Result<(), SignerError> {
         let _ = self
             .provider
-            .send_raw_transaction(&signed.encoded_2718())
+            .send_raw_transaction(&tx.encoded_2718())
             .await
             .inspect(|_| {
                 trace!(
-                    tx_hash = %signed.hash(),
-                    nonce = %signed.nonce(),
+                    tx_hash = %tx.hash(),
+                    nonce = %tx.nonce(),
                     "Sent transaction"
                 );
             })
             .inspect_err(|err| {
                 error!(
-                    tx_hash = %signed.hash(),
-                    nonce = %signed.nonce(),
+                    tx_hash = %tx.hash(),
+                    nonce = %tx.nonce(),
                     err = %err,
                     "Failed to send transaction"
                 );
             })?;
 
-        Ok(signed)
+        Ok(())
     }
 
     /// Waits for a pending transaction to be confirmed.
@@ -397,9 +399,10 @@ impl Signer {
             if let Some(new_tx) =
                 fees.prepare_replacement(best_tx, tx.tx.max_fee_for_transaction())?
             {
-                let replacement = self.send_transaction(new_tx).await?;
-                self.metrics.replacements_sent.increment(1);
+                let replacement = self.sign_transaction(new_tx).await?;
                 self.storage.add_pending_envelope(tx.id(), &replacement).await?;
+                self.send_transaction(&replacement).await?;
+                self.metrics.replacements_sent.increment(1);
                 self.update_tx_status(tx.id(), TransactionStatus::Pending(*replacement.tx_hash()))
                     .await?;
                 tx.sent.push(replacement);
@@ -464,9 +467,6 @@ impl Signer {
         &self,
         mut tx: RelayTransaction,
     ) -> Result<(), SignerError> {
-        // Make sure the transaction is no longer in the queue as we've started processing it.
-        self.storage.remove_from_queue(&tx).await?;
-
         // Fetch the fees for the first transaction.
         let fees =
             self.get_fee_context().await?.fees_for_new_transaction(tx.max_fee_for_transaction());
@@ -485,12 +485,34 @@ impl Signer {
             current_nonce
         };
 
-        let sent = match self.send_transaction(tx.build(nonce, fees)).await {
-            Ok(sent) => sent,
+        let tx_id = tx.id;
+
+        let try_send = async {
+            // sign transaction
+            let signed = self.sign_transaction(tx.build(nonce, fees)).await?;
+
+            // write pending transaction to storage first to avoid race condition
+            let tx = PendingTransaction {
+                tx,
+                sent: vec![signed.clone()],
+                signer: self.address(),
+                received_at: Utc::now(),
+            };
+            self.storage.replace_queued_tx_with_pending(&tx).await?;
+
+            // send transaction and update status
+            self.send_transaction(&signed).await?;
+            self.update_tx_status(tx.id(), TransactionStatus::Pending(*signed.hash())).await?;
+
+            Ok::<_, SignerError>(tx)
+        };
+
+        match try_send.await {
+            Ok(tx) => self.watch_transaction(tx).await,
             Err(err) => {
                 error!(%err, "failed to send a transaction");
 
-                self.update_tx_status(tx.id, TransactionStatus::Failed(Arc::new(err))).await?;
+                self.update_tx_status(tx_id, TransactionStatus::Failed(Arc::new(err))).await?;
 
                 // If no other transaction occupied the next nonce, we can just reset it.
                 {
@@ -504,21 +526,9 @@ impl Signer {
                 // Otherwise, we need to close the nonce gap.
                 self.close_nonce_gap(nonce, None).await;
 
-                return Ok(());
+                Ok(())
             }
-        };
-
-        self.update_tx_status(tx.id, TransactionStatus::Pending(*sent.tx_hash())).await?;
-
-        let tx = PendingTransaction {
-            tx,
-            sent: vec![sent],
-            signer: self.address(),
-            received_at: Utc::now(),
-        };
-        self.storage.write_pending_transaction(&tx).await?;
-
-        self.watch_transaction(tx).await
+        }
     }
 
     /// Closes the nonce gap by sending a dummy transaction to the signer.
@@ -559,7 +569,8 @@ impl Signer {
                 ..Default::default()
             });
 
-            let tx = self.send_transaction(tx).await?;
+            let tx = self.sign_transaction(tx).await?;
+            self.send_transaction(&tx).await?;
             // Give transaction 10 blocks to be mined.
             self.provider
                 .watch_pending_transaction(


### PR DESCRIPTION
One more fix for https://github.com/ithacaxyz/relay/pull/527#issuecomment-2822446329

Right now if service is restarted while sending a transaction it might never hit database or even get removed from queue and just be lost

This PR fixes it by ensuring that queued -> pending transition is atomic and always persisting transactions before sending them. Persisting transaction that was not sent is much better than another way around as it will just get resent 