### PR TITLE
refactor: derive tx signers from mnemonic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -609,6 +609,8 @@ dependencies = [
  "alloy-primitives",
  "alloy-signer",
  "async-trait",
+ "coins-bip32",
+ "coins-bip39",
  "k256",
  "rand 0.8.5",
  "thiserror 2.0.12",
@@ -695,7 +697,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ceb96b29dd4e3ffdca0b68de4820f4867e1af3af944d6716e7b7fa7ec67c22c"
 dependencies = [
  "alloy-json-rpc",
- "base64",
+ "base64 0.22.1",
  "derive_more 2.0.1",
  "futures",
  "futures-utils-wasm",
@@ -1478,6 +1480,12 @@ checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -1497,6 +1505,12 @@ name = "base64ct"
 version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
+
+[[package]]
+name = "bech32"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 
 [[package]]
 name = "bindgen"
@@ -1582,6 +1596,16 @@ dependencies = [
  "glob",
  "threadpool",
  "zeroize",
+]
+
+[[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "sha2",
+ "tinyvec",
 ]
 
 [[package]]
@@ -1780,6 +1804,57 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "coins-bip32"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2073678591747aed4000dd468b97b14d7007f7936851d3f2f01846899f5ebf08"
+dependencies = [
+ "bs58",
+ "coins-core",
+ "digest 0.10.7",
+ "hmac",
+ "k256",
+ "serde",
+ "sha2",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "coins-bip39"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74b169b26623ff17e9db37a539fe4f15342080df39f129ef7631df7683d6d9d4"
+dependencies = [
+ "bitvec",
+ "coins-bip32",
+ "hmac",
+ "once_cell",
+ "pbkdf2",
+ "rand 0.8.5",
+ "sha2",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "coins-core"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b962ad8545e43a28e14e87377812ba9ae748dd4fd963f4c10e9fcc6d13475b"
+dependencies = [
+ "base64 0.21.7",
+ "bech32",
+ "bs58",
+ "const-hex",
+ "digest 0.10.7",
+ "generic-array",
+ "ripemd",
+ "serde",
+ "sha2",
+ "sha3",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3233,7 +3308,7 @@ version = "0.24.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bacb85abf4117092455e1573625e21b8f8ef4dec8aff13361140b2dc266cdff2"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "futures-channel",
  "futures-util",
  "gloo-net",
@@ -3286,7 +3361,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c872b6c9961a4ccc543e321bb5b89f6b2d2c7fe8b61906918273a3333c95400c"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "http-body 1.0.1",
  "hyper",
  "hyper-rustls",
@@ -3386,7 +3461,7 @@ version = "9.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "js-sys",
  "pem",
  "ring",
@@ -3407,6 +3482,7 @@ dependencies = [
  "once_cell",
  "serdect",
  "sha2",
+ "signature",
 ]
 
 [[package]]
@@ -3633,7 +3709,7 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df88858cd28baaaf2cfc894e37789ed4184be0e1351157aec7bf3c2266c793fd"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "http-body-util",
  "hyper",
  "hyper-rustls",
@@ -4053,12 +4129,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest 0.10.7",
+ "hmac",
+]
+
+[[package]]
 name = "pem"
 version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38af38e8470ac9dee3ce1bae1af9c1671fffc44ddfd8bd1d0a3445bf349a8ef3"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "serde",
 ]
 
@@ -4564,7 +4650,7 @@ dependencies = [
  "async-trait",
  "aws-config",
  "aws-sdk-kms",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "chrono",
  "clap",
@@ -4615,7 +4701,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d19c46a6fdd48bc4dab94b6103fccc55d34c67cc0ad04653aad4ea2a07cd7bbb"
 dependencies = [
  "async-compression",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-core",
@@ -4679,6 +4765,15 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "ripemd"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
+dependencies = [
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -5129,7 +5224,7 @@ version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6b6f7f2fcb69f747921f79f3926bd1e203fce4fef62c268dd3abfb6d86029aa"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -5291,7 +5386,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e859df029d160cb88608f5d7df7fb4753fd20fdfb4de5644f3d8b8440841721"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures",
  "http 1.3.1",
@@ -5339,7 +5434,7 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55c4720d7d4cd3d5b00f61d03751c685ad09c33ae8290c8a2c11335e0604300b"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "chrono",
  "crc",
@@ -5414,7 +5509,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "847d2e5393a4f39e47e4f36cab419709bc2b83cbe4223c60e86e1471655be333"
 dependencies = [
  "atoi",
- "base64",
+ "base64 0.22.1",
  "bitflags 2.9.0",
  "byteorder",
  "bytes",
@@ -5457,7 +5552,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc35947a541b9e0a2e3d85da444f1c4137c13040267141b208395a0d0ca4659f"
 dependencies = [
  "atoi",
- "base64",
+ "base64 0.22.1",
  "bitflags 2.9.0",
  "byteorder",
  "chrono",
@@ -5874,7 +5969,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "http 1.3.1",
  "http-body 1.0.1",
@@ -5896,7 +5991,7 @@ checksum = "85839f0b32fd242bb3209262371d07feda6d780d16ee9d2bc88581b89da1549b"
 dependencies = [
  "async-trait",
  "axum",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "h2",
  "http 1.3.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ alloy = { version = "0.15", features = [
     "network",
     "json-rpc",
     "reqwest-rustls-tls",
+    "signer-mnemonic",
 ], default-features = false }
 alloy-chains = "0.2"
 async-trait = "0.1"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,12 +2,15 @@
 use crate::{
     config::RelayConfig,
     constants::{
-        DEFAULT_MAX_TRANSACTIONS, DEFAULT_RPC_DEFAULT_MAX_CONNECTIONS, TX_GAS_BUFFER,
-        USER_OP_GAS_BUFFER,
+        DEFAULT_MAX_TRANSACTIONS, DEFAULT_NUM_SIGNERS, DEFAULT_RPC_DEFAULT_MAX_CONNECTIONS,
+        TX_GAS_BUFFER, USER_OP_GAS_BUFFER,
     },
     spawn::try_spawn_with_args,
 };
-use alloy::primitives::Address;
+use alloy::{
+    primitives::Address,
+    signers::local::coins_bip39::{English, Mnemonic},
+};
 use clap::Parser;
 use std::{
     net::{IpAddr, Ipv4Addr},
@@ -79,9 +82,6 @@ pub struct Args {
     /// A fee token the relay accepts.
     #[arg(long = "fee-token", value_name = "ADDRESS", required = true)]
     pub fee_tokens: Vec<Address>,
-    /// The secret key to sign transactions with.
-    #[arg(long = "secret-key", value_name = "SECRET_KEY", num_args=1.., value_delimiter = ',', env = "RELAY_SK")]
-    pub secret_keys: Vec<String>,
     /// The database URL for the relay.
     #[arg(long = "database-url", value_name = "URL", env = "RELAY_DB_URL")]
     pub database_url: Option<String>,
@@ -92,6 +92,12 @@ pub struct Args {
     /// simultaneously.
     #[arg(long = "max-pending-transactions", value_name = "NUM", default_value_t = DEFAULT_MAX_TRANSACTIONS)]
     pub max_pending_transactions: usize,
+    /// The mnemonic to use for deriving transaction signers.
+    #[arg(long = "signers-mnemonic", value_name = "MNEMONIC", env = "RELAY_MNEMONIC")]
+    pub signers_mnemonic: Mnemonic<English>,
+    /// The number of signers to derive from mnemonic and use to send transactions.
+    #[arg(long = "num-signers", value_name = "NUM", default_value_t = DEFAULT_NUM_SIGNERS)]
+    pub num_signers: usize,
 }
 
 impl Args {
@@ -108,7 +114,7 @@ impl Args {
     pub fn merge_relay_config(self, config: RelayConfig) -> RelayConfig {
         config
             .with_quote_key(self.quote_secret_key)
-            .with_transaction_keys(&self.secret_keys)
+            .with_signers_mnemonic(self.signers_mnemonic)
             .with_endpoints(&self.endpoints)
             .with_fee_tokens(&self.fee_tokens)
             .with_fee_recipient(self.fee_recipient)
@@ -125,6 +131,7 @@ impl Args {
             .with_tx_gas_buffer(self.tx_gas_buffer)
             .with_database_url(self.database_url)
             .with_max_pending_transactions(self.max_pending_transactions)
+            .with_num_signers(self.num_signers)
     }
 }
 
@@ -156,6 +163,7 @@ mod tests {
         let config = dir.join("relay.toml");
         let registry = dir.join("registry.toml");
         let key = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+        let mnemonic = "test test test test test test test test test test test junk";
 
         for _ in 0..=1 {
             let _ = try_spawn_with_args(
@@ -175,11 +183,12 @@ mod tests {
                     rate_ttl: Default::default(),
                     quote_secret_key: key.to_string(),
                     fee_tokens: Default::default(),
-                    secret_keys: vec![key.to_string()],
                     user_op_gas_buffer: Default::default(),
                     tx_gas_buffer: Default::default(),
                     database_url: Default::default(),
                     max_pending_transactions: Default::default(),
+                    num_signers: Default::default(),
+                    signers_mnemonic: mnemonic.parse().unwrap(),
                 },
                 config.clone(),
                 registry.clone(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,11 @@
 //! Relay configuration.
-use crate::constants::{DEFAULT_MAX_TRANSACTIONS, TX_GAS_BUFFER, USER_OP_GAS_BUFFER};
-use alloy::primitives::Address;
+use crate::constants::{
+    DEFAULT_MAX_TRANSACTIONS, DEFAULT_NUM_SIGNERS, TX_GAS_BUFFER, USER_OP_GAS_BUFFER,
+};
+use alloy::{
+    primitives::Address,
+    signers::local::coins_bip39::{English, Mnemonic},
+};
 use eyre::Context;
 use reqwest::Url;
 use serde::{Deserialize, Serialize};
@@ -8,6 +13,7 @@ use std::{
     collections::BTreeSet,
     net::{IpAddr, Ipv4Addr},
     path::Path,
+    str::FromStr,
     time::Duration,
 };
 
@@ -103,17 +109,32 @@ impl QuoteConfig {
 }
 
 /// Secrets (kept out of serialized output).
-#[derive(Debug, Serialize, Deserialize, Default)]
+#[derive(Debug, Deserialize)]
 pub struct SecretsConfig {
     /// The secret key to sign transactions with.
-    pub transaction_keys: Vec<String>,
+    #[serde(with = "alloy::serde::displayfromstr")]
+    pub signers_mnemonic: Mnemonic<English>,
     /// The secret key to sign fee quotes with.
     pub quote_key: String,
+}
+
+impl Default for SecretsConfig {
+    fn default() -> Self {
+        Self {
+            signers_mnemonic: Mnemonic::<English>::from_str(
+                "test test test test test test test test test test test junk",
+            )
+            .unwrap(),
+            quote_key: String::new(),
+        }
+    }
 }
 
 /// Configuration for transaction service.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TransactionServiceConfig {
+    /// Number of signers to derive from mnemonic and use for sending transactions.
+    pub num_signers: usize,
     /// Maximum number of transactions that can be pending at any given time.
     pub max_pending_transactions: usize,
     /// Maximum number of pending transactions that can be handled by a single signer.
@@ -132,6 +153,7 @@ pub struct TransactionServiceConfig {
 impl Default for TransactionServiceConfig {
     fn default() -> Self {
         Self {
+            num_signers: DEFAULT_NUM_SIGNERS,
             max_pending_transactions: DEFAULT_MAX_TRANSACTIONS,
             max_transactions_per_signer: 16,
             balance_check_interval: Duration::from_secs(5),
@@ -252,14 +274,8 @@ impl RelayConfig {
     }
 
     /// Sets the secret key used to sign transactions.
-    pub fn with_transaction_key(mut self, secret_key: String) -> Self {
-        self.secrets.transaction_keys.push(secret_key);
-        self
-    }
-
-    /// Sets the secret key used to sign transactions.
-    pub fn with_transaction_keys(mut self, secret_keys: &[String]) -> Self {
-        self.secrets.transaction_keys.extend_from_slice(secret_keys);
+    pub fn with_signers_mnemonic(mut self, mnemonic: Mnemonic<English>) -> Self {
+        self.secrets.signers_mnemonic = mnemonic;
         self
     }
 
@@ -290,6 +306,12 @@ impl RelayConfig {
     /// Sets the maximum number of pending transactions.
     pub fn with_max_pending_transactions(mut self, max_pending_transactions: usize) -> Self {
         self.transactions.max_pending_transactions = max_pending_transactions;
+        self
+    }
+
+    /// Sets the number of signers to derive from mnemonic and use for sending transactions.
+    pub fn with_num_signers(mut self, num_signers: usize) -> Self {
+        self.transactions.num_signers = num_signers;
         self
     }
 

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -41,3 +41,6 @@ pub const BASE_SEPOLIA_PUBLIC_RPC_URL: &str = "https://sepolia.base.org";
 
 /// Default cap on maximum number of pending transactions per chain.
 pub const DEFAULT_MAX_TRANSACTIONS: usize = 100;
+
+/// Default number of signers to derive from mnemonic and use for sending transactions.
+pub const DEFAULT_NUM_SIGNERS: usize = 16;

--- a/src/spawn.rs
+++ b/src/spawn.rs
@@ -99,11 +99,11 @@ pub async fn try_spawn(config: RelayConfig, registry: CoinRegistry) -> eyre::Res
         RelayStorage::in_memory()
     };
 
-    // construct provider
-    let signers = futures_util::future::try_join_all(
-        config.secrets.transaction_keys.iter().map(|sk| DynSigner::load(sk, None)),
-    )
-    .await?;
+    // setup signers
+    let signers = DynSigner::derive_from_mnemonic(
+        config.secrets.signers_mnemonic,
+        config.transactions.num_signers,
+    )?;
     let signer_addresses = signers.iter().map(|signer| signer.address()).collect::<Vec<_>>();
 
     // setup metrics exporter and periodic metric collectors
@@ -112,6 +112,7 @@ pub async fn try_spawn(config: RelayConfig, registry: CoinRegistry) -> eyre::Res
     metrics::spawn_periodic_collectors(signer_addresses.clone(), config.chain.endpoints.clone())
         .await?;
 
+    // setup providers
     let providers: Vec<DynProvider> = futures_util::future::try_join_all(
         config.chain.endpoints.iter().cloned().map(|url| async move {
             ClientBuilder::default()

--- a/tests/e2e/cases/transactions.rs
+++ b/tests/e2e/cases/transactions.rs
@@ -1,5 +1,5 @@
 use crate::e2e::{
-    MockErc20, await_calls_status,
+    FIRST_RELAY_SIGNER, MockErc20, SIGNERS_MNEMONIC, await_calls_status,
     environment::{Environment, EnvironmentConfig},
     send_prepared_calls,
 };
@@ -332,7 +332,7 @@ async fn dropped_transaction() -> eyre::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn fee_bump() -> eyre::Result<()> {
     let config = EnvironmentConfig { is_prep: true, block_time: Some(1.0), ..Default::default() };
-    let signer = PrivateKeySigner::from_bytes(config.signers.first().unwrap()).unwrap().address();
+    let signer = PrivateKeySigner::from_bytes(&FIRST_RELAY_SIGNER)?;
     let env = Environment::setup(config).await.unwrap();
     let tx_service_handle = env.relay_handle.chains.get(env.chain_id).unwrap().transactions.clone();
 
@@ -366,8 +366,12 @@ async fn fee_bump() -> eyre::Result<()> {
     assert!(
         new_tx.max_priority_fee_per_gas().unwrap() > dropped.max_priority_fee_per_gas().unwrap()
     );
-    let pending_txs =
-        env.relay_handle.storage.read_pending_transactions(signer, env.chain_id).await.unwrap();
+    let pending_txs = env
+        .relay_handle
+        .storage
+        .read_pending_transactions(signer.address(), env.chain_id)
+        .await
+        .unwrap();
     assert_eq!(pending_txs.len(), 1);
     assert_eq!(pending_txs.first().unwrap().sent.len(), 2);
 
@@ -444,12 +448,12 @@ async fn fee_growth_nonce_gap() -> eyre::Result<()> {
 /// nonce gap caused by it.
 #[tokio::test(flavor = "multi_thread")]
 async fn pause_out_of_funds() -> eyre::Result<()> {
-    let signers = (0..3).map(|_| PrivateKeySigner::random()).collect::<Vec<_>>();
+    let num_signers = 3;
     let env = Environment::setup(EnvironmentConfig {
         is_prep: true,
         block_time: Some(0.2),
-        signers: signers.iter().map(|s| B256::from_slice(&s.credential().to_bytes())).collect(),
         transaction_service_config: TransactionServiceConfig {
+            num_signers,
             // set lower interval to make sure that we hit the pause logic
             balance_check_interval: Duration::from_millis(100),
             // set lower throughput to make sure that transactions are not getting included too
@@ -462,6 +466,7 @@ async fn pause_out_of_funds() -> eyre::Result<()> {
     })
     .await
     .unwrap();
+    let signers = DynSigner::derive_from_mnemonic(SIGNERS_MNEMONIC.parse()?, num_signers)?;
     let tx_service_handle = env.relay_handle.chains.get(env.chain_id).unwrap().transactions.clone();
 
     // use a consistent seed
@@ -526,12 +531,12 @@ async fn pause_out_of_funds() -> eyre::Result<()> {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn resume_paused() -> eyre::Result<()> {
-    let signers = (0..5).map(|_| PrivateKeySigner::random()).collect::<Vec<_>>();
+    let num_signers = 5;
     let env = Environment::setup(EnvironmentConfig {
         is_prep: true,
         block_time: Some(0.2),
-        signers: signers.iter().map(|s| B256::from_slice(&s.credential().to_bytes())).collect(),
         transaction_service_config: TransactionServiceConfig {
+            num_signers,
             // set lower interval to make sure that we hit the pause logic
             balance_check_interval: Duration::from_millis(100),
             // set lower throughput to make sure that transactions are not getting included too
@@ -545,6 +550,8 @@ async fn resume_paused() -> eyre::Result<()> {
     .await
     .unwrap();
     let tx_service_handle = env.relay_handle.chains.get(env.chain_id).unwrap().transactions.clone();
+
+    let signers = DynSigner::derive_from_mnemonic(SIGNERS_MNEMONIC.parse()?, num_signers)?;
 
     // setup 10 accounts
     let num_accounts = 10;
@@ -621,7 +628,7 @@ async fn diverged_nonce() -> eyre::Result<()> {
         },
         ..Default::default()
     };
-    let signer = PrivateKeySigner::from_bytes(&config.signers[0]).unwrap();
+    let signer = PrivateKeySigner::from_bytes(&FIRST_RELAY_SIGNER)?;
     let env = Environment::setup(config.clone()).await.unwrap();
     let tx_service_handle = env.relay_handle.chains.get(env.chain_id).unwrap().transactions.clone();
 
@@ -665,10 +672,10 @@ async fn restart_with_pending() -> eyre::Result<()> {
         },
         ..Default::default()
     };
-    let signers = try_join_all(
-        config.signers.iter().map(async |s| DynSigner::load(&s.to_string(), None).await),
+    let signers = DynSigner::derive_from_mnemonic(
+        SIGNERS_MNEMONIC.parse()?,
+        config.transaction_service_config.num_signers,
     )
-    .await
     .unwrap();
     let env = Environment::setup(config.clone()).await.unwrap();
     let tx_service_handle = env.relay_handle.chains.get(env.chain_id).unwrap().transactions.clone();

--- a/tests/e2e/constants.rs
+++ b/tests/e2e/constants.rs
@@ -8,6 +8,12 @@ pub const EOA_PRIVATE_KEY: B256 =
 pub const RELAY_PRIVATE_KEY: B256 =
     b256!("0xffffffbec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80");
 
+pub const SIGNERS_MNEMONIC: &str =
+    "forget sound story reveal safe minimum wasp mechanic solar predict harsh catch";
+
 pub const DEFAULT_EXECUTE_SELECTOR: FixedBytes<4> = fixed_bytes!("0x32323232");
 
 pub const DEFAULT_EXECUTE_TO: Address = address!("0x3232323232323232323232323232323232323232");
+
+pub const FIRST_RELAY_SIGNER: B256 =
+    b256!("0xab78933d36d3e049cc43e1f72845a6c03cdadf8557027bc4895053e8351b71cd");

--- a/tests/e2e/environment.rs
+++ b/tests/e2e/environment.rs
@@ -50,7 +50,6 @@ const MULTICALL3_BYTECODE: Bytes = bytes!(
 pub struct EnvironmentConfig {
     pub is_prep: bool,
     pub block_time: Option<f64>,
-    pub signers: Vec<B256>,
     pub transaction_service_config: TransactionServiceConfig,
     /// The default block number to use for forking.
     ///
@@ -63,8 +62,10 @@ impl Default for EnvironmentConfig {
         Self {
             is_prep: false,
             block_time: None,
-            signers: vec![RELAY_PRIVATE_KEY],
-            transaction_service_config: Default::default(),
+            transaction_service_config: TransactionServiceConfig {
+                num_signers: 1,
+                ..Default::default()
+            },
             fork_block_number: None,
         }
     }
@@ -191,6 +192,14 @@ impl Environment {
             .wallet(EthereumWallet::from(deployer.0.clone()))
             .connect_client(client);
 
+        // fund relay signers
+        for signer in DynSigner::derive_from_mnemonic(
+            SIGNERS_MNEMONIC.parse()?,
+            config.transaction_service_config.num_signers,
+        )? {
+            provider.anvil_set_balance(signer.address(), U256::from(1000e18)).await?;
+        }
+
         // Get or deploy mock contracts.
         let (delegation, entrypoint, account_registry, erc20s) =
             get_or_deploy_contracts(&provider).await?;
@@ -208,29 +217,14 @@ impl Environment {
             )
         };
 
+        // fund EOA
         if !eoa.is_prep() {
             // mints erc20 and fee_token
             mint_erc20s(&erc20s[..2], &[eoa.address()], &provider).await?;
-        }
 
-        // Ensure our registry has our tokens
-        let chain_id = provider.get_chain_id().await?;
-        let mut registry = CoinRegistry::default();
-        registry.extend(erc20s.iter().map(|erc20| ((chain_id, Some(*erc20)), CoinKind::USDT)));
-
-        // Fund relay signers and EOA
-        let relay_signers =
-            config.signers.iter().map(|s| PrivateKeySigner::from_bytes(s).unwrap().address());
-        let fundable_addresses = if eoa.is_prep() {
-            relay_signers.collect::<Vec<_>>()
-        } else {
-            relay_signers.chain(iter::once(eoa.address())).collect()
-        };
-
-        for address in fundable_addresses {
             provider
                 .send_transaction(TransactionRequest {
-                    to: Some(TxKind::Call(address)),
+                    to: Some(TxKind::Call(eoa.address())),
                     value: Some(U256::from(1000e18)),
                     ..Default::default()
                 })
@@ -238,6 +232,11 @@ impl Environment {
                 .get_receipt()
                 .await?;
         }
+
+        // Ensure our registry has our tokens
+        let chain_id = provider.get_chain_id().await?;
+        let mut registry = CoinRegistry::default();
+        registry.extend(erc20s.iter().map(|erc20| ((chain_id, Some(*erc20)), CoinKind::USDT)));
 
         let database_url = if let Ok(db_url) = std::env::var("DATABASE_URL") {
             let opts = PgConnectOptions::from_str(&db_url)?;
@@ -260,10 +259,8 @@ impl Environment {
                 .with_endpoints(&[endpoint.clone()])
                 .with_quote_ttl(Duration::from_secs(60))
                 .with_rate_ttl(Duration::from_secs(300))
-                .with_quote_key(config.signers[0].clone().to_string())
-                .with_transaction_keys(
-                    &config.signers.into_iter().map(|s| s.to_string()).collect::<Vec<_>>(),
-                )
+                .with_quote_key(RELAY_PRIVATE_KEY.to_string())
+                .with_signers_mnemonic(SIGNERS_MNEMONIC.parse().unwrap())
                 .with_quote_constant_rate(1.0)
                 .with_fee_tokens(&[erc20s.as_slice(), &[Address::ZERO]].concat())
                 .with_entrypoint(entrypoint)


### PR DESCRIPTION
Instead of specifying individual private keys, changes configuration to only require a single mnemonic, and a CLI flag configurating number of signers to derive and use.

cc @jenpaff 
