### PR TITLE
fix: ensure valid fees when sending transaction

### DIFF
--- a/src/transactions/signer.rs
+++ b/src/transactions/signer.rs
@@ -469,7 +469,7 @@ impl Signer {
     ) -> Result<(), SignerError> {
         // Fetch the fees for the first transaction.
         let fees =
-            self.get_fee_context().await?.fees_for_new_transaction(tx.max_fee_for_transaction());
+            self.get_fee_context().await?.fees_for_new_transaction(tx.max_fee_for_transaction())?;
 
         // Validate the transaction.
         if let Err(err) = self.validate_transaction(&mut tx, fees).await {


### PR DESCRIPTION
Right now we don't account for potential fee growth since we've issued the quote. This might result in us sending a transaction with `maxFeePerGas` lower than current basefee or with priority fee exceeding the `maxFeePerGas` (this case was hit during stress test)

With this PR we check that we can afford the basefee and also cap priority fee correctly