### PR TITLE
chore: update lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4556,7 +4556,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "relay"
-version = "6.1.0"
+version = "6.1.1"
 dependencies = [
  "alloy",
  "alloy-chains",


### PR DESCRIPTION
out of sync