### PR TITLE
refactor!: remove quote key config

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -76,9 +76,6 @@ pub struct Args {
     /// Extra buffer added to transaction gas estimates.
     #[arg(long, value_name = "TX_OP_GAS", default_value_t = TX_GAS_BUFFER)]
     pub tx_gas_buffer: u64,
-    /// The secret key to sign fee quotes with.
-    #[arg(long, value_name = "SECRET_KEY", env = "RELAY_FEE_SK")]
-    pub quote_secret_key: String,
     /// A fee token the relay accepts.
     #[arg(long = "fee-token", value_name = "ADDRESS", required = true)]
     pub fee_tokens: Vec<Address>,
@@ -113,7 +110,6 @@ impl Args {
     /// Merges [`Args`] values into an existing [`RelayConfig`] instance.
     pub fn merge_relay_config(self, config: RelayConfig) -> RelayConfig {
         config
-            .with_quote_key(self.quote_secret_key)
             .with_signers_mnemonic(self.signers_mnemonic)
             .with_endpoints(&self.endpoints)
             .with_fee_tokens(&self.fee_tokens)
@@ -162,7 +158,6 @@ mod tests {
         let dir = temp_dir();
         let config = dir.join("relay.toml");
         let registry = dir.join("registry.toml");
-        let key = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
         let mnemonic = "test test test test test test test test test test test junk";
 
         for _ in 0..=1 {
@@ -181,7 +176,6 @@ mod tests {
                     fee_recipient: Default::default(),
                     quote_ttl: Default::default(),
                     rate_ttl: Default::default(),
-                    quote_secret_key: key.to_string(),
                     fee_tokens: Default::default(),
                     user_op_gas_buffer: Default::default(),
                     tx_gas_buffer: Default::default(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -114,8 +114,6 @@ pub struct SecretsConfig {
     /// The secret key to sign transactions with.
     #[serde(with = "alloy::serde::displayfromstr")]
     pub signers_mnemonic: Mnemonic<English>,
-    /// The secret key to sign fee quotes with.
-    pub quote_key: String,
 }
 
 impl Default for SecretsConfig {
@@ -125,7 +123,6 @@ impl Default for SecretsConfig {
                 "test test test test test test test test test test test junk",
             )
             .unwrap(),
-            quote_key: String::new(),
         }
     }
 }
@@ -264,12 +261,6 @@ impl RelayConfig {
     /// Sets the fee recipient address.
     pub fn with_fee_recipient(mut self, fee_recipient: Address) -> Self {
         self.chain.fee_recipient = fee_recipient;
-        self
-    }
-
-    /// Sets the secret key used to sign fee quotes.
-    pub fn with_quote_key(mut self, quote_secret_key: String) -> Self {
-        self.secrets.quote_key = quote_secret_key;
         self
     }
 

--- a/src/spawn.rs
+++ b/src/spawn.rs
@@ -13,8 +13,10 @@ use crate::{
     types::{CoinKind, CoinPair, CoinRegistry, FeeTokens},
 };
 use alloy::{
+    primitives::B256,
     providers::{DynProvider, Provider, ProviderBuilder},
     rpc::client::ClientBuilder,
+    signers::local::LocalSigner,
     transports::layers::RetryBackoffLayer,
 };
 use http::header;
@@ -127,7 +129,7 @@ pub async fn try_spawn(config: RelayConfig, registry: CoinRegistry) -> eyre::Res
     .await?;
 
     // construct quote signer
-    let quote_signer = DynSigner::load(&config.secrets.quote_key, None).await?;
+    let quote_signer = DynSigner(Arc::new(LocalSigner::from_bytes(&B256::random())?));
     let quote_signer_addr = quote_signer.address();
 
     // construct rpc module

--- a/tests/e2e/constants.rs
+++ b/tests/e2e/constants.rs
@@ -5,9 +5,6 @@ use alloy::primitives::{Address, B256, FixedBytes, address, b256, fixed_bytes};
 pub const EOA_PRIVATE_KEY: B256 =
     b256!("0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d");
 
-pub const RELAY_PRIVATE_KEY: B256 =
-    b256!("0xffffffbec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80");
-
 pub const SIGNERS_MNEMONIC: &str =
     "forget sound story reveal safe minimum wasp mechanic solar predict harsh catch";
 

--- a/tests/e2e/environment.rs
+++ b/tests/e2e/environment.rs
@@ -259,7 +259,6 @@ impl Environment {
                 .with_endpoints(&[endpoint.clone()])
                 .with_quote_ttl(Duration::from_secs(60))
                 .with_rate_ttl(Duration::from_secs(300))
-                .with_quote_key(RELAY_PRIVATE_KEY.to_string())
                 .with_signers_mnemonic(SIGNERS_MNEMONIC.parse().unwrap())
                 .with_quote_constant_rate(1.0)
                 .with_fee_tokens(&[erc20s.as_slice(), &[Address::ZERO]].concat())


### PR DESCRIPTION
Removes `RELAY_FEE_SK`/`--quote-secret-key` and just uses a random key for signing quotes. This minimizes configuration and it doesn't really matter if the key is the same across restarts.

Closes #548 