### PR TITLE
ci: tag docker image with short sha if dispatched release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,13 +51,13 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Get short commit
-        if: env.GITHUB_EVENT_NAME != 'workflow_dispatch'
+        if: env.GITHUB_EVENT_NAME == 'workflow_dispatch'
         id: vars
         run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
       - name: Build and push dispatched
         uses: docker/build-push-action@v6
-        if: env.GITHUB_EVENT_NAME != 'workflow_dispatch'
+        if: env.GITHUB_EVENT_NAME == 'workflow_dispatch'
         with:
           context: .
           file: ${{ matrix.dockerfile }}


### PR DESCRIPTION
If the release workflow is triggered via dispatch, it will push a Docker image with the short sha of the commit it was dispatched at. If it was triggered via a tag, it will push a Docker image with the tag name and update `latest`.