### PR TITLE
fix: do not pin block number on ci

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -60,11 +60,9 @@ jobs:
       - uses: taiki-e/install-action@nextest
 
       - name: Set fork environment
-        # when updating deployed address, also update TEST_FORK_BLOCK_NUMBER_PINNED
         if: ${{ matrix.variant == 'base_sepolia' }}
         run: |
           echo "TEST_FORK_URL=https://base-sepolia.ithaca.xyz" >> $GITHUB_ENV
-          echo "TEST_FORK_BLOCK_NUMBER_PINNED=25077241" >> $GITHUB_ENV
           echo "TEST_ENTRYPOINT=0x84a9c32db444bb831d1f425729ded15e65970511" >> $GITHUB_ENV
           echo "TEST_DELEGATION=0x9dcb3249b6beb3146f87b0317e7a00ac83d76a91" >> $GITHUB_ENV
           echo "TEST_ACCOUNT_REGISTRY=0x8694bcd337f2e14af6d2f5491d3d6f20c798fb96" >> $GITHUB_ENV


### PR DESCRIPTION
The sepolia node we're using is a full node, and we are starting to hit pruned data errors:
```
- failed to get account for 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266: server returned an error response: error code -32603: state at block #25077242 is pruned
```

Removing the pin seems to work.