### PR TITLE
fix: don't override storage slots for prep accounts

### DIFF
--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -30,7 +30,7 @@ use alloy::{
         SignedAuthorization,
         constants::{EIP7702_DELEGATION_DESIGNATOR, PER_AUTH_BASE_COST, PER_EMPTY_ACCOUNT_COST},
     },
-    primitives::{Address, Bytes, ChainId, U256, bytes, map::B256Map},
+    primitives::{Address, Bytes, ChainId, U256, bytes},
     providers::{DynProvider, Provider},
     rpc::types::{
         TransactionReceipt,


### PR DESCRIPTION
closes #574 