### PR TITLE
feat: add `prehashed_signing` field to `prepare` apis

### DIFF
--- a/src/bin/stress.rs
+++ b/src/bin/stress.rs
@@ -94,6 +94,7 @@ impl StressAccount {
                         revoke_keys: vec![],
                         pre_ops: vec![],
                         pre_op: false,
+                        prehashed_signing: false,
                     },
                 })
                 .await

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -351,7 +351,7 @@ impl Relay {
         op.signature = Signature {
             innerSignature: signature,
             keyHash: account_key.key_hash(),
-            prehash: account_key.keyType.is_p256(), // WebCrypto P256 uses prehash
+            prehash: request.prehashed_signing,
         }
         .abi_encode_packed()
         .into();
@@ -948,6 +948,7 @@ impl RelayApiServer for Relay {
                             pre_ops: request.capabilities.pre_ops.clone(),
                         },
                         chain_id: request.chain_id,
+                        prehashed_signing: request.capabilities.prehashed_signing,
                     },
                     request.capabilities.meta.fee_token,
                     maybe_prep.as_ref().map(|acc| acc.prep.signed_authorization.address),
@@ -1024,6 +1025,7 @@ impl RelayApiServer for Relay {
                         pre_ops: request.capabilities.pre_ops,
                     },
                     chain_id: request.chain_id,
+                    prehashed_signing: request.capabilities.prehashed_signing,
                 },
                 request.capabilities.fee_token,
                 Some(request.capabilities.delegation),

--- a/src/types/action.rs
+++ b/src/types/action.rs
@@ -15,4 +15,6 @@ pub struct PartialAction {
     pub op: PartialUserOp,
     /// The destination chain ID.
     pub chain_id: ChainId,
+    /// Whether the digest will be prehashed before signing.
+    pub prehashed_signing: bool,
 }

--- a/src/types/rpc/account.rs
+++ b/src/types/rpc/account.rs
@@ -152,6 +152,9 @@ pub struct UpgradeAccountCapabilities {
     /// Optional [`PreOp`] to execute before signature verification.
     #[serde(default)]
     pub pre_ops: Vec<PreOp>,
+    /// Whether the digest will be prehashed before signing.
+    #[serde(default)]
+    pub prehashed_signing: bool,
 }
 
 /// Request parameters for `wallet_prepareUpgradeAccount`.

--- a/src/types/rpc/calls.rs
+++ b/src/types/rpc/calls.rs
@@ -82,6 +82,9 @@ pub struct PrepareCallsCapabilities {
     /// Whether the call bundle is to be considered a preop.
     #[serde(default)]
     pub pre_op: bool,
+    /// Whether the digest will be prehashed before signing.
+    #[serde(default)]
+    pub prehashed_signing: bool,
 }
 
 /// Capabilities for `wallet_prepareCalls` response.

--- a/tests/e2e/cases/assets.rs
+++ b/tests/e2e/cases/assets.rs
@@ -72,6 +72,7 @@ async fn asset_diff() -> eyre::Result<()> {
             revoke_keys: vec![],
             pre_ops: vec![],
             pre_op: false,
+            prehashed_signing: false,
         },
     };
 

--- a/tests/e2e/cases/calls.rs
+++ b/tests/e2e/cases/calls.rs
@@ -65,6 +65,7 @@ async fn calls_with_upgraded_account() -> eyre::Result<()> {
                     },
                     pre_ops: Vec::new(),
                     pre_op: false,
+                    prehashed_signing: false,
                 },
             })
             .await?;

--- a/tests/e2e/cases/transactions.rs
+++ b/tests/e2e/cases/transactions.rs
@@ -113,6 +113,7 @@ impl MockAccount {
                     pre_ops: vec![],
                     pre_op: false,
                     revoke_keys: vec![],
+                    prehashed_signing: false,
                 },
             })
             .await
@@ -150,6 +151,7 @@ impl MockAccount {
                     pre_ops: vec![],
                     pre_op: false,
                     revoke_keys: vec![],
+                    prehashed_signing: false,
                 },
             })
             .await

--- a/tests/e2e/cases/upgrade.rs
+++ b/tests/e2e/cases/upgrade.rs
@@ -30,6 +30,7 @@ pub async fn upgrade_account(
                 fee_payer: None,
                 fee_token: env.fee_token,
                 pre_ops,
+                prehashed_signing: false,
             },
         })
         .await?;
@@ -93,6 +94,7 @@ async fn invalid_auth_quote_check() -> eyre::Result<()> {
                 fee_payer: None,
                 fee_token: env.fee_token,
                 pre_ops: vec![],
+                prehashed_signing: false,
             },
         })
         .await?;

--- a/tests/e2e/environment.rs
+++ b/tests/e2e/environment.rs
@@ -268,7 +268,7 @@ impl Environment {
                 .with_delegation_proxy(delegation)
                 .with_account_registry(account_registry)
                 .with_simulator(simulator)
-                .with_user_op_gas_buffer(45_000) // todo: temp
+                .with_user_op_gas_buffer(0) // todo: temp
                 .with_tx_gas_buffer(75_000) // todo: temp
                 .with_transaction_service_config(config.transaction_service_config)
                 .with_database_url(database_url),

--- a/tests/e2e/mod.rs
+++ b/tests/e2e/mod.rs
@@ -153,6 +153,7 @@ pub async fn prepare_calls(
                 },
                 pre_ops,
                 pre_op,
+                prehashed_signing: false,
             },
         })
         .await;


### PR DESCRIPTION
proposing, can just close it if not desired

Instead of assuming during `simulation` that a p256 key signature always takes `prehash:true`, it takes it from the request capabilities (similar to how signature already has a prehash field that porto fills)

affected:
* prepare_upgrade_account
* prepare_calls