### PR TITLE
chore: ensure ERC721 mints show the `tokenURI`

### DIFF
--- a/src/types/tokens.rs
+++ b/src/types/tokens.rs
@@ -25,6 +25,7 @@ sol! {
 
         function safeTransferFrom(address from, address to, uint256 id);
         function tokenURI(uint256 id) public view virtual returns (string);
+        function burn(uint256 id) public virtual;
     }
 }
 

--- a/tests/e2e/common_calls.rs
+++ b/tests/e2e/common_calls.rs
@@ -19,15 +19,19 @@ pub fn transfer(erc20: Address, recipient: Address, amount: U256) -> Call {
     }
 }
 
-/// ERC20 transfer call.
-pub fn transfer_721(erc20: Address, from: Address, to: Address, id: U256) -> Call {
+/// ERC721 transfer call.
+pub fn transfer_721(erc721: Address, from: Address, to: Address, id: U256) -> Call {
     Call {
-        to: erc20,
+        to: erc721,
         value: U256::ZERO,
         data: IERC721::safeTransferFromCall { from, to, id }.abi_encode().into(),
     }
 }
 
+/// ERC721 burn call.
+pub fn burn_721(erc721: Address, id: U256) -> Call {
+    Call { to: erc721, value: U256::ZERO, data: IERC721::burnCall { id }.abi_encode().into() }
+}
 /// ERC20 mint call.
 pub fn mint(erc20: Address, a: Address, val: U256) -> Call {
     Call { to: erc20, value: U256::ZERO, data: MockErc20::mintCall { a, val }.abi_encode().into() }


### PR DESCRIPTION
closes https://github.com/ithacaxyz/relay/issues/584
follow-up on https://github.com/ithacaxyz/relay/pull/582#issuecomment-2847377828
```rust
    /// Since tokenURI calls revert if the token is not owned, this requires a [`SimBlock`], so the
    /// URI calls can be done before and after:
    ///  * Before, so we can query the URIs from burned tokens.
    ///  * After, so we can query the URIs from minted tokens.
```