### PR TITLE
feat: add `CallKey` to `wallet_prepareCalls` 

### DIFF
--- a/src/bin/stress.rs
+++ b/src/bin/stress.rs
@@ -85,16 +85,12 @@ impl StressAccount {
                     from: Some(self.address),
                     capabilities: PrepareCallsCapabilities {
                         authorize_keys: vec![],
-                        meta: Meta {
-                            fee_payer: None,
-                            fee_token,
-                            key_hash: self.key.key_hash(),
-                            nonce: None,
-                        },
+                        meta: Meta { fee_payer: None, fee_token, nonce: None },
                         revoke_keys: vec![],
                         pre_ops: vec![],
                         pre_op: false,
                     },
+                    key: self.key.to_call_key(),
                 })
                 .await
                 .expect("prepare calls failed");

--- a/src/types/action.rs
+++ b/src/types/action.rs
@@ -15,4 +15,6 @@ pub struct PartialAction {
     pub op: PartialUserOp,
     /// The destination chain ID.
     pub chain_id: ChainId,
+    /// Whether the digest will be prehashed before signing.
+    pub prehash: bool,
 }

--- a/src/types/key.rs
+++ b/src/types/key.rs
@@ -1,7 +1,7 @@
 use super::{
     super::signers::{DynSigner, Eip712PayLoadSigner, P256Key, P256Signer, WebAuthnSigner},
     Call, U40,
-    rpc::{AuthorizeKey, Permission, RevokeKey},
+    rpc::{AuthorizeKey, CallKey, Permission, RevokeKey},
 };
 use IDelegation::getKeysReturn;
 use alloy::{
@@ -359,6 +359,11 @@ impl KeyWith712Signer {
     /// Returns a reference to the inner [`Key`].
     pub fn key(&self) -> &Key {
         &self.key
+    }
+
+    /// Returns a [`CallKey`].
+    pub fn to_call_key(&self) -> CallKey {
+        CallKey { key_type: self.keyType, public_key: self.publicKey.clone(), prehash: false }
     }
 
     /// Returns a [`AuthorizeKey`] equivalent.

--- a/src/types/rpc/mod.rs
+++ b/src/types/rpc/mod.rs
@@ -15,7 +15,7 @@ pub use permission::*;
 mod settings;
 pub use settings::*;
 
-use alloy::primitives::{Address, B256, U256};
+use alloy::primitives::{Address, U256};
 use serde::{Deserialize, Serialize};
 
 /// Represents extra request values.
@@ -31,8 +31,6 @@ pub struct Meta {
     /// Defaults to the native token.
     #[serde(default)]
     pub fee_token: Address,
-    /// Key (hash) that will be used to sign the request.
-    pub key_hash: B256,
     /// Nonce.
     pub nonce: Option<U256>,
 }

--- a/tests/e2e/cases/assets.rs
+++ b/tests/e2e/cases/assets.rs
@@ -66,17 +66,13 @@ async fn asset_diff() -> eyre::Result<()> {
         calls: vec![], // fill in per test
         chain_id: env.chain_id,
         capabilities: PrepareCallsCapabilities {
-            meta: Meta {
-                fee_payer: None,
-                fee_token: Address::ZERO,
-                key_hash: admin_key.key_hash(),
-                nonce: None,
-            },
+            meta: Meta { fee_payer: None, fee_token: Address::ZERO, nonce: None },
             authorize_keys: vec![],
             revoke_keys: vec![],
             pre_ops: vec![],
             pre_op: false,
         },
+        key: admin_key.to_call_key(),
     };
 
     let prepare_calls = |calls: Vec<Call>| {
@@ -202,17 +198,13 @@ async fn asset_diff_has_uri() -> eyre::Result<()> {
         },
         chain_id: env.chain_id,
         capabilities: PrepareCallsCapabilities {
-            meta: Meta {
-                fee_token: Address::ZERO,
-                key_hash: admin_key.key_hash(),
-                nonce: None,
-                fee_payer: None,
-            },
+            meta: Meta { fee_token: Address::ZERO, nonce: None, fee_payer: None },
             authorize_keys: vec![],
             revoke_keys: vec![],
             pre_ops: vec![],
             pre_op: false,
         },
+        key: admin_key.to_call_key(),
     };
 
     // mint 2 NFTs

--- a/tests/e2e/cases/calls.rs
+++ b/tests/e2e/cases/calls.rs
@@ -60,12 +60,12 @@ async fn calls_with_upgraded_account() -> eyre::Result<()> {
                     meta: Meta {
                         fee_payer: None,
                         fee_token: env.fee_token,
-                        key_hash: signer.key_hash(),
                         nonce: Some(U256::from(tx_num + user_op_nonce)),
                     },
                     pre_ops: Vec::new(),
                     pre_op: false,
                 },
+                key: signer.to_call_key(),
             })
             .await?;
 

--- a/tests/e2e/cases/transactions.rs
+++ b/tests/e2e/cases/transactions.rs
@@ -104,16 +104,12 @@ impl MockAccount {
                 from: Some(address),
                 capabilities: PrepareCallsCapabilities {
                     authorize_keys: vec![],
-                    meta: Meta {
-                        fee_payer: None,
-                        fee_token: Address::ZERO,
-                        key_hash: key.key_hash(),
-                        nonce: None,
-                    },
+                    meta: Meta { fee_payer: None, fee_token: Address::ZERO, nonce: None },
                     pre_ops: vec![],
                     pre_op: false,
                     revoke_keys: vec![],
                 },
+                key: key.to_call_key(),
             })
             .await
             .unwrap();
@@ -141,16 +137,12 @@ impl MockAccount {
                 from: Some(self.address),
                 capabilities: PrepareCallsCapabilities {
                     authorize_keys: vec![],
-                    meta: Meta {
-                        fee_payer: None,
-                        fee_token: env.erc20,
-                        key_hash: self.key.key_hash(),
-                        nonce: None,
-                    },
+                    meta: Meta { fee_payer: None, fee_token: env.erc20, nonce: None },
                     pre_ops: vec![],
                     pre_op: false,
                     revoke_keys: vec![],
                 },
+                key: self.key.to_call_key(),
             })
             .await
             .unwrap();

--- a/tests/e2e/mod.rs
+++ b/tests/e2e/mod.rs
@@ -148,12 +148,12 @@ pub async fn prepare_calls(
                 meta: Meta {
                     fee_payer: None,
                     fee_token: tx.fee_token.unwrap_or(env.fee_token),
-                    key_hash: signer.key_hash(),
                     nonce: tx.nonce,
                 },
                 pre_ops,
                 pre_op,
             },
+            key: signer.to_call_key(),
         })
         .await;
 


### PR DESCRIPTION
Aligns more closely with [erc7836](https://github.com/lukasrosario/ERCs/blob/bcb32d649abf3b2a8939ea5ca4160e7949d4e1af/ERCS/erc-7836.md#request). This way, we also have the `prehash` hint to have a closer simulation

* removes `request.capabilities.key_hash`
* add `request.key`

```rust
/// Key that will be used to sign the call bundle.
pub struct CallKey {
    /// Type of key.
    pub key_type: KeyType,
    /// Public key in encoded form.
    pub public_key: Bytes,
    /// Whether the digest will be prehashed by the key.
    pub prehash: bool,
}
```