### PR TITLE
feat: add `feeSignature` capability

### DIFF
--- a/src/bin/stress.rs
+++ b/src/bin/stress.rs
@@ -111,7 +111,7 @@ impl StressAccount {
             let send_start = Instant::now();
             let bundle_id = relay_client
                 .send_prepared_calls(relay::types::rpc::SendPreparedCallsParameters {
-                    capabilities: None,
+                    capabilities: Default::default(),
                     context,
                     signature: KeySignature {
                         public_key: self.key.publicKey.clone(),

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -1077,8 +1077,7 @@ impl RelayApiServer for Relay {
         let op = &mut quote.ty_mut().op;
 
         // Fill UserOp with the fee payment signature (if exists).
-        op.paymentSignature =
-            capabilities.map_or(bytes!(""), |capabilities| capabilities.fee_signature);
+        op.paymentSignature = capabilities.fee_signature;
 
         // Fill UserOp with the user signature.
         let key_hash = signature.key_hash();

--- a/src/types/rpc/calls.rs
+++ b/src/types/rpc/calls.rs
@@ -186,11 +186,10 @@ impl PrepareCallsContext {
 }
 
 /// Capabilities for `wallet_sendPreparedCalls` request.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SendPreparedCallsCapabilities {
     /// Fee payment signature.
-    #[serde(default)]
     pub fee_signature: Bytes,
 }
 
@@ -198,7 +197,8 @@ pub struct SendPreparedCallsCapabilities {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SendPreparedCallsParameters {
     /// The [`SendPreparedCallsCapabilities`] of the prepared call bundle.
-    pub capabilities: Option<SendPreparedCallsCapabilities>,
+    #[serde(default)]
+    pub capabilities: SendPreparedCallsCapabilities,
     /// The [`PrepareCallsContext`] of the prepared call bundle.
     pub context: PrepareCallsContext,
     /// UserOp key signature.

--- a/tests/e2e/mod.rs
+++ b/tests/e2e/mod.rs
@@ -183,7 +183,7 @@ pub async fn send_prepared_calls(
     let response = env
         .relay_endpoint
         .send_prepared_calls(SendPreparedCallsParameters {
-            capabilities: None,
+            capabilities: Default::default(),
             context,
             signature: KeySignature {
                 public_key: signer.publicKey.clone(),


### PR DESCRIPTION
Adds a `feeSignature` capability so apps can pass sponsor signatures.