### PR TITLE
feat: `onramp_` scaffolding

### DIFF
--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -1,0 +1,7 @@
+//! RPC modules.
+
+mod onramp;
+mod relay;
+
+pub use onramp::*;
+pub use relay::*;

--- a/src/rpc/onramp.rs
+++ b/src/rpc/onramp.rs
@@ -1,0 +1,30 @@
+//! The `onramp_` namespace.
+
+use async_trait::async_trait;
+use jsonrpsee::{core::RpcResult, proc_macros::rpc};
+
+/// Ithaca `onramp_` RPC namespace.
+#[rpc(server, client, namespace = "onramp")]
+pub trait OnrampApi {
+    /// Temporary
+    #[method(name = "dummy")]
+    async fn dummy(&self) -> RpcResult<()>;
+}
+
+/// Ithaca `onramp_` RPC module.
+#[derive(Debug, Default)]
+pub struct Onramp;
+
+impl Onramp {
+    /// Create a new onramp RPC module.
+    pub fn new() -> Self {
+        Default::default()
+    }
+}
+
+#[async_trait]
+impl OnrampApiServer for Onramp {
+    async fn dummy(&self) -> RpcResult<()> {
+        Ok(())
+    }
+}

--- a/src/rpc/relay.rs
+++ b/src/rpc/relay.rs
@@ -1,3 +1,4 @@
+//! The `relay_` namespace.
 //! # Ithaca Relay RPC
 //!
 //! Implementations of a custom `relay_` namespace.


### PR DESCRIPTION
Creates the `onramp_` module with a dummy method. The dummy method is only needed to stop `jsonrpsee` from complaining

Ref #586