### PR TITLE
fix: flaky test

### DIFF
--- a/tests/e2e/cases/transactions.rs
+++ b/tests/e2e/cases/transactions.rs
@@ -186,7 +186,7 @@ async fn wait_for_tx_hash(events: &mut mpsc::UnboundedReceiver<TransactionStatus
 async fn assert_failed(events: mpsc::UnboundedReceiver<TransactionStatus>, error: &str) {
     match wait_for_tx(events).await {
         TransactionStatus::Failed(err) => {
-            assert!(err.to_string().contains(error), "tx failed with different error: {}", err);
+            assert!(err.to_string().contains(error), "tx failed with different error: {err}");
         }
         TransactionStatus::Confirmed(_) => panic!("expected failure"),
         _ => unreachable!(),


### PR DESCRIPTION
Closes #601 

We are no longer failing transactions if priority fee market is inflated as it's very likely that transaction will get confirmed even with a bit older priority fee.

So the priority fee branch here doesn't make sense anymore