### PR TITLE
fix: handle `prepareCalls` requests without a `nonce` correctly

### DIFF
--- a/src/types/account.rs
+++ b/src/types/account.rs
@@ -14,7 +14,9 @@ use alloy::{
         SignedAuthorization,
         constants::{EIP7702_CLEARED_DELEGATION, EIP7702_DELEGATION_DESIGNATOR},
     },
-    primitives::{Address, B256, Bytes, FixedBytes, Keccak256, U256, keccak256, map::HashMap},
+    primitives::{
+        Address, B256, Bytes, FixedBytes, Keccak256, U256, aliases::U192, keccak256, map::HashMap,
+    },
     providers::{MulticallError, Provider},
     rpc::types::{Authorization, TransactionRequest, state::StateOverride},
     sol,
@@ -24,6 +26,9 @@ use alloy::{
 };
 use serde::{Deserialize, Serialize};
 use tracing::debug;
+
+/// Default sequence key used on prepareCalls.
+pub const DEFAULT_SEQUENCE_KEY: U192 = uint!(0_U192);
 
 sol! {
     #[sol(rpc)]
@@ -369,7 +374,7 @@ impl<P: Provider> Account<P> {
     /// This gets the next nonce for sequence key `0`.
     pub async fn get_nonce(&self) -> TransportResult<U256> {
         self.delegation
-            .getNonce(uint!(0_U192))
+            .getNonce(DEFAULT_SEQUENCE_KEY)
             .call()
             .overrides(self.overrides.clone())
             .await

--- a/src/types/op.rs
+++ b/src/types/op.rs
@@ -131,9 +131,6 @@ sol! {
         /// This allows for more efficient safe forwarding to the EOA.
         bytes executionData;
         /// Per delegated EOA. Same logic as the `nonce` in UserOp.
-        ///
-        /// A nonce of `type(uint256).max` skips the check, incrementing,
-        /// and the emission of the {UserOpExecuted} event.
         uint256 nonce;
         /// The wrapped signature.
         ///
@@ -155,7 +152,7 @@ pub struct PartialUserOp {
     /// This allows for more efficient safe forwarding to the EOA.
     pub execution_data: Bytes,
     /// Per delegated EOA.
-    pub nonce: Option<U256>,
+    pub nonce: U256,
     /// Optional data for `initPREP` on the delegation.
     ///
     /// Excluded from signature.


### PR DESCRIPTION
our nonce fetching was not correct since:
* optional nonces are no longer supported
* if there are preops, the nonce should be fetched from the list first, before checking the chain. 

```
    /// Gets the nonce based on information from the request.
    ///
    /// If the request does not contain a nonce it will:
    /// * attempt to find a nonce with `DEFAULT_SEQUENCE_KEY` in the preops and increment it.
    /// * return 0 if there is a pending PREP account request.
    /// * check next available nonce with `DEFAULT_SEQUENCE_KEY` from chain.
```

