### PR TITLE
chore: make `key` optional on `PrepareCallsParameters`

### DIFF
--- a/src/bin/stress.rs
+++ b/src/bin/stress.rs
@@ -90,7 +90,7 @@ impl StressAccount {
                         pre_ops: vec![],
                         pre_op: false,
                     },
-                    key: self.key.to_call_key(),
+                    key: Some(self.key.to_call_key()),
                 })
                 .await
                 .expect("prepare calls failed");

--- a/src/error/op.rs
+++ b/src/error/op.rs
@@ -10,9 +10,12 @@ use thiserror::Error;
 /// Errors related to user ops.
 #[derive(Debug, Error)]
 pub enum UserOpError {
-    /// The userop could not be simulated.
+    /// The userop could not be simulated without a sender.
     #[error("user op creation requires a sender.")]
     MissingSender,
+    /// The userop could not be simulated without a key.
+    #[error("user op creation requires a signing key.")]
+    MissingKey,
     /// The userop could not be simulated.
     #[error("the op could not be simulated")]
     SimulationError,
@@ -43,7 +46,8 @@ impl From<UserOpError> for jsonrpsee::types::error::ErrorObject<'static> {
     fn from(err: UserOpError) -> Self {
         match err {
             UserOpError::SimulationError => internal_rpc(err.to_string()),
-            UserOpError::MissingSender
+            UserOpError::MissingKey
+            | UserOpError::MissingSender
             | UserOpError::UnallowedPreOpCalls
             | UserOpError::InvalidOpDigest { .. } => invalid_params(err.to_string()),
             UserOpError::OpRevert(err) => err.into(),

--- a/src/rpc/relay.rs
+++ b/src/rpc/relay.rs
@@ -917,7 +917,10 @@ impl RelayApiServer for Relay {
             (AssetDiffs(vec![]), PrepareCallsContext::with_preop(preop))
         } else {
             let Some(eoa) = request.from else { return Err(UserOpError::MissingSender.into()) };
-            let key_hash = request.key.key_hash();
+            let Some(request_key) = &request.key else {
+                return Err(UserOpError::MissingKey.into());
+            };
+            let key_hash = request_key.key_hash();
 
             // Find the key that authorizes this userop
             let Some(key) = self
@@ -940,7 +943,7 @@ impl RelayApiServer for Relay {
                             pre_ops: request.capabilities.pre_ops.clone(),
                         },
                         chain_id: request.chain_id,
-                        prehash: request.key.prehash,
+                        prehash: request_key.prehash,
                     },
                     request.capabilities.meta.fee_token,
                     maybe_prep.as_ref().map(|acc| acc.prep.signed_authorization.address),
@@ -978,7 +981,7 @@ impl RelayApiServer for Relay {
                 revoke_keys: request.capabilities.revoke_keys,
                 asset_diff,
             },
-            key: Some(request.key),
+            key: request.key,
         };
 
         Ok(response)

--- a/src/types/rpc/calls.rs
+++ b/src/types/rpc/calls.rs
@@ -67,8 +67,10 @@ pub struct PrepareCallsParameters {
     pub from: Option<Address>,
     /// Request capabilities.
     pub capabilities: PrepareCallsCapabilities,
-    /// Key that will be used to sign the call bundle.
-    pub key: CallKey,
+    /// Key that will be used to sign the call bundle. It can only be None, if we are handling a
+    /// preop.
+    #[serde(default)]
+    pub key: Option<CallKey>,
 }
 
 impl PrepareCallsParameters {

--- a/tests/e2e/cases/assets.rs
+++ b/tests/e2e/cases/assets.rs
@@ -72,7 +72,7 @@ async fn asset_diff() -> eyre::Result<()> {
             pre_ops: vec![],
             pre_op: false,
         },
-        key: admin_key.to_call_key(),
+        key: Some(admin_key.to_call_key()),
     };
 
     let prepare_calls = |calls: Vec<Call>| {
@@ -204,7 +204,7 @@ async fn asset_diff_has_uri() -> eyre::Result<()> {
             pre_ops: vec![],
             pre_op: false,
         },
-        key: admin_key.to_call_key(),
+        key: Some(admin_key.to_call_key()),
     };
 
     // mint 2 NFTs

--- a/tests/e2e/cases/calls.rs
+++ b/tests/e2e/cases/calls.rs
@@ -65,7 +65,7 @@ async fn calls_with_upgraded_account() -> eyre::Result<()> {
                     pre_ops: Vec::new(),
                     pre_op: false,
                 },
-                key: signer.to_call_key(),
+                key: Some(signer.to_call_key()),
             })
             .await?;
 

--- a/tests/e2e/cases/keys.rs
+++ b/tests/e2e/cases/keys.rs
@@ -202,7 +202,7 @@ async fn ensure_prehash_simulation() -> eyre::Result<()> {
                 pre_ops: vec![],
                 pre_op: false,
             },
-            key: call_key,
+            key: Some(call_key),
         })
         .await?;
 

--- a/tests/e2e/cases/simple.rs
+++ b/tests/e2e/cases/simple.rs
@@ -309,7 +309,7 @@ async fn empty_request_nonce() -> eyre::Result<()> {
                 pre_ops: vec![],
                 pre_op: true,
             },
-            key: admin_key.to_call_key(),
+            key: Some(admin_key.to_call_key()),
         })
         .await?;
 
@@ -337,7 +337,7 @@ async fn empty_request_nonce() -> eyre::Result<()> {
                 pre_ops: vec![preop],
                 pre_op: false,
             },
-            key: admin_key.to_call_key(),
+            key: Some(admin_key.to_call_key()),
         })
         .await?;
 
@@ -375,7 +375,7 @@ async fn single_sign_up_popup() -> eyre::Result<()> {
                 pre_ops: vec![],
                 pre_op: true,
             },
-            key: admin_key.to_call_key(),
+            key: None,
         })
         .await?;
 
@@ -405,7 +405,7 @@ async fn single_sign_up_popup() -> eyre::Result<()> {
                 pre_ops: vec![accountless_preop],
                 pre_op: false,
             },
-            key: session_key.to_call_key(),
+            key: Some(session_key.to_call_key()),
         })
         .await?;
 

--- a/tests/e2e/cases/transactions.rs
+++ b/tests/e2e/cases/transactions.rs
@@ -109,7 +109,7 @@ impl MockAccount {
                     pre_op: false,
                     revoke_keys: vec![],
                 },
-                key: key.to_call_key(),
+                key: Some(key.to_call_key()),
             })
             .await
             .unwrap();
@@ -142,7 +142,7 @@ impl MockAccount {
                     pre_op: false,
                     revoke_keys: vec![],
                 },
-                key: self.key.to_call_key(),
+                key: Some(self.key.to_call_key()),
             })
             .await
             .unwrap();

--- a/tests/e2e/mod.rs
+++ b/tests/e2e/mod.rs
@@ -152,7 +152,7 @@ pub async fn prepare_calls(
                 pre_ops,
                 pre_op,
             },
-            key: signer.to_call_key(),
+            key: Some(signer.to_call_key()),
         })
         .await;
 


### PR DESCRIPTION
keys are not used for preops, so they can be optional. 