### PR TITLE
feat: allow `upgradeProxyDelegaton` call on preops

### DIFF
--- a/src/error/op.rs
+++ b/src/error/op.rs
@@ -19,8 +19,8 @@ pub enum UserOpError {
     /// The userop could not be simulated.
     #[error("the op could not be simulated")]
     SimulationError,
-    /// The preop can only contain key management calls.
-    #[error("the preop can only contain key management calls.")]
+    /// The preop can only contain account management calls.
+    #[error("the preop can only contain account management calls.")]
     UnallowedPreOpCalls,
     /// The quote was signed for a different userop.
     #[error("invalid op digest, expected {expected}, got {got}")]

--- a/src/types/call.rs
+++ b/src/types/call.rs
@@ -9,7 +9,10 @@ use serde::{Deserialize, Serialize};
 
 use super::{
     AccountRegistry,
-    Delegation::{SpendPeriod, removeSpendLimitCall, setCanExecuteCall, setSpendLimitCall},
+    Delegation::{
+        SpendPeriod, removeSpendLimitCall, setCanExecuteCall, setSpendLimitCall,
+        upgradeProxyDelegationCall,
+    },
     IDelegation::{authorizeCall, revokeCall},
     Key, KeyID,
 };
@@ -119,10 +122,11 @@ impl Call {
 }
 
 /// All selectors allowed in preops.
-const WHITELISTED_SELECTORS: [[u8; 4]; 5] = [
+const WHITELISTED_SELECTORS: [[u8; 4]; 6] = [
     authorizeCall::SELECTOR,
     revokeCall::SELECTOR,
     setCanExecuteCall::SELECTOR,
     setSpendLimitCall::SELECTOR,
     removeSpendLimitCall::SELECTOR,
+    upgradeProxyDelegationCall::SELECTOR,
 ];


### PR DESCRIPTION
closes  https://github.com/ithacaxyz/relay/issues/532
on top of https://github.com/ithacaxyz/relay/pull/622

allows `upgradeProxyDelegation` to be called as a preop

