### PR TITLE
chore: log simulateV1 request on simulation failure

### DIFF
--- a/src/types/entrypoint.rs
+++ b/src/types/entrypoint.rs
@@ -213,7 +213,7 @@ impl<P: Provider> Entry<P> {
             .ok_or_else(|| TransportErrorKind::custom_str("could not simulate call"))?;
 
         if !result.status {
-            debug!(?result, "Unable to simulate user op.");
+            debug!(?result, ?simulate_block, "Unable to simulate user op.");
             return Err(UserOpError::op_revert(result.return_data).into());
         }
 


### PR DESCRIPTION
We've had 2 bugs today where it'd be useful to obtain an input for failing simulation which can later be traced to debug