### PR TITLE
chore: make preop nonces always random

### DIFF
--- a/tests/e2e/cases/simple.rs
+++ b/tests/e2e/cases/simple.rs
@@ -322,8 +322,6 @@ async fn empty_request_nonce() -> eyre::Result<()> {
     .abi_encode_packed()
     .into();
 
-    assert!(preop.nonce == uint!(1_U256));
-
     let response = env
         .relay_endpoint
         .prepare_calls(PrepareCallsParameters {
@@ -341,7 +339,7 @@ async fn empty_request_nonce() -> eyre::Result<()> {
         })
         .await?;
 
-    assert!(response.context.take_quote().unwrap().ty().op.nonce == uint!(2_U256));
+    assert!(response.context.take_quote().unwrap().ty().op.nonce == uint!(1_U256));
 
     Ok(())
 }


### PR DESCRIPTION
```
   /// Retrieves the appropriate nonce for the request, following this order:
    ///
    /// 1. If `capabilities.meta.nonce` is set, return it directly.
    /// 2. If this is a preop, generate a random sequence key without the multichain prefix and
    ///    return its 0th nonce.
    /// 3. If this is a userop and there are any previous preop entries with the
    ///    `DEFAULT_SEQUENCE_KEY`, take the highest nonce and increment it by 1.
    /// 4. If this is the first userop of a PREP account (`maybe_prep`), return 0.
    /// 5. If none of the above match, query for the next account nonce onchain (for
    ///    `DEFAULT_SEQUENCE_KEY`).
```