### PR TITLE
feat!: improve `registry.yaml` format 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,5 +37,5 @@ crates/testing/resources/**/cache/*
 .env
 
 # Relay configuration
-relay.toml
-registry.toml
+relay.yaml
+registry.yaml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4543,6 +4543,7 @@ dependencies = [
  "sqlx",
  "strum",
  "strum_macros",
+ "tempfile",
  "thiserror 2.0.12",
  "tokio",
  "tower",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,6 +100,7 @@ dotenvy = "0.15"
 itertools = "0.14"
 strum = "0.27"
 strum_macros = "0.27"
+tempfile = "3.20"
 
 [build-dependencies]
 vergen = { version = "9.0", features = ["build", "cargo", "emit_and_set"] }

--- a/src/types/coin.rs
+++ b/src/types/coin.rs
@@ -51,9 +51,9 @@ impl CoinKind {
         registry
             .iter()
             .find(|(entry_key, entry_coin)| {
-                entry_key.chain == chain && *entry_coin == self && entry_key.token_address.is_some()
+                entry_key.chain == chain && *entry_coin == self && entry_key.address.is_some()
             })
-            .map(|(key, _)| key.token_address.expect("qed"))
+            .map(|(key, _)| key.address.expect("qed"))
     }
 
     /// Whether this is ETH.
@@ -63,12 +63,12 @@ impl CoinKind {
 
     /// Get native [`CoinKind`] from [`Chain`].
     pub fn get_native(registry: &CoinRegistry, chain: ChainId) -> Option<Self> {
-        registry.get(&CoinRegistryKey { chain, token_address: None }).copied()
+        registry.get(&CoinRegistryKey { chain, address: None }).copied()
     }
 
     /// Get [`CoinKind`] from a [`Chain`] and [`Address`].
     pub fn get_token(registry: &CoinRegistry, chain: ChainId, address: Address) -> Option<Self> {
-        registry.get(&CoinRegistryKey { chain, token_address: Some(address) }).copied()
+        registry.get(&CoinRegistryKey { chain, address: Some(address) }).copied()
     }
 
     /// Returns the str identifier


### PR DESCRIPTION
closes https://github.com/ithacaxyz/relay/issues/637 

closes https://github.com/ithacaxyz/relay/issues/498

`serde_yaml` doesn't seem to be able to add indentation.

```yaml
911867:
- kind: ETH
- address: 0x238c8cd93ee9f8c7edf395548ef60c0d2e46665e
  kind: USDT
- address: 0x706aa5c8e5cc2c67da21ee220718f6f6b154e75c
  kind: USDT
1:
- address: 0xdac17f958d2ee523a2206206994597c13d831ec7
  kind: USDT
- address: 0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48
  kind: USDC
- kind: ETH
8453:
- kind: ETH
- address: 0x833589fcd6edb6e08f4c7c32d4f71b54bda02913
  kind: USDC
10:
- address: 0xdac17f958d2ee523a2206206994597c13d831ec7
  kind: USDT
- kind: ETH
```