### PR TITLE
feat: change default userop gas buffer to zero

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -12,7 +12,7 @@ pub const P256_GAS_BUFFER: U256 = uint!(10_000_U256);
 
 /// Extra buffer added to UserOp gas estimates to cover execution overhead
 /// and ensure sufficient gas is provided.
-pub const USER_OP_GAS_BUFFER: u64 = 25_000;
+pub const USER_OP_GAS_BUFFER: u64 = 0;
 
 /// The default poll interval used by the relay clients.
 pub const DEFAULT_POLL_INTERVAL: Duration = Duration::from_millis(300);

--- a/tests/e2e/environment.rs
+++ b/tests/e2e/environment.rs
@@ -268,7 +268,7 @@ impl Environment {
                 .with_delegation_proxy(delegation)
                 .with_account_registry(account_registry)
                 .with_simulator(simulator)
-                .with_user_op_gas_buffer(45_000) // todo: temp
+                .with_user_op_gas_buffer(0) // todo: temp
                 .with_tx_gas_buffer(75_000) // todo: temp
                 .with_transaction_service_config(config.transaction_service_config)
                 .with_database_url(database_url),


### PR DESCRIPTION
the remaining reason, we still had any useop gas buffer was for `prepareUpgradeAccount` & `upgradeAccount` afaict.

this PR uses a fake key on the simulation instead of the requested admin authorization key, so we maintain the same number of storage writes, and dont underestimate gas. 

Since we are using the `Delegation::Key` scheme instead of the EOA signature, we will end up slightly overestimating here, but that's fine.

traces (look at gUsed vs gas)

`simulateV1`:
`main`: https://paste.rs/0ETYw.txt  (gUsed: 211929, gCombined: 314723)
`branch`: https://paste.rs/Z3Xa2.txt  (gUsed: 255929, gCombined: 358735)

`actual tx`:
https://paste.rs/tvBSN.txt (gas: 243294, receipt.gas: 288570)

--

this doesn't enable lowering the tx gas buffer though
