### PR TITLE
chore: remove `preops` from `UpgradeAccountCapabilities`

### DIFF
--- a/src/rpc/relay.rs
+++ b/src/rpc/relay.rs
@@ -1096,7 +1096,7 @@ impl RelayApiServer for Relay {
                         nonce,
                         init_data: None,
                         payer: request.capabilities.fee_payer,
-                        pre_ops: request.capabilities.pre_ops,
+                        pre_ops: vec![],
                     },
                     chain_id: request.chain_id,
                     // signed by the eoa root key

--- a/src/types/rpc/account.rs
+++ b/src/types/rpc/account.rs
@@ -6,7 +6,7 @@ use super::{
 };
 use crate::{
     error::{AuthError, KeysError},
-    types::{Key, KeyHash, KeyHashWithID, KeyID, PREPAccount, PreOp},
+    types::{Key, KeyHash, KeyHashWithID, KeyID, PREPAccount},
 };
 use alloy::{
     eips::eip7702::SignedAuthorization,
@@ -149,9 +149,6 @@ pub struct UpgradeAccountCapabilities {
     /// Defaults to the native token.
     #[serde(default)]
     pub fee_token: Address,
-    /// Optional [`PreOp`] to execute before signature verification.
-    #[serde(default)]
-    pub pre_ops: Vec<PreOp>,
 }
 
 /// Request parameters for `wallet_prepareUpgradeAccount`.

--- a/tests/e2e/cases/calls.rs
+++ b/tests/e2e/cases/calls.rs
@@ -34,7 +34,7 @@ async fn calls_with_upgraded_account() -> eyre::Result<()> {
     .into_iter()
     .collect::<(Vec<_>, Vec<_>)>();
 
-    upgrade_account(&env, &keys, AuthKind::Auth, vec![]).await?;
+    upgrade_account(&env, &keys, AuthKind::Auth).await?;
 
     // Every key will sign a ERC20 transfer
     let erc20_transfer = Call {

--- a/tests/e2e/types.rs
+++ b/tests/e2e/types.rs
@@ -152,12 +152,10 @@ impl TxContext<'_> {
         env: &Environment,
         tx_num: usize,
     ) -> Result<Vec<Call>, eyre::Error> {
-        let pre_ops = build_pre_ops(env, &self.pre_ops, tx_num).await?;
         let (tx_hash, authorization) = upgrade_account(
             env,
             &self.authorization_keys(Some(env.eoa.address())).await?,
             self.auth.clone().expect("should have"),
-            pre_ops,
         )
         .await
         .map_or_else(|e| (Err(e), None), |(a, b)| (Ok(a), Some(b)));


### PR DESCRIPTION
It's not actually used or in the plans.