### PR TITLE
feat!: add `VersionedContract` and `VersionedContracts`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4536,6 +4536,7 @@ dependencies = [
  "rand 0.9.1",
  "reqwest",
  "schnellru",
+ "semver 1.0.26",
  "serde",
  "serde_json",
  "serde_repr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,6 +98,7 @@ alloy-primitives = { version = "1.1.0", features = ["rand"] }
 derive_more = { version = "2", features = ["debug"] }
 dotenvy = "0.15"
 itertools = "0.14"
+semver = "1.0.26"
 strum = "0.27"
 strum_macros = "0.27"
 tempfile = "3.20"

--- a/src/bin/stress.rs
+++ b/src/bin/stress.rs
@@ -183,7 +183,7 @@ impl StressTester {
                         .prepare_create_account(PrepareCreateAccountParameters {
                             capabilities: PrepareCreateAccountCapabilities {
                                 authorize_keys: vec![key.to_authorized(None).await?],
-                                delegation: caps.contracts.delegation_proxy,
+                                delegation: caps.contracts.delegation_proxy.address,
                             },
                             chain_id: args.chain_id.id(),
                         })

--- a/src/types/account.rs
+++ b/src/types/account.rs
@@ -176,6 +176,23 @@ sol! {
         /// Upgrades the implementation.
         function upgradeProxyDelegation(address newImplementation);
 
+        /// Returns the EIP712 domain of the delegation.
+        ///
+        /// See: https://eips.ethereum.org/EIPS/eip-5267
+        function eip712Domain()
+            public
+            view
+            virtual
+            returns (
+                bytes1 fields,
+                string memory name,
+                string memory version,
+                uint256 chainId,
+                address verifyingContract,
+                bytes32 salt,
+                uint256[] memory extensions
+            );
+
     }
 }
 
@@ -227,6 +244,18 @@ impl<P: Provider> Account<P> {
             delegation: DelegationInstance::new(address, provider),
             overrides: StateOverride::default(),
         }
+    }
+
+    /// Get the version of the account.
+    pub async fn version(&self) -> TransportResult<String> {
+        Ok(self
+            .delegation
+            .eip712Domain()
+            .call()
+            .overrides(self.overrides.clone())
+            .await
+            .map_err(TransportErrorKind::custom)?
+            .version)
     }
 
     /// Returns the address of the account.

--- a/src/types/contracts.rs
+++ b/src/types/contracts.rs
@@ -1,0 +1,112 @@
+use crate::{
+    config::RelayConfig,
+    error::RelayError,
+    types::{Account, DelegationProxy::DelegationProxyInstance, Entry},
+};
+use alloy::{primitives::Address, providers::Provider, transports::TransportErrorKind};
+use futures_util::future::try_join_all;
+use serde::{Deserialize, Serialize};
+use tokio::try_join;
+
+/// Contract address with optional version.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+pub struct VersionedContract {
+    /// Contract address.
+    pub address: Address,
+    /// Contract version.
+    #[serde(default)]
+    pub version: Option<String>,
+}
+
+impl VersionedContract {
+    /// Creates a [`VersionedContract`].
+    pub fn new(address: Address, version: String) -> Self {
+        Self { address, version: Some(version) }
+    }
+
+    /// Creates a [`VersionedContract`] without a version.
+    pub fn no_version(address: Address) -> Self {
+        Self { address, version: None }
+    }
+}
+
+/// Relay versioned contracts.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VersionedContracts {
+    /// Entrypoint.
+    pub entrypoint: VersionedContract,
+    /// The delegation implementation.
+    ///
+    /// This is directly fetched from the proxy.
+    pub delegation_implementation: VersionedContract,
+    /// Previously deployed entrypoints.
+    pub legacy_entrypoints: Vec<VersionedContract>,
+    /// Previously deployed delegation implementations.
+    pub legacy_delegations: Vec<VersionedContract>,
+    /// Delegation proxy.
+    pub delegation_proxy: VersionedContract,
+    /// Account registry.
+    pub account_registry: VersionedContract,
+    /// Simulator.
+    pub simulator: VersionedContract,
+}
+
+impl VersionedContracts {
+    /// Generates a [`VersionedContracts`] from [`RelayConfig`].
+    pub async fn new<P: Provider>(config: &RelayConfig, provider: &P) -> Result<Self, RelayError> {
+        let legacy_entrypoints =
+            try_join_all(config.legacy_entrypoints.iter().map(async |&address| {
+                Ok::<_, RelayError>(VersionedContract::new(
+                    address,
+                    Entry::new(address, provider).version().await?,
+                ))
+            }));
+
+        let legacy_delegations =
+            try_join_all(config.legacy_delegations.iter().map(async |&address| {
+                Ok(VersionedContract::new(
+                    address,
+                    Account::new(address, provider).version().await?,
+                ))
+            }));
+
+        let entrypoint = async {
+            Ok(VersionedContract::new(
+                config.entrypoint,
+                Entry::new(config.entrypoint, provider).version().await?,
+            ))
+        };
+
+        let delegation_implementation = async {
+            let delegation_implementation =
+                DelegationProxyInstance::new(config.delegation_proxy, provider)
+                    .implementation()
+                    .call()
+                    .await
+                    .map_err(TransportErrorKind::custom)?;
+
+            Ok(VersionedContract::new(
+                delegation_implementation,
+                Account::new(delegation_implementation, provider).version().await?,
+            ))
+        };
+
+        let (legacy_entrypoints, legacy_delegations, entrypoint, delegation_implementation) = try_join!(
+            legacy_entrypoints,
+            legacy_delegations,
+            entrypoint,
+            delegation_implementation
+        )?;
+
+        Ok(Self {
+            entrypoint,
+            delegation_implementation,
+            legacy_entrypoints,
+            legacy_delegations,
+            delegation_proxy: VersionedContract::no_version(config.delegation_proxy),
+            account_registry: VersionedContract::no_version(config.account_registry),
+            simulator: VersionedContract::no_version(config.simulator),
+        })
+    }
+}

--- a/src/types/entrypoint.rs
+++ b/src/types/entrypoint.rs
@@ -177,6 +177,11 @@ impl<P: Provider> Entry<P> {
         self.entrypoint.address()
     }
 
+    /// Get the version of the entrypoint.
+    pub async fn version(&self) -> TransportResult<String> {
+        Ok(self.eip712_domain(false).await?.version.unwrap_or_default().to_string())
+    }
+
     /// Sets overrides for all calls on this entrypoint.
     pub fn with_overrides(mut self, overrides: StateOverride) -> Self {
         self.overrides = overrides;

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -17,6 +17,9 @@ pub use coin::*;
 mod coin_registry;
 pub use coin_registry::*;
 
+mod contracts;
+pub use contracts::*;
+
 mod entrypoint;
 pub use entrypoint::*;
 

--- a/src/types/rpc/capabilities.rs
+++ b/src/types/rpc/capabilities.rs
@@ -1,4 +1,7 @@
-use crate::{config::QuoteConfig, types::FeeTokens};
+use crate::{
+    config::QuoteConfig,
+    types::{FeeTokens, VersionedContracts},
+};
 use alloy::primitives::Address;
 use serde::{Deserialize, Serialize};
 
@@ -7,27 +10,9 @@ use serde::{Deserialize, Serialize};
 #[serde(rename_all = "camelCase")]
 pub struct RelayCapabilities {
     /// The contracts of the relay.
-    pub contracts: RelayContracts,
+    pub contracts: VersionedContracts,
     /// The fee configuration of the relay.
     pub fees: RelayFees,
-}
-
-/// Relay contracts.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct RelayContracts {
-    /// The entrypoint address.
-    pub entrypoint: Address,
-    /// The delegation proxy address.
-    pub delegation_proxy: Address,
-    /// The delegation implementation address.
-    ///
-    /// This is directly fetched from the proxy.
-    pub delegation_implementation: Address,
-    /// The account registry address.
-    pub account_registry: Address,
-    /// The simulator address.
-    pub simulator: Address,
 }
 
 /// Relay fee settings.

--- a/tests/e2e/cases/account.rs
+++ b/tests/e2e/cases/account.rs
@@ -23,7 +23,8 @@ async fn register_and_unregister_id() -> eyre::Result<()> {
         .process(0, &env)
         .await?;
 
-    let account_registry = env.relay_endpoint.get_capabilities().await?.contracts.account_registry;
+    let account_registry =
+        env.relay_endpoint.get_capabilities().await?.contracts.account_registry.address;
 
     if let EoaKind::Prep(ref account) = env.eoa {
         let account = account.clone().unwrap();
@@ -172,7 +173,7 @@ async fn ensure_delegation_implementation() -> eyre::Result<()> {
         .relay_endpoint
         .get_accounts(GetAccountsParameters { id: admin_key.id(), chain_id: env.chain_id })
         .await?;
-    assert_eq!(accounts[0].delegation, caps.contracts.delegation_implementation);
+    assert_eq!(accounts[0].delegation, caps.contracts.delegation_implementation.address);
 
     // Deploy on chain
     TxContext { expected: ExpectedOutcome::Pass, key: Some(&admin_key), ..Default::default() }
@@ -184,7 +185,7 @@ async fn ensure_delegation_implementation() -> eyre::Result<()> {
         .relay_endpoint
         .get_accounts(GetAccountsParameters { id: admin_key.id(), chain_id: env.chain_id })
         .await?;
-    assert_eq!(accounts[0].delegation, caps.contracts.delegation_implementation);
+    assert_eq!(accounts[0].delegation, caps.contracts.delegation_implementation.address);
 
     Ok(())
 }

--- a/tests/e2e/cases/cli.rs
+++ b/tests/e2e/cases/cli.rs
@@ -25,7 +25,7 @@ async fn respawn_cli() -> eyre::Result<()> {
                 port: 0,
                 metrics_port: 0,
                 max_connections: Default::default(),
-                entrypoint: Default::default(),
+                entrypoint: Some(env.entrypoint),
                 delegation_proxy: Some(env.delegation),
                 account_registry: Default::default(),
                 simulator: Default::default(),

--- a/tests/e2e/cases/delegation.rs
+++ b/tests/e2e/cases/delegation.rs
@@ -36,9 +36,10 @@ async fn catch_invalid_delegation() -> eyre::Result<()> {
             .await?;
     }
 
-    let expected_proxy_code = env.provider.get_code_at(caps.contracts.delegation_proxy).await?;
+    let expected_proxy_code =
+        env.provider.get_code_at(caps.contracts.delegation_proxy.address).await?;
     let expected_impl_code =
-        env.provider.get_code_at(caps.contracts.delegation_implementation).await?;
+        env.provider.get_code_at(caps.contracts.delegation_implementation.address).await?;
     let expected_eoa_code = env.provider.get_code_at(env.eoa.address()).await?;
 
     let another_impl = Address::random();
@@ -62,7 +63,7 @@ async fn catch_invalid_delegation() -> eyre::Result<()> {
 
     assert!(
         good_quote.context.quote().unwrap().ty().op.supportedDelegationImplementation
-            == caps.contracts.delegation_implementation
+            == caps.contracts.delegation_implementation.address
     );
 
     let signed_payload = admin_key.sign_payload_hash(good_quote.digest).await?;
@@ -145,7 +146,7 @@ async fn catch_invalid_delegation() -> eyre::Result<()> {
     {
         let mut code = expected_proxy_code.to_vec();
         code[2] = code[2].wrapping_add(1);
-        env.provider.anvil_set_code(caps.contracts.delegation_proxy, code.into()).await?;
+        env.provider.anvil_set_code(caps.contracts.delegation_proxy.address, code.into()).await?;
 
         assert!(
             env.relay_endpoint
@@ -170,7 +171,9 @@ async fn catch_invalid_delegation() -> eyre::Result<()> {
             .is_failed()
         );
 
-        env.provider.anvil_set_code(caps.contracts.delegation_proxy, expected_proxy_code).await?;
+        env.provider
+            .anvil_set_code(caps.contracts.delegation_proxy.address, expected_proxy_code)
+            .await?;
     }
 
     // Upgrade implementation to another one and expect it to fail.
@@ -204,7 +207,7 @@ async fn catch_invalid_delegation() -> eyre::Result<()> {
 
     // Upgrade implementation to original and expect it to succeed sending the userop.
     {
-        upgrade_delegation(&env, caps.contracts.delegation_implementation).await;
+        upgrade_delegation(&env, caps.contracts.delegation_implementation.address).await;
 
         assert!(
             await_calls_status(
@@ -253,7 +256,7 @@ async fn upgrade_delegation_with_preop() -> eyre::Result<()> {
                 to: env.eoa.address(),
                 value: U256::ZERO,
                 data: Delegation::upgradeProxyDelegationCall {
-                    newImplementation: caps.contracts.delegation_implementation,
+                    newImplementation: caps.contracts.delegation_implementation.address,
                 }
                 .abi_encode()
                 .into(),

--- a/tests/e2e/cases/mod.rs
+++ b/tests/e2e/cases/mod.rs
@@ -11,6 +11,7 @@ mod paymaster;
 mod porto;
 mod prep;
 pub use prep::prep_account;
+mod relay;
 mod simple;
 mod upgrade;
 pub use upgrade::upgrade_account;

--- a/tests/e2e/cases/relay.rs
+++ b/tests/e2e/cases/relay.rs
@@ -1,0 +1,16 @@
+use crate::e2e::environment::Environment;
+use relay::rpc::RelayApiClient;
+use semver::{self, Version};
+
+#[tokio::test]
+async fn versioned_contracts() -> eyre::Result<()> {
+    let env = Environment::setup_with_prep().await?;
+
+    let capabilities = env.relay_endpoint.get_capabilities().await?;
+
+    Version::parse(capabilities.contracts.entrypoint.version.as_ref().unwrap()).unwrap();
+    Version::parse(capabilities.contracts.delegation_implementation.version.as_ref().unwrap())
+        .unwrap();
+
+    Ok(())
+}


### PR DESCRIPTION
closes https://github.com/ithacaxyz/relay/issues/448

* Moves contracts into `VersionedContracts` (in `RelayInner` and `RelayCapabilities`).
* Each contract is now a `VersionedContract` (address and optional version).
* breaking api for `wallet_getCapabilities` contracts field. example:
```json
...
    "contracts": {
      "entrypoint": {
        "address": "0x2e71297e895fd480019810605360cd09dbb8783b",
        "version": "0.1.2"
      },
      "delegationImplementation": {
        "address": "0x5c4fd1f648a89802b7fcd0bced8a35567d99cf15",
        "version": "0.1.2"
      },
      "legacyEntrypoints": [],
      "legacyDelegations": [],
      "delegationProxy": {
        "address": "0xc49cc88a576cf77053ba11b1c3a3011b42da0f34",
        "version": null
      },
      "accountRegistry": {
        "address": "0x623b5b44647871268d481d2930f60d5d7f37a1fe",
        "version": null
      },
      "simulator": {
        "address": "0x45b65d48e60a9414872ecd092ddf5b37c6bf4d06",
        "version": null
      }
    },
...
```