### PR TITLE
fix!: replace `I512` with `DiffDirection & U256` on asset diffs

### DIFF
--- a/src/types/entrypoint.rs
+++ b/src/types/entrypoint.rs
@@ -13,7 +13,7 @@ use alloy::{
 };
 use tracing::debug;
 
-use super::{KeyType, SimulationResult, Simulator::SimulatorInstance};
+use super::{Asset, KeyType, SimulationResult, Simulator::SimulatorInstance};
 use crate::{
     asset::AssetInfoServiceHandle,
     constants::P256_GAS_BUFFER,
@@ -255,9 +255,11 @@ impl<P: Provider> Entry<P> {
 
         // Remove the fee from the asset diff payer as to not confuse the user.
         let simulated_payment = op.prePaymentAmount + payment_per_gas * simulation_result.gCombined;
+        let payment_token =
+            if op.paymentToken.is_zero() { Asset::Native } else { Asset::Token(op.paymentToken) };
         let payer = if op.payer.is_zero() { op.eoa } else { op.payer };
         if op.payer == op.eoa || op.payer.is_zero() {
-            asset_diffs.remove_payer_fee(payer, op.paymentToken, simulated_payment);
+            asset_diffs.remove_payer_fee(payer, payment_token, simulated_payment);
         }
 
         Ok((asset_diffs, simulation_result))

--- a/tests/e2e/cases/simple.rs
+++ b/tests/e2e/cases/simple.rs
@@ -17,11 +17,11 @@ use relay::{
 
 #[tokio::test(flavor = "multi_thread")]
 async fn auth_then_erc20_transfer() -> Result<()> {
-    for key_type in [KeyType::Secp256k1, KeyType::WebAuthnP256] {
+    for key_type in [KeyType::WebAuthnP256] {
         let key = KeyWith712Signer::random_admin(key_type)?.unwrap();
 
         // The first TX will bundle the prep/upgrade calls
-        run_e2e(|env| {
+        run_e2e_prep_erc20(|env| {
             let to = Address::random();
             let transfer_amount = U256::from(10);
             vec![
@@ -184,10 +184,10 @@ async fn native_transfer() -> Result<()> {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn spend_limits_bundled() -> Result<()> {
-    let key1 = KeyWith712Signer::random_admin(KeyType::WebAuthnP256)?.unwrap();
+    let key1 = KeyWith712Signer::random_admin(KeyType::Secp256k1)?.unwrap();
     let session_key = KeyWith712Signer::random_session(KeyType::P256)?.unwrap();
 
-    run_e2e(|env| {
+    run_e2e_prep_erc20(|env| {
         vec![
             TxContext {
                 expected: ExpectedOutcome::Pass,
@@ -417,7 +417,7 @@ async fn single_sign_up_popup() -> eyre::Result<()> {
 
     // Wait for bundle to not be pending.
     let status = await_calls_status(&env, bundle_id).await?;
-    assert!(status.status.is_final());
+    assert!(status.status.is_confirmed());
 
     Ok(())
 }


### PR DESCRIPTION
closes https://github.com/ithacaxyz/relay/issues/675

A erc721 token diff with id `0` cannot be represented by a signed int (obv...)

* `I512` replaced with `DiffDirection & U256`
* breaking api: asset diffs instead of returning the `I512` value now return:
```rust
    /// Value.
    pub value: U256,
    /// Incoming or outgoing direction.
    pub direction: DiffDirection, // "incoming" or "outgoing"
```