### PR TITLE
feat: always try re-submitting transactions

### DIFF
--- a/src/transactions/signer.rs
+++ b/src/transactions/signer.rs
@@ -447,7 +447,7 @@ impl Signer {
     }
 
     /// Awaits the given [`PendingTransaction`] and watches it for status updates.
-    #[instrument(skip_all)]
+    #[instrument(skip_all, fields(tx_id = %tx.tx.id))]
     async fn watch_transaction(&self, mut tx: PendingTransaction) -> Result<(), SignerError> {
         Span::current().add_link(tx.tx.trace_context.span().span_context().clone());
 


### PR DESCRIPTION
The `get_transaction_by_hash` check does not really make sense in scope of OP as transaction might be in our own pool but dropped by sequencer. This PR changes logic to always assume that transaction was dropped and try to re-submit it