### PR TITLE
feat: add metric for total tx wait time

### DIFF
--- a/.sqlx/query-0e7a3fa8802afa71128f8195407a728fe5f09491fbcc77929268ce4bbc428055.json
+++ b/.sqlx/query-0e7a3fa8802afa71128f8195407a728fe5f09491fbcc77929268ce4bbc428055.json
@@ -30,7 +30,7 @@
       },
       {
         "ordinal": 5,
-        "name": "received_at",
+        "name": "sent_at",
         "type_info": "Timestamp"
       }
     ],

--- a/.sqlx/query-d918ed5091140ccf09ee3efbb18c9a23846361a55fc785d012a2310bfedacaeb.json
+++ b/.sqlx/query-d918ed5091140ccf09ee3efbb18c9a23846361a55fc785d012a2310bfedacaeb.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "insert into pending_txs (chain_id, sender, tx_id, tx, envelopes, received_at) values ($1, $2, $3, $4, $5, $6)",
+  "query": "insert into pending_txs (chain_id, sender, tx_id, tx, envelopes, sent_at) values ($1, $2, $3, $4, $5, $6)",
   "describe": {
     "columns": [],
     "parameters": {
@@ -15,5 +15,5 @@
     },
     "nullable": []
   },
-  "hash": "a5040c20570a8d55d35c0decbd6a0750ee6226748686bce86db701f22b1bea82"
+  "hash": "d918ed5091140ccf09ee3efbb18c9a23846361a55fc785d012a2310bfedacaeb"
 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ alloy-chains = "0.2"
 async-trait = "0.1"
 base64 = "0.22"
 clap = { version = "4", features = ["derive", "env"] }
-chrono = "0.4"
+chrono = { version = "0.4", features = ["serde"] }
 dashmap = "6.1.0"
 eyre = "0.6.12"
 futures-util = "0.3"

--- a/migrations/0010_sent_at.sql
+++ b/migrations/0010_sent_at.sql
@@ -1,0 +1,1 @@
+alter table pending_txs rename column received_at to sent_at;

--- a/src/transactions/metrics.rs
+++ b/src/transactions/metrics.rs
@@ -35,6 +35,8 @@ pub struct TransactionServiceMetrics {
     pub external_confirmations: Counter,
     /// Number of transaction confirmations received from local node provider.
     pub local_confirmations: Counter,
+    /// TOtal time transaction took to land on chain, including time in queue.
+    pub total_wait_time: Histogram,
 }
 
 /// Metrics of an individual signer, should be labeled with the signer address and chain ID.

--- a/src/transactions/signer.rs
+++ b/src/transactions/signer.rs
@@ -273,8 +273,11 @@ impl Signer {
 
         self.metrics
             .confirmation_time
-            .record(Utc::now().signed_duration_since(tx.received_at).num_milliseconds() as f64);
+            .record(Utc::now().signed_duration_since(tx.sent_at).num_milliseconds() as f64);
         self.metrics.pending.decrement(1);
+        self.metrics
+            .total_wait_time
+            .record(tx.tx.received_at.signed_duration_since(Utc::now()).num_milliseconds() as f64);
 
         // Spawn a task to record metrics.
         let this = self.clone();
@@ -530,7 +533,7 @@ impl Signer {
                 tx,
                 sent: vec![signed.clone()],
                 signer: self.address(),
-                received_at: Utc::now(),
+                sent_at: Utc::now(),
             };
             self.storage.replace_queued_tx_with_pending(&tx).await?;
 

--- a/src/transactions/transaction.rs
+++ b/src/transactions/transaction.rs
@@ -31,12 +31,20 @@ pub struct RelayTransaction {
     /// Trace context for the transaction.
     #[serde(with = "crate::serde::trace_context", default)]
     pub trace_context: Context,
+    /// Time at which we've received this transaction.
+    pub received_at: DateTime<Utc>,
 }
 
 impl RelayTransaction {
     /// Create a new [`RelayTransaction`].
     pub fn new(quote: SignedQuote, authorization: Option<SignedAuthorization>) -> Self {
-        Self { id: TxId(B256::random()), quote, authorization, trace_context: Context::current() }
+        Self {
+            id: TxId(B256::random()),
+            quote,
+            authorization,
+            trace_context: Context::current(),
+            received_at: Utc::now(),
+        }
     }
 
     /// Builds a [`TypedTransaction`] for this quote given a nonce.
@@ -151,7 +159,7 @@ pub struct PendingTransaction {
     /// Signer that signed the transaction.
     pub signer: Address,
     /// Time at which we've received this transaction.
-    pub received_at: DateTime<Utc>,
+    pub sent_at: DateTime<Utc>,
 }
 
 impl PendingTransaction {


### PR DESCRIPTION
Added field `received_at` field and a metric for total time we spent on landing the transaction 