### PR TITLE
fix: don't fail transaction on resend failure

### DIFF
--- a/src/transactions/signer.rs
+++ b/src/transactions/signer.rs
@@ -439,7 +439,6 @@ impl Signer {
                 {
                     if !err.is_already_known() {
                         debug!(%err, tx_hash=%best_tx.tx_hash(), "failed to resubmit transaction");
-                        return Err(err.into());
                     }
                 }
             }


### PR DESCRIPTION
Forgot to add this in #693, we don't want to fail transactions on such errors