### PR TITLE
feat: add pg migration test

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -90,11 +90,58 @@ jobs:
             -E "kind(lib) | kind(bin) | kind(proc-macro) | kind(test)" \
             --no-tests=warn
 
+  test-migrations:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+          fetch-depth: 0
+
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+
+      - uses: taiki-e/install-action@nextest
+
+      - name: Set database URL
+        run: |
+          echo "DATABASE_URL=postgres://postgres:postgres@localhost:5432/postgres" >> $GITHUB_ENV
+          echo "SQLX_OFFLINE=true" >> $GITHUB_ENV
+
+      # Write to DB with base branch
+      - name: Write DB
+        run: |
+          git worktree add ../base ${{ github.event.pull_request.base.sha }}
+          (
+            cd ../base
+            cargo test -p relay --test tests -- storage::roundtrip::write --exact --ignored
+          )
+
+      # Read from DB with PR branch
+      - name: Read DB
+        run: cargo test -p relay --test tests -- storage::roundtrip::read --exact --ignored
+
   unit-success:
     name: unit success
     runs-on: ubuntu-latest
     if: always()
-    needs: [test]
+    needs: [test, test-migrations]
     timeout-minutes: 30
     steps:
       - name: Decide whether the needed jobs succeeded or failed

--- a/tests/e2e/mod.rs
+++ b/tests/e2e/mod.rs
@@ -2,7 +2,7 @@
 
 mod cases;
 
-mod common_calls;
+pub mod common_calls;
 
 mod config;
 use config::{AccountConfig, PaymentConfig, TestConfig};

--- a/tests/storage/mod.rs
+++ b/tests/storage/mod.rs
@@ -1,0 +1,3 @@
+//! Relay storage tests
+
+mod roundtrip;

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,3 +1,4 @@
 //! Relay tests
 
 mod e2e;
+mod storage;


### PR DESCRIPTION
closes #697

During the rename release we missed a few pg migrations and the new version couldn’t deserialize existing old data.

```rust
//! Storage roundtrip compatibility tests.
//!
//! CI safeguard:
//! 1. The **base** branch should run `storage::roundtrip::write`, seeding a fresh Postgres database with
//!    rows produced by the OLD code.
//! 2. The PR branch should run `storage::roundtrip::read`, which must successfully deserialize those same
//!    rows with the NEW code.
//!
//! If any migration is missing, the read step fails.

```


fail case example (https://github.com/ithacaxyz/relay/pull/706) 
https://github.com/ithacaxyz/relay/actions/runs/15193051057/job/42730451789?pr=706