### PR TITLE
fix: correctly calculate gas values

### DIFF
--- a/src/transactions/transaction.rs
+++ b/src/transactions/transaction.rs
@@ -57,7 +57,7 @@ impl RelayTransaction {
         let mut intent = quote.intent.clone();
 
         let payment_amount = (quote.extra_payment
-            + (intent.combinedGas
+            + (U256::from(gas_limit)
                 * U256::from(fees.max_fee_per_gas)
                 * U256::from(10u128.pow(quote.payment_token_decimals as u32)))
             .div_ceil(quote.eth_price))

--- a/src/types/simulator.rs
+++ b/src/types/simulator.rs
@@ -1,3 +1,4 @@
+use crate::config::QuoteConfig;
 use alloy::sol;
 use serde::{Deserialize, Serialize};
 
@@ -44,7 +45,12 @@ impl GasEstimate {
     /// function, plus any extra buffer.
     ///
     /// The recommended transaction gas is calculated according to the contracts recommendation: [https://github.com/ithacaxyz/account/blob/feffa280d5de487223e43a69126f5b6b3d99a10a/test/SimulateExecute.t.sol#L205-L206]
-    pub fn from_combined_gas(combined_gas: u64, tx_gas_buffer: u64) -> Self {
-        Self { tx: (((combined_gas + 110_000) * 64) / 63) + tx_gas_buffer, intent: combined_gas }
+    pub fn from_combined_gas(
+        combined_gas: u64,
+        intrinsic_gas: u64,
+        quote_config: &QuoteConfig,
+    ) -> Self {
+        let intent = combined_gas + quote_config.intent_buffer();
+        Self { tx: (intent + 110_000) * 64 / 63 + intrinsic_gas + quote_config.tx_buffer(), intent }
     }
 }


### PR DESCRIPTION
1. Right now intrinsic gas is included as part of `combinedGas` which is wrong as it's charged before the userop execution. With this PR intrinsic gas is handled separately and is only added separately to transaction gas to avoid it affecting the 63/64th condition.
2. Right now we were using `combinedGas * paymentPerGas` to calculate userop payment, now we're using `txGas * paymentPerGas`

ref https://ithacaxyz.slack.com/archives/C07U1UBTN9H/p1748270801881289