### PR TITLE
fix: never stop attempting to reconnect

### DIFF
--- a/src/transactions/service.rs
+++ b/src/transactions/service.rs
@@ -10,6 +10,7 @@ use crate::{
     signers::DynSigner,
     spawn::RETRY_LAYER,
     storage::{RelayStorage, StorageApi},
+    transport::create_transport,
 };
 use alloy::{
     primitives::Address,
@@ -119,10 +120,10 @@ impl TransactionService {
 
         let external_provider =
             if let Some(endpoint) = config.public_node_endpoints.get(&Chain::from_id(chain_id)) {
+                let (transport, is_local) = create_transport(endpoint).await?;
                 let client = ClientBuilder::default()
                     .layer(RETRY_LAYER)
-                    .connect(endpoint.as_str())
-                    .await?
+                    .transport(transport, is_local)
                     .with_poll_interval(DEFAULT_POLL_INTERVAL);
                 Some(ProviderBuilder::new().connect_client(client).erased())
             } else {


### PR DESCRIPTION
Right now if node is going down and we have a ws connection to it, we will fallback to default alloy behavior of retrying 10 times with 3s interval. This is not great and means that after 30s downtime our provider will become useless causing all relay requests/tasks to fail.

This PR changes transport configuration so that it never stops retrying to reconnect, thus making sure that as soon as node is back up we will reconnect