### PR TITLE
chore(rpc)!: replace `relay_` namespace with `wallet_`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2487,7 +2487,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
- "tonic 0.13.1",
+ "tonic",
  "tower",
  "tower-layer",
  "tower-util",
@@ -3832,20 +3832,6 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "opentelemetry"
-version = "0.29.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e87237e2775f74896f9ad219d26a2081751187eb7c9f5c58dde20a23b95d16c"
-dependencies = [
- "futures-core",
- "futures-sink",
- "js-sys",
- "pin-project-lite",
- "thiserror 2.0.12",
- "tracing",
-]
-
-[[package]]
-name = "opentelemetry"
 version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aaf416e4cb72756655126f7dd7bb0af49c674f4c1b9903e80c009e0c37e552e6"
@@ -3860,30 +3846,28 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-http"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46d7ab32b827b5b495bd90fa95a6cb65ccc293555dcc3199ae2937d2d237c8ed"
+checksum = "50f6639e842a97dbea8886e3439710ae463120091e2e064518ba8e716e6ac36d"
 dependencies = [
  "async-trait",
  "bytes",
  "http 1.3.1",
- "opentelemetry 0.29.1",
+ "opentelemetry",
  "reqwest",
- "tracing",
 ]
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d899720fe06916ccba71c01d04ecd77312734e2de3467fd30d9d580c8ce85656"
+checksum = "dbee664a43e07615731afc539ca60c6d9f1a9425e25ca09c57bc36c87c55852b"
 dependencies = [
- "futures-core",
  "http 1.3.1",
- "opentelemetry 0.29.1",
+ "opentelemetry",
  "opentelemetry-http",
  "opentelemetry-proto",
- "opentelemetry_sdk 0.29.0",
+ "opentelemetry_sdk",
  "prost",
  "reqwest",
  "thiserror 2.0.12",
@@ -3892,14 +3876,14 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c40da242381435e18570d5b9d50aca2a4f4f4d8e146231adb4e7768023309b3"
+checksum = "2e046fd7660710fe5a05e8748e70d9058dc15c94ba914e7c4faa7c728f0e8ddc"
 dependencies = [
- "opentelemetry 0.29.1",
- "opentelemetry_sdk 0.29.0",
+ "opentelemetry",
+ "opentelemetry_sdk",
  "prost",
- "tonic 0.12.3",
+ "tonic",
 ]
 
 [[package]]
@@ -3909,27 +3893,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "447191061af41c3943e082ea359ab8b64ff27d6d34d30d327df309ddef1eef6f"
 dependencies = [
  "chrono",
- "opentelemetry 0.30.0",
- "opentelemetry_sdk 0.30.0",
-]
-
-[[package]]
-name = "opentelemetry_sdk"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afdefb21d1d47394abc1ba6c57363ab141be19e27cc70d0e422b7f303e4d290b"
-dependencies = [
- "futures-channel",
- "futures-executor",
- "futures-util",
- "glob",
- "opentelemetry 0.29.1",
- "percent-encoding",
- "rand 0.9.1",
- "serde_json",
- "thiserror 2.0.12",
- "tokio",
- "tokio-stream",
+ "opentelemetry",
+ "opentelemetry_sdk",
 ]
 
 [[package]]
@@ -3941,11 +3906,13 @@ dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
- "opentelemetry 0.30.0",
+ "opentelemetry",
  "percent-encoding",
  "rand 0.9.1",
  "serde_json",
  "thiserror 2.0.12",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]
@@ -4591,10 +4558,10 @@ dependencies = [
  "metrics",
  "metrics-derive",
  "metrics-exporter-prometheus",
- "opentelemetry 0.29.1",
+ "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry-stdout",
- "opentelemetry_sdk 0.29.0",
+ "opentelemetry_sdk",
  "p256",
  "rand 0.9.1",
  "reqwest",
@@ -5911,27 +5878,6 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
-dependencies = [
- "async-trait",
- "base64 0.22.1",
- "bytes",
- "http 1.3.1",
- "http-body 1.0.1",
- "http-body-util",
- "percent-encoding",
- "pin-project 1.1.10",
- "prost",
- "tokio-stream",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tonic"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e581ba15a835f4d9ea06c55ab1bd4dce26fc53752c69a04aac00703bfb49ba9"
@@ -6076,14 +6022,14 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd8e764bd6f5813fd8bebc3117875190c5b0415be8f7f8059bffb6ecd979c444"
+checksum = "ddcf5959f39507d0d04d6413119c04f33b623f4f951ebcbdddddfad2d0623a9c"
 dependencies = [
  "js-sys",
  "once_cell",
- "opentelemetry 0.29.1",
- "opentelemetry_sdk 0.29.0",
+ "opentelemetry",
+ "opentelemetry_sdk",
  "smallvec",
  "tracing",
  "tracing-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,10 +51,10 @@ http-body = "1"
 jsonrpsee = { version = "0.25", features = ["server", "client", "macros"] }
 metrics = "0.24.2"
 metrics-exporter-prometheus = "0.17"
-opentelemetry = { version = "0.29.1", features = ["trace"] }
-opentelemetry-otlp = { version = "0.29.0" }
+opentelemetry = { version = "0.30.0", features = ["trace"] }
+opentelemetry-otlp = { version = "0.30.0" }
 opentelemetry-stdout = { version = "0.30.0", features = ["trace"] }
-opentelemetry_sdk = { version = "0.29.0", default-features = false, features = [
+opentelemetry_sdk = { version = "0.30.0", default-features = false, features = [
     "trace",
     "rt-tokio",
 ] }
@@ -70,7 +70,7 @@ tower = "0.5"
 tower-http = { version = "0.6", features = ["cors"] }
 tracing = "0.1.0"
 tracing-futures = { version = "0.2.5", features = ["std-future"] }
-tracing-opentelemetry = "0.30.0"
+tracing-opentelemetry = "0.31.0"
 tracing-subscriber = { version = "0.3.19", features = [
     "fmt",
     "std",

--- a/src/rpc/relay.rs
+++ b/src/rpc/relay.rs
@@ -81,65 +81,65 @@ use crate::{
 };
 
 /// Ithaca `relay_` RPC namespace.
-#[rpc(server, client, namespace = "relay")]
+#[rpc(server, client, namespace = "wallet")]
 pub trait RelayApi {
     /// Checks the health of the relay and returns its version.
     #[method(name = "health", aliases = ["health"])]
     async fn health(&self) -> RpcResult<String>;
 
     /// Get capabilities of the relay, which are different sets of configuration values.
-    #[method(name = "getCapabilities", aliases = ["wallet_getCapabilities"])]
+    #[method(name = "getCapabilities")]
     async fn get_capabilities(&self, chains: Vec<ChainId>) -> RpcResult<RelayCapabilities>;
 
     /// Prepares an account for the user.
-    #[method(name = "prepareCreateAccount", aliases = ["wallet_prepareCreateAccount"])]
+    #[method(name = "prepareCreateAccount")]
     async fn prepare_create_account(
         &self,
         parameters: PrepareCreateAccountParameters,
     ) -> RpcResult<PrepareCreateAccountResponse>;
 
     /// Initialize an account.
-    #[method(name = "createAccount", aliases = ["wallet_createAccount"])]
+    #[method(name = "createAccount")]
     async fn create_account(
         &self,
         parameters: CreateAccountParameters,
     ) -> RpcResult<Vec<KeyHashWithID>>;
 
     /// Get all accounts from an ID.
-    #[method(name = "getAccounts", aliases = ["wallet_getAccounts"])]
+    #[method(name = "getAccounts")]
     async fn get_accounts(
         &self,
         parameters: GetAccountsParameters,
     ) -> RpcResult<Vec<AccountResponse>>;
 
     /// Get all keys for an account.
-    #[method(name = "getKeys", aliases = ["wallet_getKeys"])]
+    #[method(name = "getKeys")]
     async fn get_keys(&self, parameters: GetKeysParameters)
     -> RpcResult<Vec<AuthorizeKeyResponse>>;
 
     /// Prepares a call bundle for a user.
-    #[method(name = "prepareCalls", aliases = ["wallet_prepareCalls"])]
+    #[method(name = "prepareCalls")]
     async fn prepare_calls(
         &self,
         parameters: PrepareCallsParameters,
     ) -> RpcResult<PrepareCallsResponse>;
 
     /// Prepares an EOA to be upgraded.
-    #[method(name = "prepareUpgradeAccount", aliases = ["wallet_prepareUpgradeAccount"])]
+    #[method(name = "prepareUpgradeAccount")]
     async fn prepare_upgrade_account(
         &self,
         parameters: PrepareUpgradeAccountParameters,
     ) -> RpcResult<PrepareCallsResponse>;
 
     /// Send a signed call bundle.
-    #[method(name = "sendPreparedCalls", aliases = ["wallet_sendPreparedCalls"])]
+    #[method(name = "sendPreparedCalls")]
     async fn send_prepared_calls(
         &self,
         parameters: SendPreparedCallsParameters,
     ) -> RpcResult<SendPreparedCallsResponse>;
 
     /// Upgrade an account.
-    #[method(name = "upgradeAccount", aliases = ["wallet_upgradeAccount"])]
+    #[method(name = "upgradeAccount")]
     async fn upgrade_account(
         &self,
         parameters: UpgradeAccountParameters,
@@ -148,13 +148,13 @@ pub trait RelayApi {
     /// Get the status of a call batch that was sent via `send_prepared_calls`.
     ///
     /// The identifier of the batch is the value returned from `send_prepared_calls`.
-    #[method(name = "getCallsStatus", aliases = ["wallet_getCallsStatus"])]
+    #[method(name = "getCallsStatus")]
     async fn get_calls_status(&self, parameters: BundleId) -> RpcResult<CallsStatus>;
 
     /// Get the status of a call batch that was sent via `send_prepared_calls`.
     ///
     /// The identifier of the batch is the value returned from `send_prepared_calls`.
-    #[method(name = "verifySignature", aliases = ["wallet_verifySignature"])]
+    #[method(name = "verifySignature")]
     async fn verify_signature(
         &self,
         parameters: VerifySignatureParameters,


### PR DESCRIPTION
Closes #667 

Technically breaking, but I don't think we use `relay_` anywhere.