### PR TITLE
feat(email): encode verify URL search params

### DIFF
--- a/src/rpc/account.rs
+++ b/src/rpc/account.rs
@@ -5,6 +5,7 @@ use async_trait::async_trait;
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 use rand::{Rng, distr::Alphanumeric};
 use resend_rs::{Resend, types::CreateEmailBaseOptions};
+use url::Url;
 
 use crate::{
     error::EmailError,
@@ -64,23 +65,24 @@ impl AccountApiServer for AccountRpc {
         }
 
         let token = generate_token(8);
+
+        let mut url = Url::parse("https://id.porto.sh/email/verify").unwrap();
+        url.query_pairs_mut().append_pair("address", wallet_address.to_string().as_str());
+        url.query_pairs_mut().append_pair("email", email.as_str());
+        url.query_pairs_mut().append_pair("token", token.as_str());
+
         let mail = CreateEmailBaseOptions::new(
             "Porto <no-reply@porto.sh>",
             &[email.to_string()],
             "Verify email address for Porto",
         )
         .with_text(&format!(
-            r#"
-    Please verify your email address.
-
-    Use the following link to verify your email address: https://id.porto.sh/email/verify?address={wallet_address}&email={email}&token={token}
-
-    If you did not sign up for Porto, please ignore this email.
-
-    This is an automated message. Please do NOT reply to this email.
-
-    Thanks!
-    "#
+            "Please verify your email address.\n\n\
+            Use the following link to verify your email address:\n\n\
+            {url}\n\n\
+            If you did not sign up for Porto, please ignore this email.\n\
+            This is an automated message. Please do NOT reply to this email.\n\
+            Thanks!"
         ));
 
         self.client.emails.send(mail).await.map_err(|err| EmailError::InternalError(err.into()))?;


### PR DESCRIPTION
1. I used this email to sign up: `omar+2385629843@ithaca.xyz`. When it gets added to the verify URL as is, the `+` gets interpreted as space encoded. This change adds url search param encoding to handle that

	URL before: https://id.porto.sh/email/verify?address=0x958a3aD95F60870a7E4ccb4Da8737Fd658f3b6E7&email=omar+4455@ithaca.xyz&token=7WxXkxFe
	
	URL after: https://id.porto.sh/email/verify?address=0x958a3aD95F60870a7E4ccb4Da8737Fd658f3b6E7&email=omar%2B4455%40ithaca.xyz&token=7WxXkxFe
	
	URL navigation before:
	
	![CleanShot 2025-06-11 at 10 23 14](https://github.com/user-attachments/assets/20439e0a-7f6a-48a4-be1e-7cf3a9f3136a)
	
	URL navigation after:
	
	![image](https://github.com/user-attachments/assets/a3cc8a75-fad0-4f03-8ffa-ec9653cc4ae4)

2. [Slight enhancement](https://play.rust-lang.org/?version=stable&mode=debug&edition=2024&gist=6277b6dca7cb597c877335daeb0d133f) to the email body to remove extra spaces in the beginning of each line.