### PR TITLE
feat!: use legacy_delegation_proxies instead of legacy_delegations

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -39,8 +39,8 @@ pub struct RelayConfig {
     pub orchestrator: Address,
     /// Previously deployed orchestrators.
     pub legacy_orchestrators: BTreeSet<Address>,
-    /// Previously deployed delegation implementations.
-    pub legacy_delegations: BTreeSet<Address>,
+    /// Previously deployed delegation proxies.
+    pub legacy_delegation_proxies: BTreeSet<Address>,
     /// Delegation proxy address.
     pub delegation_proxy: Address,
     /// Simulator address.
@@ -253,7 +253,7 @@ impl Default for RelayConfig {
             email: EmailConfig::default(),
             transactions: TransactionServiceConfig::default(),
             legacy_orchestrators: BTreeSet::new(),
-            legacy_delegations: BTreeSet::new(),
+            legacy_delegation_proxies: BTreeSet::new(),
             orchestrator: Address::ZERO,
             delegation_proxy: Address::ZERO,
             simulator: Address::ZERO,

--- a/src/types/contracts.rs
+++ b/src/types/contracts.rs
@@ -65,10 +65,16 @@ impl VersionedContracts {
             }));
 
         let legacy_delegations =
-            try_join_all(config.legacy_delegations.iter().map(async |&address| {
+            try_join_all(config.legacy_delegation_proxies.iter().map(async |&proxy_address| {
+                let implementation = DelegationProxyInstance::new(proxy_address, provider)
+                    .implementation()
+                    .call()
+                    .await
+                    .map_err(TransportErrorKind::custom)?;
+
                 Ok(VersionedContract::new(
-                    address,
-                    Account::new(address, provider).version().await?,
+                    implementation,
+                    Account::new(implementation, provider).version().await?,
                 ))
             }));
 


### PR DESCRIPTION
## Summary
- Renamed config field from `legacy_delegations` to `legacy_delegation_proxies`
- Updated logic to fetch delegation implementations from proxy addresses instead of using them directly
- This properly handles legacy delegation proxies by resolving their implementation addresses

## Breaking Change
**⚠️ Infrastructure configuration breaking change**

The `legacy_delegations` field in the relay configuration has been renamed to `legacy_delegation_proxies`. The relay now fetches the actual delegation implementation addresses from these proxy contracts.

cc @laibe 

Fixes #786

🤖 Generated with [Claude Code](https://claude.ai/code)