### PR TITLE
ci: pin foundry to v1

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Install foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly
+          version: v1.0.0
 
       - name: Build account
         run: |


### PR DESCRIPTION
Closes #792 

Possibly related to https://github.com/foundry-rs/foundry/issues/10452