### PR TITLE
fix: don't trust hash field in Signed json

### DIFF
--- a/src/types/quote.rs
+++ b/src/types/quote.rs
@@ -2,7 +2,7 @@
 
 use crate::types::{Intent, Signed};
 use alloy::{
-    primitives::{Address, B256, ChainId, Keccak256, Signature, U256},
+    primitives::{Address, B256, ChainId, Keccak256, Sealable, Signature, U256},
     providers::utils::Eip1559Estimation,
 };
 use serde::{Deserialize, Serialize};
@@ -67,5 +67,11 @@ impl Quote {
         );
         hasher.update(self.orchestrator);
         hasher.finalize()
+    }
+}
+
+impl Sealable for Quote {
+    fn hash_slow(&self) -> B256 {
+        self.digest()
     }
 }

--- a/src/types/signed.rs
+++ b/src/types/signed.rs
@@ -1,13 +1,10 @@
-use alloy::primitives::{Address, B256, Signature, SignatureError};
+use alloy::primitives::{Address, B256, Sealable, Signature, SignatureError};
 use serde::{Deserialize, Serialize};
 
 /// A type that has been signed.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Signed<T> {
-    #[serde(flatten)]
     ty: T,
-    #[serde(flatten)]
     signature: Signature,
     hash: B256,
 }
@@ -41,5 +38,44 @@ impl<T> Signed<T> {
     /// Recover the address of the signer.
     pub fn recover_address(&self) -> Result<Address, SignatureError> {
         self.signature().recover_address_from_prehash(self.hash())
+    }
+}
+
+mod serde_impl {
+    use super::*;
+    use serde::de::DeserializeOwned;
+    use std::borrow::Cow;
+
+    #[derive(Serialize, Deserialize)]
+    struct SerdeHelper<'a, T: Clone> {
+        #[serde(flatten)]
+        ty: Cow<'a, T>,
+        #[serde(flatten)]
+        signature: Signature,
+        #[serde(skip_deserializing)]
+        hash: Option<B256>,
+    }
+
+    impl<T: Clone + Serialize> Serialize for Signed<T> {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            let Self { ty, signature, hash } = self;
+            SerdeHelper { ty: Cow::Borrowed(ty), signature: *signature, hash: Some(*hash) }
+                .serialize(serializer)
+        }
+    }
+
+    impl<'de, T: Clone + Sealable + DeserializeOwned> Deserialize<'de> for Signed<T> {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            let SerdeHelper::<T> { ty, signature, hash: _ } =
+                SerdeHelper::deserialize(deserializer)?;
+            let hash = ty.hash_slow();
+            Ok(Self::new_unchecked(ty.into_owned(), signature, hash))
+        }
     }
 }


### PR DESCRIPTION
Right now on `prepareCalls` we always expect `SignedQuote` to come with a precomputed hash and blindly trust it which means that the actual quote data such as fee token price can be changed arbitrarily without relay noticing.

This PR changes logic to always compute hash when deserializing

cc @mattsse alloy's `Signed` works similarly so maybe worth changing there too, although don't think this has similar implications rn