### PR TITLE
feat: add --funder config parameter

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -64,6 +64,9 @@ pub struct Args {
     /// The address of the simulator
     #[arg(long = "simulator", required_unless_present("config_only"), value_name = "SIMULATOR")]
     pub simulator: Option<Address>,
+    /// The address of the funder
+    #[arg(long = "funder", required_unless_present("config_only"), value_name = "FUNDER")]
+    pub funder: Option<Address>,
     /// The RPC endpoint of a chain to send transactions to.
     ///
     /// Must be a valid HTTP or HTTPS URL pointing to an Ethereum JSON-RPC endpoint.
@@ -176,6 +179,7 @@ impl Args {
             .with_orchestrator(self.orchestrator)
             .with_delegation_proxy(self.delegation_proxy)
             .with_simulator(self.simulator)
+            .with_funder(self.funder)
             .with_intent_gas_buffer(self.intent_gas_buffer)
             .with_tx_gas_buffer(self.tx_gas_buffer)
             .with_database_url(self.database_url)

--- a/src/config.rs
+++ b/src/config.rs
@@ -45,6 +45,8 @@ pub struct RelayConfig {
     pub delegation_proxy: Address,
     /// Simulator address.
     pub simulator: Address,
+    /// Funder address.
+    pub funder: Address,
     /// Secrets.
     #[serde(skip_serializing, default)]
     pub secrets: SecretsConfig,
@@ -259,6 +261,7 @@ impl Default for RelayConfig {
             orchestrator: Address::ZERO,
             delegation_proxy: Address::ZERO,
             simulator: Address::ZERO,
+            funder: Address::ZERO,
             secrets: SecretsConfig::default(),
             database_url: None,
         }
@@ -382,6 +385,14 @@ impl RelayConfig {
     pub fn with_simulator(mut self, simulator: Option<Address>) -> Self {
         if let Some(simulator) = simulator {
             self.simulator = simulator;
+        }
+        self
+    }
+
+    /// Sets the funder address.
+    pub fn with_funder(mut self, funder: Option<Address>) -> Self {
+        if let Some(funder) = funder {
+            self.funder = funder;
         }
         self
     }

--- a/src/rpc/relay.rs
+++ b/src/rpc/relay.rs
@@ -33,7 +33,7 @@ use crate::{
 use alloy::{
     consensus::{SignableTransaction, TxEip1559},
     eips::eip7702::constants::{EIP7702_DELEGATION_DESIGNATOR, PER_EMPTY_ACCOUNT_COST},
-    primitives::{Address, B256, Bytes, ChainId, U256, address, bytes},
+    primitives::{Address, B256, Bytes, ChainId, U256, bytes},
     providers::{
         DynProvider, Provider,
         utils::{EIP1559_FEE_ESTIMATION_PAST_BLOCKS, Eip1559Estimator},
@@ -374,7 +374,7 @@ impl Relay {
                     .unwrap(),
                 1,
             )?;
-            intent.funder = address!("0xa15bb66138824a1c7167f5e85b957d04dd34e468");
+            intent.funder = self.inner.contracts.funder.address;
             let (digest, _) = intent.compute_eip712_data(self.orchestrator(), &provider).await?;
             let signature = signers[0].sign_payload_hash(digest).await?;
             intent.funderSignature = Signature {

--- a/src/spawn.rs
+++ b/src/spawn.rs
@@ -255,6 +255,7 @@ pub async fn try_spawn(config: RelayConfig, registry: CoinRegistry) -> eyre::Res
         "orchestrator" => config.orchestrator.to_string(),
         "delegation_proxy" => config.delegation_proxy.to_string(),
         "simulator" => config.simulator.to_string(),
+        "funder" => config.funder.to_string(),
         "fee_recipient" => config.chain.fee_recipient.to_string()
     )
     .absolute(1);

--- a/src/types/contracts.rs
+++ b/src/types/contracts.rs
@@ -51,6 +51,8 @@ pub struct VersionedContracts {
     pub delegation_proxy: VersionedContract,
     /// Simulator.
     pub simulator: VersionedContract,
+    /// Funder.
+    pub funder: VersionedContract,
 }
 
 impl VersionedContracts {
@@ -113,6 +115,7 @@ impl VersionedContracts {
             legacy_delegations,
             delegation_proxy: VersionedContract::no_version(config.delegation_proxy),
             simulator: VersionedContract::no_version(config.simulator),
+            funder: VersionedContract::no_version(config.funder),
         })
     }
 }

--- a/tests/e2e/cases/cli.rs
+++ b/tests/e2e/cases/cli.rs
@@ -28,6 +28,7 @@ async fn respawn_cli() -> eyre::Result<()> {
                 orchestrator: Some(env.orchestrator),
                 delegation_proxy: Some(env.delegation),
                 simulator: Default::default(),
+                funder: Default::default(),
                 endpoints: Some(vec![
                     Url::from_str(&env.anvils[0].as_ref().unwrap().endpoint()).unwrap(),
                 ]),

--- a/tests/e2e/environment.rs
+++ b/tests/e2e/environment.rs
@@ -598,6 +598,7 @@ impl Environment {
                 .with_orchestrator(Some(contracts.orchestrator()))
                 .with_delegation_proxy(Some(contracts.delegation()))
                 .with_simulator(Some(contracts.simulator()))
+                .with_funder(Some(contracts.funder()))
                 .with_intent_gas_buffer(0) // todo: temp
                 .with_tx_gas_buffer(75_000) // todo: temp
                 .with_transaction_service_config(config.transaction_service_config)


### PR DESCRIPTION
## Summary
Implement configurable funder address following the same pattern as orchestrator configuration.

## Changes
- **CLI Integration**: Add  CLI argument with proper validation
- **Config Support**: Add funder field to RelayConfig with  method  
- **VersionedContracts**: Integrate funder into VersionedContracts for e2e test compatibility
- **Remove Hardcoding**: Replace hardcoded funder address with configurable value from contracts
- **Test Updates**: Update environment setup and CLI tests to properly configure funder

## Implementation Details
The funder address is now configurable via CLI argument and config file, following the exact same pattern as the orchestrator configuration. This enables proper multichain fund transfer functionality with custom funder contracts instead of hardcoded addresses.

## Test Results
✅ The specific test  passes successfully

🤖 Generated with [Claude Code](https://claude.ai/code)