### PR TITLE
feat: track `required_funds` on `Quote`

### DIFF
--- a/src/types/intent.rs
+++ b/src/types/intent.rs
@@ -259,10 +259,13 @@ impl Intent {
 
     /// Returns all fund transfers in the intent.
     pub fn fund_transfers(&self) -> Result<Vec<(Address, U256)>, alloy::sol_types::Error> {
-        self.encodedFundTransfers.iter().map(|transfer| {
-            let transfer = Transfer::abi_decode(transfer)?;
-            Ok((transfer.token, transfer.amount))
-        }).collect()
+        self.encodedFundTransfers
+            .iter()
+            .map(|transfer| {
+                let transfer = Transfer::abi_decode(transfer)?;
+                Ok((transfer.token, transfer.amount))
+            })
+            .collect()
     }
 
     /// Encodes this intent into calldata for [`OrchestratorContract::executeCall`].


### PR DESCRIPTION
afaict there's currently no way to determine the amount of funds we're going to pay to the user after `sendPreparedCalls`, however, this is a useful context for `InteropService`.

This PR adds `required_funds` field to `Quote`. We should remove it if there'll be an equivalent field on `Intent` but for now it's not too invasive