### PR TITLE
feat: state overrides for preparecalls (v14)

### DIFF
--- a/src/bin/stress.rs
+++ b/src/bin/stress.rs
@@ -92,6 +92,7 @@ impl StressAccount {
                         pre_calls: vec![],
                         pre_call: false,
                     },
+                    state_overrides: Default::default(),
                     key: Some(self.key.to_call_key()),
                 })
                 .await

--- a/src/types/rpc/calls.rs
+++ b/src/types/rpc/calls.rs
@@ -17,7 +17,7 @@ use alloy::{
         wrap_fixed_bytes,
     },
     providers::DynProvider,
-    rpc::types::Log,
+    rpc::types::{Log, state::StateOverride},
     sol_types::SolEvent,
     uint,
 };
@@ -69,6 +69,9 @@ pub struct PrepareCallsParameters {
     pub from: Option<Address>,
     /// Request capabilities.
     pub capabilities: PrepareCallsCapabilities,
+    /// State overrides for simulating the call bundle.
+    #[serde(default)]
+    pub state_overrides: StateOverride,
     /// Key that will be used to sign the call bundle. It can only be None, if we are handling a
     /// precall.
     #[serde(default)]

--- a/tests/e2e/cases/assets.rs
+++ b/tests/e2e/cases/assets.rs
@@ -74,6 +74,7 @@ async fn asset_diff_no_fee() -> eyre::Result<()> {
                 pre_calls: vec![],
                 pre_call: false,
             },
+            state_overrides: Default::default(),
             key: Some(admin_key.to_call_key()),
         };
         let diffs = env.relay_endpoint.prepare_calls(params).await?.capabilities.asset_diff;
@@ -108,6 +109,7 @@ async fn asset_diff() -> eyre::Result<()> {
             pre_calls: vec![],
             pre_call: false,
         },
+        state_overrides: Default::default(),
         key: Some(admin_key.to_call_key()),
     };
 
@@ -234,6 +236,7 @@ async fn asset_diff_has_uri() -> eyre::Result<()> {
             pre_calls: vec![],
             pre_call: false,
         },
+        state_overrides: Default::default(),
         key: Some(admin_key.to_call_key()),
     };
 

--- a/tests/e2e/cases/calls.rs
+++ b/tests/e2e/cases/calls.rs
@@ -59,6 +59,7 @@ async fn calls_with_upgraded_account() -> eyre::Result<()> {
                     pre_calls: Vec::new(),
                     pre_call: false,
                 },
+                state_overrides: Default::default(),
                 key: Some(signer.to_call_key()),
             })
             .await?;

--- a/tests/e2e/cases/delegation.rs
+++ b/tests/e2e/cases/delegation.rs
@@ -57,6 +57,7 @@ async fn catch_invalid_delegation() -> eyre::Result<()> {
             pre_calls: vec![],
             pre_call: false,
         },
+        state_overrides: Default::default(),
         key: Some(admin_key.to_call_key()),
     };
 
@@ -286,6 +287,7 @@ async fn upgrade_delegation_with_precall() -> eyre::Result<()> {
                 pre_calls: vec![],
                 pre_call: true,
             },
+            state_overrides: Default::default(),
             key: Some(admin_key.to_call_key()),
         })
         .await?;
@@ -313,6 +315,7 @@ async fn upgrade_delegation_with_precall() -> eyre::Result<()> {
                 pre_calls: vec![precall],
                 pre_call: false,
             },
+            state_overrides: Default::default(),
             key: Some(admin_key.to_call_key()),
         })
         .await?;

--- a/tests/e2e/cases/errors.rs
+++ b/tests/e2e/cases/errors.rs
@@ -30,6 +30,7 @@ async fn decode_insufficient_balance() -> eyre::Result<()> {
                 pre_calls: vec![],
                 pre_call: false,
             },
+            state_overrides: Default::default(),
             key: Some(key.to_call_key()),
         })
         .await;

--- a/tests/e2e/cases/fees.rs
+++ b/tests/e2e/cases/fees.rs
@@ -57,6 +57,7 @@ async fn ensure_valid_fees() -> eyre::Result<()> {
                 pre_calls: vec![],
                 pre_call: false,
             },
+            state_overrides: Default::default(),
             key: Some(admin_key.to_call_key()),
         })
         .await?;

--- a/tests/e2e/cases/keys.rs
+++ b/tests/e2e/cases/keys.rs
@@ -182,6 +182,7 @@ async fn ensure_prehash_simulation() -> eyre::Result<()> {
                 pre_calls: vec![],
                 pre_call: false,
             },
+            state_overrides: Default::default(),
             key: Some(call_key),
         })
         .await?;

--- a/tests/e2e/cases/pause.rs
+++ b/tests/e2e/cases/pause.rs
@@ -34,6 +34,7 @@ async fn pause() -> eyre::Result<()> {
             pre_calls: vec![],
             pre_call: false,
         },
+        state_overrides: Default::default(),
         key: Some(eoa.key.to_call_key()),
     };
 

--- a/tests/e2e/cases/paymaster.rs
+++ b/tests/e2e/cases/paymaster.rs
@@ -53,6 +53,7 @@ async fn use_external_fee_payer() -> eyre::Result<()> {
                     pre_call: false,
                     revoke_keys: vec![],
                 },
+                state_overrides: Default::default(),
                 key: Some(eoa.key.to_call_key()),
             })
             .await

--- a/tests/e2e/cases/simple.rs
+++ b/tests/e2e/cases/simple.rs
@@ -401,6 +401,7 @@ async fn empty_request_nonce() -> eyre::Result<()> {
                 pre_calls: vec![],
                 pre_call: true,
             },
+            state_overrides: Default::default(),
             key: Some(admin_key.to_call_key()),
         })
         .await?;
@@ -427,6 +428,7 @@ async fn empty_request_nonce() -> eyre::Result<()> {
                 pre_calls: vec![precall],
                 pre_call: false,
             },
+            state_overrides: Default::default(),
             key: Some(admin_key.to_call_key()),
         })
         .await?;
@@ -474,6 +476,7 @@ async fn single_sign_up_popup() -> eyre::Result<()> {
                 pre_calls: vec![],
                 pre_call: false,
             },
+            state_overrides: Default::default(),
             key: Some(session_key.to_call_key()),
         })
         .await?;

--- a/tests/e2e/eoa.rs
+++ b/tests/e2e/eoa.rs
@@ -80,6 +80,7 @@ impl MockAccount {
                     pre_call: false,
                     revoke_keys: vec![],
                 },
+                state_overrides: Default::default(),
                 key: Some(key.to_call_key()),
             })
             .await
@@ -113,6 +114,7 @@ impl MockAccount {
                     pre_call: false,
                     revoke_keys: vec![],
                 },
+                state_overrides: Default::default(),
                 key: Some(self.key.to_call_key()),
             })
             .await

--- a/tests/e2e/mod.rs
+++ b/tests/e2e/mod.rs
@@ -128,6 +128,7 @@ pub async fn prepare_calls(
                 pre_calls,
                 pre_call,
             },
+            state_overrides: Default::default(),
             key: Some(signer.to_call_key()),
         })
         .await;


### PR DESCRIPTION
Adds state overrides on top of v14.0.2 to allow Porto SDK to set arbitrary state overrides for simulation only.

I'm merging this into a new branch (v14.1.0) for a minor release

Closes #842 