### PR TITLE
feat: state overrides for output intents

### DIFF
--- a/src/bin/stress.rs
+++ b/src/bin/stress.rs
@@ -93,6 +93,7 @@ impl StressAccount {
                         pre_calls: vec![],
                         pre_call: false,
                     },
+                    state_overrides: Default::default(),
                     key: Some(self.key.to_call_key()),
                 })
                 .await

--- a/src/types/rpc/calls.rs
+++ b/src/types/rpc/calls.rs
@@ -17,7 +17,7 @@ use alloy::{
         wrap_fixed_bytes,
     },
     providers::DynProvider,
-    rpc::types::Log,
+    rpc::types::{Log, state::StateOverride},
     sol_types::{SolCall, SolEvent},
     uint,
 };
@@ -69,6 +69,11 @@ pub struct PrepareCallsParameters {
     pub from: Option<Address>,
     /// Request capabilities.
     pub capabilities: PrepareCallsCapabilities,
+    /// State overrides for simulating the call bundle.
+    ///
+    /// This will only be applied to the intent on the output chain in multichain intents.
+    #[serde(default)]
+    pub state_overrides: StateOverride,
     /// Key that will be used to sign the call bundle. It can only be None, if we are handling a
     /// precall.
     #[serde(default)]
@@ -187,6 +192,7 @@ impl PrepareCallsParameters {
                 pre_calls: vec![],
                 pre_call: false,
             },
+            state_overrides: Default::default(),
             key: Some(request_key),
             required_funds: vec![],
         }

--- a/tests/e2e/cases/assets.rs
+++ b/tests/e2e/cases/assets.rs
@@ -78,6 +78,7 @@ async fn asset_diff_no_fee() -> eyre::Result<()> {
                 pre_calls: vec![],
                 pre_call: false,
             },
+            state_overrides: Default::default(),
             key: Some(admin_key.to_call_key()),
         };
         let diffs = env.relay_endpoint.prepare_calls(params).await?.capabilities.asset_diff;
@@ -113,6 +114,7 @@ async fn asset_diff() -> eyre::Result<()> {
             pre_calls: vec![],
             pre_call: false,
         },
+        state_overrides: Default::default(),
         key: Some(admin_key.to_call_key()),
     };
 
@@ -240,6 +242,7 @@ async fn asset_diff_has_uri() -> eyre::Result<()> {
             pre_calls: vec![],
             pre_call: false,
         },
+        state_overrides: Default::default(),
         key: Some(admin_key.to_call_key()),
     };
 

--- a/tests/e2e/cases/calls.rs
+++ b/tests/e2e/cases/calls.rs
@@ -60,6 +60,7 @@ async fn calls_with_upgraded_account() -> eyre::Result<()> {
                     pre_calls: Vec::new(),
                     pre_call: false,
                 },
+                state_overrides: Default::default(),
                 key: Some(signer.to_call_key()),
             })
             .await?;

--- a/tests/e2e/cases/delegation.rs
+++ b/tests/e2e/cases/delegation.rs
@@ -58,6 +58,7 @@ async fn catch_invalid_delegation() -> eyre::Result<()> {
             pre_calls: vec![],
             pre_call: false,
         },
+        state_overrides: Default::default(),
         key: Some(admin_key.to_call_key()),
     };
 
@@ -294,6 +295,7 @@ async fn upgrade_delegation_with_precall() -> eyre::Result<()> {
                 pre_calls: vec![],
                 pre_call: true,
             },
+            state_overrides: Default::default(),
             key: Some(admin_key.to_call_key()),
         })
         .await?;
@@ -322,6 +324,7 @@ async fn upgrade_delegation_with_precall() -> eyre::Result<()> {
                 pre_calls: vec![precall],
                 pre_call: false,
             },
+            state_overrides: Default::default(),
             key: Some(admin_key.to_call_key()),
         })
         .await?;

--- a/tests/e2e/cases/errors.rs
+++ b/tests/e2e/cases/errors.rs
@@ -31,6 +31,7 @@ async fn decode_insufficient_balance() -> eyre::Result<()> {
                 pre_calls: vec![],
                 pre_call: false,
             },
+            state_overrides: Default::default(),
             key: Some(key.to_call_key()),
         })
         .await;

--- a/tests/e2e/cases/fees.rs
+++ b/tests/e2e/cases/fees.rs
@@ -61,6 +61,7 @@ async fn ensure_valid_fees() -> eyre::Result<()> {
                 pre_calls: vec![],
                 pre_call: false,
             },
+            state_overrides: Default::default(),
             key: Some(admin_key.to_call_key()),
         })
         .await?;

--- a/tests/e2e/cases/keys.rs
+++ b/tests/e2e/cases/keys.rs
@@ -183,6 +183,7 @@ async fn ensure_prehash_simulation() -> eyre::Result<()> {
                 pre_calls: vec![],
                 pre_call: false,
             },
+            state_overrides: Default::default(),
             key: Some(call_key),
         })
         .await?;

--- a/tests/e2e/cases/multichain_usdt_transfer.rs
+++ b/tests/e2e/cases/multichain_usdt_transfer.rs
@@ -78,6 +78,7 @@ async fn test_multichain_usdt_transfer() -> Result<()> {
                 pre_calls: vec![],
                 pre_call: false,
             },
+            state_overrides: Default::default(),
             key: Some(key.to_call_key()),
             required_funds: vec![(env.erc20, total_transfer_amount)],
         })

--- a/tests/e2e/cases/pause.rs
+++ b/tests/e2e/cases/pause.rs
@@ -35,6 +35,7 @@ async fn pause() -> eyre::Result<()> {
             pre_calls: vec![],
             pre_call: false,
         },
+        state_overrides: Default::default(),
         key: Some(eoa.key.to_call_key()),
     };
 

--- a/tests/e2e/cases/paymaster.rs
+++ b/tests/e2e/cases/paymaster.rs
@@ -54,6 +54,7 @@ async fn use_external_fee_payer() -> eyre::Result<()> {
                     pre_call: false,
                     revoke_keys: vec![],
                 },
+                state_overrides: Default::default(),
                 key: Some(eoa.key.to_call_key()),
             })
             .await

--- a/tests/e2e/cases/simple.rs
+++ b/tests/e2e/cases/simple.rs
@@ -402,6 +402,7 @@ async fn empty_request_nonce() -> eyre::Result<()> {
                 pre_calls: vec![],
                 pre_call: true,
             },
+            state_overrides: Default::default(),
             key: Some(admin_key.to_call_key()),
         })
         .await?;
@@ -429,6 +430,7 @@ async fn empty_request_nonce() -> eyre::Result<()> {
                 pre_calls: vec![precall],
                 pre_call: false,
             },
+            state_overrides: Default::default(),
             key: Some(admin_key.to_call_key()),
         })
         .await?;
@@ -478,6 +480,7 @@ async fn single_sign_up_popup() -> eyre::Result<()> {
                 pre_calls: vec![],
                 pre_call: false,
             },
+            state_overrides: Default::default(),
             key: Some(session_key.to_call_key()),
         })
         .await?;

--- a/tests/e2e/eoa.rs
+++ b/tests/e2e/eoa.rs
@@ -81,6 +81,7 @@ impl MockAccount {
                     pre_call: false,
                     revoke_keys: vec![],
                 },
+                state_overrides: Default::default(),
                 key: Some(key.to_call_key()),
             })
             .await
@@ -115,6 +116,7 @@ impl MockAccount {
                     pre_call: false,
                     revoke_keys: vec![],
                 },
+                state_overrides: Default::default(),
                 key: Some(self.key.to_call_key()),
             })
             .await

--- a/tests/e2e/mod.rs
+++ b/tests/e2e/mod.rs
@@ -136,6 +136,7 @@ pub async fn prepare_calls(
                 pre_calls,
                 pre_call,
             },
+            state_overrides: Default::default(),
             key: Some(signer.to_call_key()),
         })
         .await;


### PR DESCRIPTION
Same as #854 but for main; the state overrides only apply to the output intent

Ref #842