### PR TITLE
test: remove print traces arg

### DIFF
--- a/tests/e2e/environment.rs
+++ b/tests/e2e/environment.rs
@@ -200,7 +200,7 @@ fn spawn_local_anvil(index: usize, config: &EnvironmentConfig) -> eyre::Result<A
 
     Anvil::new()
         .chain_id(chain_id)
-        .args(["--optimism", "--host", "0.0.0.0", "--print-traces"].into_iter().chain(args))
+        .args(["--optimism", "--host", "0.0.0.0"].into_iter().chain(args))
         .try_spawn()
         .wrap_err(format!("Failed to spawn Anvil for chain {chain_id} (index {index})"))
 }


### PR DESCRIPTION
iirc we used this earlier for debugging but we can remove now, removing a lot of overhead from anvil