### PR TITLE
refactor: require `from` to always be provided in `prepareCalls`

### DIFF
--- a/src/bin/stress.rs
+++ b/src/bin/stress.rs
@@ -85,7 +85,7 @@ impl StressAccount {
                     required_funds: vec![],
                     calls: vec![Call { to: Address::ZERO, value: U256::ZERO, data: bytes!("") }],
                     chain_id,
-                    from: Some(self.address),
+                    from: self.address,
                     capabilities: PrepareCallsCapabilities {
                         authorize_keys: vec![],
                         meta: Meta { fee_payer: None, fee_token, nonce: None },

--- a/src/types/rpc/calls.rs
+++ b/src/types/rpc/calls.rs
@@ -159,7 +159,7 @@ pub struct PrepareCallsParameters {
     pub chain_id: ChainId,
     /// Address of the account to prepare the call bundle for. It can only be None, if we are
     /// handling a precall
-    pub from: Option<Address>,
+    pub from: Address,
     /// Request capabilities.
     pub capabilities: PrepareCallsCapabilities,
     /// State overrides for simulating the call bundle.
@@ -189,7 +189,7 @@ impl PrepareCallsParameters {
     pub fn check_calls(&self, latest_delegation: Address) -> Result<(), RelayError> {
         let has_unallowed = |calls: &[Call]| -> Result<bool, RelayError> {
             for call in calls {
-                if !call.is_whitelisted_precall(self.from.unwrap_or_default(), latest_delegation)? {
+                if !call.is_whitelisted_precall(self.from, latest_delegation)? {
                     return Ok(true);
                 }
             }
@@ -256,8 +256,7 @@ impl PrepareCallsParameters {
         } else if maybe_stored.is_some() {
             Ok(random_nonce)
         } else {
-            let eoa = self.from.ok_or(IntentError::MissingSender)?;
-            Account::new(eoa, &provider).get_nonce().await.map_err(RelayError::from)
+            Account::new(self.from, &provider).get_nonce().await.map_err(RelayError::from)
         }
     }
 }
@@ -378,7 +377,6 @@ impl PrepareCallsContext {
     pub async fn compute_signing_digest(
         &self,
         maybe_stored: Option<&CreatableAccount>,
-        latest_orchestrator: Address,
         provider: &DynProvider,
     ) -> eyre::Result<(B256, TypedData)> {
         match self {
@@ -394,19 +392,14 @@ impl PrepareCallsContext {
                 }
             }
             PrepareCallsContext::PreCall(pre_call) => {
-                let orchestrator_address = if pre_call.eoa == Address::ZERO {
-                    // EOA is unknown so we assume that latest orchestrator should be used
-                    latest_orchestrator
-                } else {
-                    // fetch orchestrator address from the account
-                    Account::new(pre_call.eoa, provider)
-                        .with_delegation_override_opt(
-                            maybe_stored.map(|acc| &acc.signed_authorization.address),
-                        )
-                        .get_orchestrator()
-                        .await
-                        .map_err(RelayError::from)?
-                };
+                // fetch orchestrator address from the account
+                let orchestrator_address = Account::new(pre_call.eoa, provider)
+                    .with_delegation_override_opt(
+                        maybe_stored.map(|acc| &acc.signed_authorization.address),
+                    )
+                    .get_orchestrator()
+                    .await
+                    .map_err(RelayError::from)?;
 
                 pre_call.compute_eip712_data(orchestrator_address, provider).await
             }

--- a/tests/e2e/cases/assets.rs
+++ b/tests/e2e/cases/assets.rs
@@ -68,7 +68,7 @@ async fn asset_diff_no_fee() -> eyre::Result<()> {
     for fee_token in [env.fee_token, Address::ZERO] {
         let params = PrepareCallsParameters {
             required_funds: vec![],
-            from: Some(env.eoa.address()),
+            from: env.eoa.address(),
             calls: vec![], // fill in per test
             chain_id: env.chain_id(),
             capabilities: PrepareCallsCapabilities {
@@ -106,7 +106,7 @@ async fn asset_diff() -> eyre::Result<()> {
     // create prepare_call request
     let params = PrepareCallsParameters {
         required_funds: vec![],
-        from: Some(env.eoa.address()),
+        from: env.eoa.address(),
         calls: vec![], // fill in per test
         chain_id: env.chain_id(),
         capabilities: PrepareCallsCapabilities {
@@ -218,7 +218,7 @@ async fn asset_diff_has_uri() -> eyre::Result<()> {
     // create prepare_call request with 2 mints.
     let mut params = PrepareCallsParameters {
         required_funds: vec![],
-        from: Some(env.eoa.address()),
+        from: env.eoa.address(),
         calls: if std::env::var("TEST_ERC721").is_ok() {
             vec![
                 Call {

--- a/tests/e2e/cases/calls.rs
+++ b/tests/e2e/cases/calls.rs
@@ -52,7 +52,7 @@ async fn calls_with_upgraded_account() -> eyre::Result<()> {
                 required_funds: vec![],
                 calls: vec![erc20_transfer.clone()],
                 chain_id: env.chain_id(),
-                from: Some(env.eoa.address()),
+                from: env.eoa.address(),
                 capabilities: PrepareCallsCapabilities {
                     authorize_keys: Vec::new(), // todo: add test authorize "inline"
                     revoke_keys: Vec::new(),

--- a/tests/e2e/cases/delegation.rs
+++ b/tests/e2e/cases/delegation.rs
@@ -48,7 +48,7 @@ async fn catch_invalid_delegation() -> eyre::Result<()> {
 
     let params = PrepareCallsParameters {
         required_funds: vec![],
-        from: Some(env.eoa.address()),
+        from: env.eoa.address(),
         calls: vec![],
         chain_id: env.chain_id(),
         capabilities: PrepareCallsCapabilities {
@@ -274,7 +274,7 @@ async fn upgrade_delegation_with_precall() -> eyre::Result<()> {
         .relay_endpoint
         .prepare_calls(PrepareCallsParameters {
             required_funds: vec![],
-            from: Some(env.eoa.address()),
+            from: env.eoa.address(),
             calls: vec![Call {
                 to: env.eoa.address(),
                 value: U256::ZERO,
@@ -316,7 +316,7 @@ async fn upgrade_delegation_with_precall() -> eyre::Result<()> {
         .relay_endpoint
         .prepare_calls(PrepareCallsParameters {
             required_funds: vec![],
-            from: Some(env.eoa.address()),
+            from: env.eoa.address(),
             calls: vec![],
             chain_id: env.chain_id(),
             capabilities: PrepareCallsCapabilities {

--- a/tests/e2e/cases/errors.rs
+++ b/tests/e2e/cases/errors.rs
@@ -21,7 +21,7 @@ async fn decode_insufficient_balance() -> eyre::Result<()> {
         .relay_endpoint
         .prepare_calls(PrepareCallsParameters {
             required_funds: vec![],
-            from: Some(env.eoa.address()),
+            from: env.eoa.address(),
             calls: vec![calls::transfer(env.erc20s[4], Address::ZERO, U256::from(10000000u64))],
             chain_id: env.chain_id(),
             capabilities: PrepareCallsCapabilities {

--- a/tests/e2e/cases/fees.rs
+++ b/tests/e2e/cases/fees.rs
@@ -49,7 +49,7 @@ async fn ensure_valid_fees() -> eyre::Result<()> {
         .relay_endpoint
         .prepare_calls(PrepareCallsParameters {
             required_funds: vec![],
-            from: Some(env.eoa.address()),
+            from: env.eoa.address(),
             calls: (1..num_calls)
                 .map(|_| Call { to: Address::ZERO, value: U256::ZERO, data: Default::default() })
                 .collect(),

--- a/tests/e2e/cases/keys.rs
+++ b/tests/e2e/cases/keys.rs
@@ -173,7 +173,7 @@ async fn ensure_prehash_simulation() -> eyre::Result<()> {
     env.relay_endpoint
         .prepare_calls(PrepareCallsParameters {
             required_funds: vec![],
-            from: Some(env.eoa.address()),
+            from: env.eoa.address(),
             calls: vec![],
             chain_id: env.chain_id(),
             capabilities: PrepareCallsCapabilities {

--- a/tests/e2e/cases/liquidity.rs
+++ b/tests/e2e/cases/liquidity.rs
@@ -50,7 +50,7 @@ async fn test_multi_chain_liquidity_management() -> Result<()> {
         .prepare_calls(PrepareCallsParameters {
             calls: vec![common_calls::transfer(env.erc20, env.eoa.address(), funder_balance_0)],
             chain_id: env.chain_id_for(1),
-            from: Some(env.eoa.address()),
+            from: env.eoa.address(),
             capabilities: PrepareCallsCapabilities {
                 authorize_keys: vec![],
                 revoke_keys: vec![],

--- a/tests/e2e/cases/multichain_usdt_transfer.rs
+++ b/tests/e2e/cases/multichain_usdt_transfer.rs
@@ -132,7 +132,7 @@ impl MultichainTransferSetup {
                     total_transfer_amount,
                 )],
                 chain_id: chain3_id,
-                from: Some(wallet),
+                from: wallet,
                 capabilities: PrepareCallsCapabilities {
                     authorize_keys: vec![],
                     revoke_keys: vec![],

--- a/tests/e2e/cases/pause.rs
+++ b/tests/e2e/cases/pause.rs
@@ -25,7 +25,7 @@ async fn pause() -> eyre::Result<()> {
 
     let prepare_params = PrepareCallsParameters {
         required_funds: vec![],
-        from: Some(eoa.address),
+        from: eoa.address,
         calls: vec![],
         chain_id: env.chain_id(),
         capabilities: PrepareCallsCapabilities {

--- a/tests/e2e/cases/paymaster.rs
+++ b/tests/e2e/cases/paymaster.rs
@@ -46,7 +46,7 @@ async fn use_external_fee_payer() -> eyre::Result<()> {
                 required_funds: vec![],
                 calls: vec![],
                 chain_id: env.chain_id(),
-                from: Some(eoa.address),
+                from: eoa.address,
                 capabilities: PrepareCallsCapabilities {
                     authorize_keys: vec![],
                     meta: Meta { fee_payer: Some(paymaster.address), fee_token, nonce: None },

--- a/tests/e2e/cases/simple.rs
+++ b/tests/e2e/cases/simple.rs
@@ -392,7 +392,7 @@ async fn empty_request_nonce() -> eyre::Result<()> {
         .relay_endpoint
         .prepare_calls(PrepareCallsParameters {
             required_funds: vec![],
-            from: Some(env.eoa.address()),
+            from: env.eoa.address(),
             calls: vec![],
             chain_id: env.chain_id(),
             capabilities: PrepareCallsCapabilities {
@@ -421,7 +421,7 @@ async fn empty_request_nonce() -> eyre::Result<()> {
         .relay_endpoint
         .prepare_calls(PrepareCallsParameters {
             required_funds: vec![],
-            from: Some(env.eoa.address()),
+            from: env.eoa.address(),
             calls: vec![],
             chain_id: env.chain_id(),
             capabilities: PrepareCallsCapabilities {
@@ -472,7 +472,7 @@ async fn single_sign_up_popup() -> eyre::Result<()> {
         .relay_endpoint
         .prepare_calls(PrepareCallsParameters {
             required_funds: vec![],
-            from: Some(env.eoa.address()),
+            from: env.eoa.address(),
             calls: vec![],
             chain_id: env.chain_id(),
             capabilities: PrepareCallsCapabilities {

--- a/tests/e2e/eoa.rs
+++ b/tests/e2e/eoa.rs
@@ -73,7 +73,7 @@ impl MockAccount {
                         .into(),
                 }],
                 chain_id: env.chain_id(),
-                from: Some(eoa.address()),
+                from: eoa.address(),
                 capabilities: PrepareCallsCapabilities {
                     authorize_keys: vec![],
                     meta: Meta { fee_payer: None, fee_token: Address::ZERO, nonce: None },
@@ -109,7 +109,7 @@ impl MockAccount {
                 required_funds: vec![],
                 calls: vec![],
                 chain_id: env.chain_id(),
-                from: Some(self.address),
+                from: self.address,
                 capabilities: PrepareCallsCapabilities {
                     authorize_keys: vec![],
                     meta: Meta { fee_payer: None, fee_token: env.erc20, nonce: None },

--- a/tests/e2e/mod.rs
+++ b/tests/e2e/mod.rs
@@ -114,15 +114,11 @@ pub async fn prepare_calls(
 ) -> eyre::Result<Option<(Bytes, PrepareCallsContext)>> {
     let pre_calls = build_pre_calls(env, &tx.pre_calls, tx_num).await?;
 
-    // Deliberately omit the `from` address for the very first Intent precalls
-    // to test the path where precalls are signed before the address is known.
-    let from = (tx_num != 0 || !pre_call).then_some(env.eoa.address());
-
     let response = env
         .relay_endpoint
         .prepare_calls(PrepareCallsParameters {
             required_funds: vec![],
-            from,
+            from: env.eoa.address(),
             calls: tx.calls.clone(),
             chain_id: env.chain_id(),
             capabilities: PrepareCallsCapabilities {


### PR DESCRIPTION
For being able to correctly determine orchestrator to fetch domain from we need to always know the `from` address.

https://ithacaxyz.slack.com/archives/C0861UJNCRJ/p1751039658024629?thread_ts=1751018671.971689&cid=C0861UJNCRJ