### PR TITLE
chore: make required funds arg optional

### DIFF
--- a/src/types/rpc/calls.rs
+++ b/src/types/rpc/calls.rs
@@ -179,6 +179,7 @@ pub struct PrepareCallsParameters {
     #[serde(default)]
     pub key: Option<CallKey>,
     /// Required funds on the target chain.
+    #[serde(default)]
     pub required_funds: Vec<(Address, U256)>,
 }
 


### PR DESCRIPTION
otherwise `requiredFunds: []` is mandatory