### PR TITLE
feat: `RELAY_SETTLER_OWNER_KEY`

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -670,6 +670,18 @@ impl RelayConfig {
         self
     }
 
+    /// Set the simple settler owner key if interop is already configured for simple settler.
+    pub fn with_simple_settler_owner_key(mut self, settler_owner_key: Option<String>) -> Self {
+        let Some(pk) = settler_owner_key else { return self };
+
+        if let Some(conf) = self.interop.as_mut().map(|conf| &mut conf.settler) {
+            if let SettlerImplementation::Simple(conf) = &mut conf.implementation {
+                conf.private_key = pk;
+            }
+        }
+        self
+    }
+
     /// Load from a YAML file.
     pub fn load_from_file<P: AsRef<Path>>(path: P) -> eyre::Result<Self> {
         let path = path.as_ref();

--- a/src/spawn.rs
+++ b/src/spawn.rs
@@ -88,7 +88,9 @@ pub async fn try_spawn_with_args(
         config.secrets.signers_mnemonic = std::env::var("RELAY_MNEMONIC")?.parse()?;
         config.secrets.funder_key = std::env::var("RELAY_FUNDER_KEY")?;
         config.database_url = std::env::var("RELAY_DB_URL").ok();
-        config.with_resend_api_key(std::env::var("RESEND_API_KEY").ok())
+        config
+            .with_resend_api_key(std::env::var("RESEND_API_KEY").ok())
+            .with_simple_settler_owner_key(std::env::var("RELAY_SETTLER_OWNER_KEY").ok())
     };
 
     let registry = if !registry_path.exists() {


### PR DESCRIPTION
Adds `RELAY_SETTLER_OWNER_KEY` to configure the simple settler config via env secrets. It's pretty ugly but it is what it is