### PR TITLE
bug: fix mocked merkle signature format

### DIFF
--- a/src/rpc/relay.rs
+++ b/src/rpc/relay.rs
@@ -357,6 +357,8 @@ impl Relay {
                     *orchestrator.address(),
                     &provider,
                     &mock_key,
+                    context.account_key.key_hash(),
+                    prehash,
                 )
                 .await
                 .map_err(RelayError::from)?;


### PR DESCRIPTION
It's not triggering an error because for whatever reason the keyHash returned below (solidity) is `0x0`, which for whatever reason doesn't trigger any error? <- needs to be investigated separately.

```solidity
        if (MerkleProofLib.verify(proof, root, digest)) {
            (isValid, keyHash) = IIthacaAccount(eoa).unwrapAndValidateSignature(root, rootSig);

            return (isValid, keyHash);
        }
```

Hit this when investigating the stress tests (but probably unrelated)

`fn send_intents` correctly formats the signature, and that's why this is a mock/simulation specific scenario.