### PR TITLE
fix: drop useless constraint

### DIFF
--- a/migrations/0021_fix_constraint.sql
+++ b/migrations/0021_fix_constraint.sql
@@ -1,0 +1,1 @@
+alter table pending_unlocks drop constraint pending_unlocks_pkey;


### PR DESCRIPTION
forcing single entry per chain-asset pair does not make sense https://github.com/ithacaxyz/relay/blob/b8609c69b654d97d9f649dd79c2cac72ebaafbb2/migrations/0016_liquidity.sql#L8-L14