### PR TITLE
feat: add bundle viewer script

### DIFF
--- a/scripts/bundle.sh
+++ b/scripts/bundle.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+usage()
+{
+    echo "Usage: $0 -r <rpc url> -b <bundle id>"
+    exit 1
+}
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+while getopts ":b:r:" opt; do
+  case ${opt} in
+    b ) bundle_id=$OPTARG;;
+    r ) rpc_url=$OPTARG;;
+    \? ) usage;;
+  esac
+done
+
+rpc_url=${rpc_url:-${ETH_RPC_URL:-http://localhost:8545}}
+
+if [ -z "$bundle_id" ] || [ -z "$rpc_url" ]; then
+  usage
+fi
+
+if ! command -v cast help 2>&1 >/dev/null
+then
+    echo "Please install cast"
+    exit 1
+fi
+
+if ! command -v jq 2>&1 >/dev/null
+then
+    echo "Please install jq"
+    exit 1
+fi
+
+bundle="$(cast rpc wallet_getCallsStatus -r $rpc_url $bundle_id)"
+status=$(echo "${bundle}" | jq '.status')
+
+case $status in
+    100 ) human_status="Pending";;
+    200 ) human_status="Confirmed";;
+    300 ) human_status="Failed offchain";;
+    400 ) human_status="Reverted";;
+    500 ) human_status="Partially reverted";;
+    *) human_status="Unknown";;
+esac
+
+echo "Bundle ${bundle_id} on ${rpc_url}"
+echo
+echo "Bundle status: ${human_status} (${status})"
+echo "Receipts:"
+
+for receipt in $(echo "${bundle}" | jq -c '.receipts[]'); do
+    tx_status=$(echo "${receipt}" | jq -r '.status')
+
+    echo -n "- "
+    if [ $tx_status = "0x1" ]; then
+        echo -en $GREEN
+    else
+        echo -en $RED
+    fi
+    echo "${receipt}" | jq -r '.transactionHash + " (" + (.chainId | tostring) + ")"'
+    echo -en $NC
+done


### PR DESCRIPTION
Adds a small script to get some basic info out of a bundle.

Takes two flags, `-b <bundle id>` and `-r <rpc url>`. The RPC URL defaults to `ETH_RPC_URL`, and if that is also unset, falls back to `http://localhost:8545`.

Example usage:

```sh
./scripts/bundle.sh -r https://base-sepolia-int.rpc.ithaca.xyz \ 
  -b 0x28407e91a01d6ae75dbf7eaec063be4146c2b6b1bfe5d97a86f017f8d8895ae5
```

Example output:

<img width="1054" height="147" alt="image" src="https://github.com/user-attachments/assets/d8532233-3f09-4435-b3c2-580ecdba5bef" />

Green receipts mean they did not revert, red means they reverted.