### PR TITLE
feat: add settlement status to bundle script

### DIFF
--- a/scripts/bundle.sh
+++ b/scripts/bundle.sh
@@ -49,9 +49,12 @@ case $status in
     *) human_status="Unknown";;
 esac
 
+settlement_status=$(echo "${bundle}" | jq -r '.capabilities.interopStatus')
+
 echo "Bundle ${bundle_id} on ${rpc_url}"
 echo
 echo "Bundle status: ${human_status} (${status})"
+echo "Settlement status: ${settlement_status}"
 echo "Receipts:"
 
 for receipt in $(echo "${bundle}" | jq -c '.receipts[]'); do


### PR DESCRIPTION
Adds the status from #967 to the bundle viewer script

```
./scripts/bundle.sh -r https://base-sepolia-int.rpc.ithaca.xyz -b 0x28407e91a01d6ae75dbf7eaec063be4146c2b6b1bfe5d97a86f017f8d8895ae5
```

```
Bundle 0x28407e91a01d6ae75dbf7eaec063be4146c2b6b1bfe5d97a86f017f8d8895ae5 on https://base-sepolia-int.rpc.ithaca.xyz

Bundle status: Confirmed (200)
Settlement status: DestinationConfirmed
Receipts:
- 0x9791cb5aedcb43bc37687eb2d7a76b1acda214b61733447bd0d4dca1eab194fb (84532)
- 0xc1f4588ca46100b2f4335184b58a09382273ace5d549f45649e5322c114d1de3 (11155420)
```