### PR TITLE
feat: preconf call status

### DIFF
--- a/src/types/rpc/calls.rs
+++ b/src/types/rpc/calls.rs
@@ -514,6 +514,12 @@ pub enum CallStatusCode {
     Pending = 100,
     /// The call bundle was confirmed.
     Confirmed = 200,
+    /// The call bundle was preconfirmed.
+    ///
+    /// Note that this status is returned if all receipts are available and at least one of the
+    /// receipts is for a block in the future, indicating it was preconfirmed. It does not
+    /// necessarily indicate that all transactions were preconfirmed.
+    PreConfirmed = 201,
     /// The call bundle failed offchain.
     Failed = 300,
     /// The call bundle reverted fully onchain.


### PR DESCRIPTION
Adds a new status code (201) to indicate that all receipts are available, but at least one transaction in the bundle is preconfirmed using e.g. Flashblocks.

A tx is considered preconfirmed if the block number in the receipt is greater than the current block number of the node we are talking to.