### PR TITLE
feat: rm preconf check stress test

### DIFF
--- a/src/types/rpc/calls.rs
+++ b/src/types/rpc/calls.rs
@@ -540,6 +540,11 @@ impl CallStatusCode {
     }
 
     /// Whether the bundle was confirmed.
+    pub fn is_preconfirmed(&self) -> bool {
+        matches!(self, CallStatusCode::PreConfirmed)
+    }
+
+    /// Whether the bundle was confirmed.
     pub fn is_confirmed(&self) -> bool {
         matches!(self, CallStatusCode::Confirmed)
     }


### PR DESCRIPTION
Removes the custom preconf check in the stress test script, instead we want for the status to be final (i.e. not pending) and not preconfirmed.