### PR TITLE
bug: wait for `nonce` to be available before calling `commitVerification` & `lzReceive`

### DIFF
--- a/src/interop/settler/layerzero/contracts.rs
+++ b/src/interop/settler/layerzero/contracts.rs
@@ -33,8 +33,8 @@ sol! {
 
     /// ReceiveUln302 interface for committing verification
     #[sol(rpc)]
+    #[derive(Debug)]
     interface IReceiveUln302 {
-        #[derive(Debug)]
         event PayloadVerified(address dvn, bytes header, uint256 confirmations, bytes32 proofHash);
 
         function commitVerification(bytes calldata _packetHeader, bytes32 _payloadHash) external;


### PR DESCRIPTION
Nonces in LZ seem to require some ordering, even if they call them unordered: https://docs.layerzero.network/v2/concepts/message-ordering#unordered-delivery 

It can only execute nonce `2` if `0` and `1`have been verified. However, since we both commit the verification and execute in the same transaction, we have to somewhat enforce the ordering. 

This PR:
* waits for `nonce` to be available, before estimating gas of the `execute_receive_transaction`.
* more logs if `estimate_gas` fails 