### PR TITLE
feat(db): readonly user account view

### DIFF
--- a/migrations/0023_readonly_user_account_view.sql
+++ b/migrations/0023_readonly_user_account_view.sql
@@ -1,4 +1,3 @@
--- Create a view that shows account address, email (if exists), and verification status
 CREATE OR REPLACE VIEW account_emails_view AS
 SELECT 
     encode(a.address, 'hex') as account_address,
@@ -11,8 +10,8 @@ SELECT
 FROM accounts a
 LEFT JOIN emails e ON a.address = e.address;
 
--- Create readonly user (Note: password should be changed in production)
--- The user creation might fail if it already exists, so we use DO block for conditional creation
+-- (Note: password should be changed in production)
+-- DO block for conditional creation (in case user already exists)
 DO $$
 BEGIN
     IF NOT EXISTS (SELECT FROM pg_catalog.pg_roles WHERE rolname = 'readonly_user') THEN
@@ -28,10 +27,8 @@ REVOKE ALL ON ALL TABLES IN SCHEMA public FROM readonly_user;
 REVOKE ALL ON ALL SEQUENCES IN SCHEMA public FROM readonly_user;
 REVOKE ALL ON ALL FUNCTIONS IN SCHEMA public FROM readonly_user;
 
--- Grant connect to database
 GRANT CONNECT ON DATABASE postgres TO readonly_user;
 
--- Grant usage on schema
 GRANT USAGE ON SCHEMA public TO readonly_user;
 
 -- Grant SELECT permission ONLY on the account_emails_view


### PR DESCRIPTION
- Where onramp backend is running:
a cloudflare worker

- What it’s missing:
ability to get user email from user address

- Concern:
  - we don’t want to make user email public or accessible by anyone except the user themselves
  - we don't want a double popup in order to trigger onramp

- Solution:
  - create a `account_emails_view` view in our postgres
  - create a readonly user that only has access to that view
  - use the readonly view in the worker to get the user email from address