### PR TITLE
fix: load `RELAY_FUNDER_OWNER_KEY` in config-only mode

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -156,7 +156,7 @@ pub struct Args {
     pub porto_base_url: Option<String>,
     /// The funder owner key for rebalance service.
     #[arg(long = "funder-owner-key", value_name = "KEY", env = "RELAY_FUNDER_OWNER_KEY")]
-    pub funder_owner_key: String,
+    pub funder_owner_key: Option<String>,
     /// The API key for Binance.
     #[arg(long = "binance-api-key", value_name = "KEY", env = "BINANCE_API_KEY")]
     pub binance_api_key: Option<String>,

--- a/src/config.rs
+++ b/src/config.rs
@@ -617,9 +617,10 @@ impl RelayConfig {
     }
 
     /// Sets the funder owner key, and enables the rebalance service.
-    pub fn with_funder_owner_key(mut self, funder_owner_key: String) -> Self {
+    pub fn with_funder_owner_key(mut self, funder_owner_key: Option<String>) -> Self {
+        let Some(key) = funder_owner_key else { return self };
         let Some(rebalance_service) = self.chain.rebalance_service.as_mut() else { return self };
-        rebalance_service.funder_owner_key = funder_owner_key;
+        rebalance_service.funder_owner_key = key;
         self
     }
 

--- a/src/spawn.rs
+++ b/src/spawn.rs
@@ -93,6 +93,7 @@ pub async fn try_spawn_with_args(
         config
             .with_resend_api_key(std::env::var("RESEND_API_KEY").ok())
             .with_simple_settler_owner_key(std::env::var("RELAY_SETTLER_OWNER_KEY").ok())
+            .with_funder_owner_key(std::env::var("RELAY_FUNDER_OWNER_KEY").ok())
     };
 
     let registry = if !registry_path.exists() {


### PR DESCRIPTION
variables are not being loaded as env vars declared in clap in config-only mode right now and need to be loaded separately