### PR TITLE
refactor: unify contract version call

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5160,7 +5160,6 @@ version = "18.1.7"
 dependencies = [
  "alloy",
  "alloy-chains",
- "alloy-primitives",
  "async-trait",
  "aws-config",
  "aws-sdk-kms",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,7 +114,6 @@ alloy = { version = "1.0.23", features = [
     "provider-anvil-node",
     "reqwest-rustls-tls",
 ], default-features = false }
-alloy-primitives = { version = "1.3.0", features = ["rand"] }
 derive_more = { version = "2", features = ["debug"] }
 dotenvy = "0.15"
 itertools = "0.14"

--- a/src/interop/settler/processor.rs
+++ b/src/interop/settler/processor.rs
@@ -243,8 +243,10 @@ mod tests {
     use crate::{
         interop::SimpleSettler, transactions::interop::InteropBundle, types::rpc::BundleId,
     };
-    use alloy::{primitives::Address, signers::local::PrivateKeySigner};
-    use alloy_primitives::B256;
+    use alloy::{
+        primitives::{Address, B256},
+        signers::local::PrivateKeySigner,
+    };
 
     #[tokio::test]
     async fn test_settler_id_validation_in_build_settlements() {

--- a/src/types/account.rs
+++ b/src/types/account.rs
@@ -160,24 +160,6 @@ sol! {
 
         /// Upgrades the implementation.
         function upgradeProxyAccount(address newImplementation);
-
-        /// Returns the EIP712 domain of the delegation.
-        ///
-        /// See: https://eips.ethereum.org/EIPS/eip-5267
-        function eip712Domain()
-            public
-            view
-            virtual
-            returns (
-                bytes1 fields,
-                string memory name,
-                string memory version,
-                uint256 chainId,
-                address verifyingContract,
-                bytes32 salt,
-                uint256[] memory extensions
-            );
-
     }
 }
 
@@ -229,18 +211,6 @@ impl<P: Provider> Account<P> {
             delegation: IthacaAccountInstance::new(address, provider),
             overrides: StateOverride::default(),
         }
-    }
-
-    /// Get the version of the account.
-    pub async fn version(&self) -> TransportResult<String> {
-        Ok(self
-            .delegation
-            .eip712Domain()
-            .call()
-            .overrides(self.overrides.clone())
-            .await
-            .map_err(TransportErrorKind::custom)?
-            .version)
     }
 
     /// Returns the address of the account.

--- a/src/types/orchestrator.rs
+++ b/src/types/orchestrator.rs
@@ -178,11 +178,6 @@ impl<P: Provider> Orchestrator<P> {
         self.orchestrator.address()
     }
 
-    /// Get the version of the orchestrator.
-    pub async fn version(&self) -> TransportResult<String> {
-        Ok(self.eip712_domain(false).await?.version.unwrap_or_default().to_string())
-    }
-
     /// Sets overrides for all calls on this orchestrator.
     pub fn with_overrides(mut self, overrides: StateOverride) -> Self {
         self.overrides = overrides;

--- a/src/types/rpc/calls.rs
+++ b/src/types/rpc/calls.rs
@@ -615,7 +615,7 @@ pub struct CallsStatusCapabilities {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_primitives::address;
+    use alloy::primitives::address;
     use std::str::FromStr;
 
     #[test]

--- a/tests/e2e/cases/delegation.rs
+++ b/tests/e2e/cases/delegation.rs
@@ -6,12 +6,11 @@ use crate::e2e::{
 };
 use alloy::{
     eips::eip7702::constants::EIP7702_DELEGATION_DESIGNATOR,
-    primitives::{B256, Bytes},
+    primitives::{Address, B256, Bytes, U256},
     providers::{Provider, ext::AnvilApi},
     rpc::types::TransactionRequest,
     sol_types::{SolCall, SolValue},
 };
-use alloy_primitives::{Address, U256};
 use relay::{
     rpc::RelayApiClient,
     signers::Eip712PayLoadSigner,

--- a/tests/e2e/cases/fees.rs
+++ b/tests/e2e/cases/fees.rs
@@ -4,8 +4,10 @@ use crate::e2e::{
     environment::{Environment, EnvironmentConfig},
     send_prepared_calls,
 };
-use alloy::providers::Provider;
-use alloy_primitives::{Address, U256};
+use alloy::{
+    primitives::{Address, U256},
+    providers::Provider,
+};
 use rand::{Rng, SeedableRng, rngs::StdRng};
 use relay::{
     config::TransactionServiceConfig,

--- a/tests/e2e/cases/liquidity.rs
+++ b/tests/e2e/cases/liquidity.rs
@@ -1,7 +1,7 @@
 //! Multi-chain relay end-to-end test cases
 
 use crate::e2e::{cases::upgrade_account_eagerly, *};
-use alloy_primitives::U256;
+use alloy::primitives::U256;
 use eyre::Result;
 use relay::{
     config::RebalanceServiceConfig,

--- a/tests/e2e/cases/pause.rs
+++ b/tests/e2e/cases/pause.rs
@@ -2,12 +2,11 @@ use crate::e2e::{
     await_calls_status, environment::Environment, eoa::MockAccount, send_prepared_calls,
 };
 use alloy::{
-    primitives::B256,
+    primitives::{Address, B256, U256},
     providers::{Provider, ext::AnvilApi},
     rpc::types::TransactionRequest,
     sol_types::SolCall,
 };
-use alloy_primitives::{Address, U256};
 use relay::{
     rpc::RelayApiClient,
     signers::Eip712PayLoadSigner,

--- a/tests/e2e/cases/signature.rs
+++ b/tests/e2e/cases/signature.rs
@@ -3,7 +3,7 @@ use crate::e2e::{
     cases::{upgrade_account_eagerly, upgrade_account_lazily},
     environment::Environment,
 };
-use alloy_primitives::{Address, B256};
+use alloy::primitives::{Address, B256};
 use relay::{
     rpc::RelayApiClient,
     signers::Eip712PayLoadSigner,

--- a/tests/storage/roundtrip.rs
+++ b/tests/storage/roundtrip.rs
@@ -12,10 +12,9 @@ use crate::e2e::SIGNERS_MNEMONIC;
 use alloy::{
     eips::{eip1559::Eip1559Estimation, eip7702::SignedAuthorization},
     network::{Ethereum, EthereumWallet, NetworkWallet},
-    primitives::{Address, B256, U256, bytes},
+    primitives::{Address, B256, ChainId, U256, bytes},
     rpc::types::Authorization,
 };
-use alloy_primitives::ChainId;
 use chrono::Utc;
 use opentelemetry::Context;
 use relay::{


### PR DESCRIPTION
Unifies logic for fetching version for versioned contracts instead of duplicating the logic across the codebase

As a drive-by also removes `alloy-primitives`