### PR TITLE
bug: fix escrowing native token

### DIFF
--- a/src/rpc/relay.rs
+++ b/src/rpc/relay.rs
@@ -2218,7 +2218,7 @@ impl Relay {
             salt,
             depositor: context.eoa,
             recipient: self.inner.contracts.funder.address,
-            token: if context.asset.is_native() { Address::ZERO } else { context.asset.address() },
+            token: context.asset.address(),
             settler: self
                 .inner
                 .chains

--- a/src/types/intent.rs
+++ b/src/types/intent.rs
@@ -1,6 +1,5 @@
 use super::{
-    Asset, Call, IDelegation::authorizeCall, Key, LazyMerkleTree, MerkleLeafInfo,
-    OrchestratorContract,
+    Call, IDelegation::authorizeCall, Key, LazyMerkleTree, MerkleLeafInfo, OrchestratorContract,
 };
 use crate::{
     error::{IntentError, MerkleError},
@@ -8,7 +7,10 @@ use crate::{
         CallPermission,
         IthacaAccount::{setCanExecuteCall, setSpendLimitCall},
         Orchestrator, Signature,
-        rpc::{AuthorizeKey, AuthorizeKeyResponse, BalanceOverrides, Permission, SpendPermission},
+        rpc::{
+            AddressOrNative, AuthorizeKey, AuthorizeKeyResponse, BalanceOverrides, Permission,
+            SpendPermission,
+        },
     },
 };
 use alloy::{
@@ -627,7 +629,7 @@ pub struct FundingIntentContext {
     /// The chain where funds will be escrowed
     pub chain_id: ChainId,
     /// The asset to be escrowed (native or ERC20)
-    pub asset: Asset,
+    pub asset: AddressOrNative,
     /// The amount to escrow
     pub amount: U256,
     /// The fee token to use for gas payment

--- a/src/types/rpc/assets.rs
+++ b/src/types/rpc/assets.rs
@@ -19,14 +19,16 @@ pub enum AddressOrNative {
 
 impl AddressOrNative {
     /// Returns the address
-    ///
-    /// # Panics
-    /// It will panic if self is of the native variant.
     pub fn address(&self) -> Address {
         match self {
             AddressOrNative::Address(address) => *address,
             AddressOrNative::Native => Address::ZERO,
         }
+    }
+
+    /// Whether it is the native asset from a chain.
+    pub fn is_native(&self) -> bool {
+        matches!(self, Self::Native)
     }
 }
 


### PR DESCRIPTION
context.asset.address() will panic here if using the native token

https://github.com/ithacaxyz/relay/blob/fd0a1c2006e9c90c3f6c7df96485a8a48df729a3/src/types/asset_diff.rs#L122

follow-up: will push a local stress test env CI job that covers this