### PR TITLE
fix: zero balance edge case

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -10,6 +10,11 @@ use std::time::Duration;
 /// bet.
 pub const P256_GAS_BUFFER: U256 = uint!(10_000_U256);
 
+/// Extra buffer accounting for the cost of a cold storage write.
+///
+/// 20_000 - 2900 gas
+pub const COLD_SSTORE_GAS_BUFFER: U256 = uint!(17_100_U256);
+
 /// Extra buffer added to Intent gas estimates to cover execution overhead
 /// and ensure sufficient gas is provided.
 pub const INTENT_GAS_BUFFER: u64 = 0;

--- a/src/rpc/relay.rs
+++ b/src/rpc/relay.rs
@@ -11,7 +11,7 @@
 
 use crate::{
     asset::AssetInfoServiceHandle,
-    constants::ESCROW_SALT_LENGTH,
+    constants::{COLD_SSTORE_GAS_BUFFER, ESCROW_SALT_LENGTH, P256_GAS_BUFFER},
     error::{IntentError, StorageError},
     provider::ProviderExt,
     signers::Eip712PayLoadSigner,
@@ -440,6 +440,16 @@ impl Relay {
             intent_to_sign.funder = self.inner.contracts.funder.address;
         }
 
+        let gas_validation_offset =
+            // Account for gas variation in P256 sig verification.
+            if context.account_key.keyType.is_secp256k1() { U256::ZERO } else { P256_GAS_BUFFER }
+                // Account for the case when we change zero fee token balance to non-zero, thus skipping a cold storage write
+                + if fee_token_balance.is_zero() && !new_fee_token_balance.is_zero() && !context.fee_token.is_zero() {
+                    COLD_SSTORE_GAS_BUFFER
+                } else {
+                    U256::ZERO
+                };
+
         // For simulation purposes we only simulate with a payment of 1 unit of the fee token. This
         // should be enough to simulate the gas cost of paying for the intent for most (if not all)
         // ERC20s.
@@ -453,8 +463,8 @@ impl Relay {
             .simulate_execute(
                 self.simulator(),
                 &intent_to_sign,
-                context.account_key.keyType,
                 self.inner.asset_info.clone(),
+                gas_validation_offset,
             )
             .await?;
 

--- a/src/types/orchestrator.rs
+++ b/src/types/orchestrator.rs
@@ -14,10 +14,9 @@ use alloy::{
 };
 use tracing::{debug, trace};
 
-use super::{KeyType, SimulationResult, Simulator::SimulatorInstance};
+use super::{SimulationResult, Simulator::SimulatorInstance};
 use crate::{
     asset::AssetInfoServiceHandle,
-    constants::P256_GAS_BUFFER,
     error::{IntentError, RelayError},
     types::{AssetDiffs, Intent, OrchestratorContract::IntentExecuted},
 };
@@ -191,13 +190,9 @@ impl<P: Provider> Orchestrator<P> {
         &self,
         simulator: Address,
         intent: &Intent,
-        key_type: KeyType,
         asset_info_handle: AssetInfoServiceHandle,
+        gas_validation_offset: U256,
     ) -> Result<(AssetDiffs, SimulationResult), RelayError> {
-        // Allows to account for gas variation in P256 sig verification.
-        let gas_validation_offset =
-            if key_type.is_secp256k1() { U256::ZERO } else { P256_GAS_BUFFER };
-
         let simulate_block = SimBlock::default()
             .call(
                 SimulatorInstance::new(simulator, self.orchestrator.provider())


### PR DESCRIPTION
Right now because of us overriding fee token balance from 0 to 1 during estimation it is possible that simulation will not account for a cold storage write increasing the balance.

This PR adds a test and fix for it. The fix is to manually add the missing amount of gas to the gas estimate