### PR TITLE
fix(relay)!: update get_capabilities method to use U64 for chain IDs

### DIFF
--- a/src/bin/stress.rs
+++ b/src/bin/stress.rs
@@ -19,7 +19,7 @@
 use alloy::{
     consensus::constants::ETH_TO_WEI,
     network::EthereumWallet,
-    primitives::{Address, B256, ChainId, U256, address, keccak256},
+    primitives::{Address, B256, ChainId, U64, U256, address, keccak256},
     providers::{
         Provider, ProviderBuilder,
         fillers::{CachedNonceManager, ChainIdFiller, GasFiller, NonceFiller},
@@ -277,7 +277,9 @@ impl StressTester {
         info!("Output chain is {destination_chain_id}");
 
         // Get capabilities for all chains
-        let caps = relay_client.get_capabilities(Some(chain_ids.clone())).await?;
+        let caps = relay_client
+            .get_capabilities(Some(chain_ids.iter().map(|&id| U64::from(id)).collect()))
+            .await?;
 
         // Build fee token mapping across all chains
         let fee_token_map = build_fee_token_map(&caps, &chain_ids, args.fee_token).await?;

--- a/src/rpc/relay.rs
+++ b/src/rpc/relay.rs
@@ -41,7 +41,7 @@ use alloy::{
         eip1559::Eip1559Estimation,
         eip7702::{SignedAuthorization, constants::EIP7702_DELEGATION_DESIGNATOR},
     },
-    primitives::{Address, B256, BlockNumber, Bytes, ChainId, U256, U64, aliases::B192, bytes},
+    primitives::{Address, B256, BlockNumber, Bytes, ChainId, U64, U256, aliases::B192, bytes},
     providers::{
         DynProvider, Provider,
         utils::{EIP1559_FEE_ESTIMATION_PAST_BLOCKS, Eip1559Estimator},

--- a/tests/e2e/cases/assets.rs
+++ b/tests/e2e/cases/assets.rs
@@ -10,7 +10,7 @@ use crate::e2e::{
     send_prepared_calls,
 };
 use alloy::{
-    primitives::{Address, U256},
+    primitives::{Address, U64, U256},
     sol_types::SolCall,
 };
 use relay::{
@@ -373,7 +373,7 @@ async fn get_assets_no_filter() -> eyre::Result<()> {
     // Gets the number of fee tokens in the environment chain
     let chain_fee_tokens_num = env
         .relay_endpoint
-        .get_capabilities(Some(vec![env.chain_id()]))
+        .get_capabilities(Some(vec![U64::from(env.chain_id())]))
         .await?
         .0
         .get(&env.chain_id())

--- a/tests/e2e/cases/delegation.rs
+++ b/tests/e2e/cases/delegation.rs
@@ -6,7 +6,7 @@ use crate::e2e::{
 };
 use alloy::{
     eips::eip7702::constants::EIP7702_DELEGATION_DESIGNATOR,
-    primitives::{Address, B256, Bytes, U256},
+    primitives::{Address, B256, Bytes, U64, U256},
     providers::{Provider, ext::AnvilApi},
     rpc::types::TransactionRequest,
     sol_types::{SolCall, SolValue},
@@ -26,7 +26,7 @@ use relay::{
 #[tokio::test(flavor = "multi_thread")]
 async fn catch_invalid_delegation() -> eyre::Result<()> {
     let env = Environment::setup().await?;
-    let caps = env.relay_endpoint.get_capabilities(Some(vec![env.chain_id()])).await?;
+    let caps = env.relay_endpoint.get_capabilities(Some(vec![U64::from(env.chain_id())])).await?;
     let admin_key = KeyWith712Signer::random_admin(KeyType::Secp256k1)?.unwrap();
 
     // Set up account correctly.
@@ -263,7 +263,7 @@ async fn upgrade_delegation(env: &Environment, address: Address) {
 async fn upgrade_delegation_with_precall() -> eyre::Result<()> {
     let env = Environment::setup().await?;
 
-    let caps = env.relay_endpoint.get_capabilities(Some(vec![env.chain_id()])).await?;
+    let caps = env.relay_endpoint.get_capabilities(Some(vec![U64::from(env.chain_id())])).await?;
     let admin_key = KeyWith712Signer::random_admin(KeyType::Secp256k1)?.unwrap();
 
     upgrade_account_lazily(&env, &[admin_key.to_authorized()], AuthKind::Auth).await?;

--- a/tests/e2e/cases/fees.rs
+++ b/tests/e2e/cases/fees.rs
@@ -5,7 +5,7 @@ use crate::e2e::{
     send_prepared_calls,
 };
 use alloy::{
-    primitives::{Address, U256},
+    primitives::{Address, U64, U256},
     providers::Provider,
 };
 use rand::{Rng, SeedableRng, rngs::StdRng};
@@ -90,7 +90,7 @@ async fn ensure_valid_fees() -> eyre::Result<()> {
 
     let kind = env
         .relay_endpoint
-        .get_capabilities(Some(vec![env.chain_id()]))
+        .get_capabilities(Some(vec![U64::from(env.chain_id())]))
         .await?
         .chain(env.chain_id())
         .fees

--- a/tests/e2e/cases/relay.rs
+++ b/tests/e2e/cases/relay.rs
@@ -1,4 +1,5 @@
 use crate::e2e::environment::Environment;
+use alloy::primitives::U64;
 use relay::rpc::RelayApiClient;
 use semver::{self, Version};
 
@@ -6,7 +7,8 @@ use semver::{self, Version};
 async fn versioned_contracts() -> eyre::Result<()> {
     let env = Environment::setup().await?;
 
-    let capabilities = env.relay_endpoint.get_capabilities(Some(vec![env.chain_id()])).await?;
+    let capabilities =
+        env.relay_endpoint.get_capabilities(Some(vec![U64::from(env.chain_id())])).await?;
 
     Version::parse(
         capabilities.chain(env.chain_id()).contracts.orchestrator.version.as_ref().unwrap(),


### PR DESCRIPTION
This change modifies the `get_capabilities` method in the `RelayApi` trait and its implementation to accept a vector of `U64` instead of `ChainId`. 

Issues: 
- https://github.com/ithacaxyz/relay/issues/1085

- https://github.com/ithacaxyz/relay/issues/955

Reading references for knowledge:
- https://gist.github.com/yongkangc/bb6e0ddb6b1b11ec27755ec4265867ea