### PR TITLE
release: v19.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5200,7 +5200,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "relay"
-version = "18.2.1"
+version = "19.0.0"
 dependencies = [
  "alloy",
  "alloy-chains",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "relay"
-version = "18.2.1"
+version = "19.0.0"
 edition = "2024"
 publish = false
 


### PR DESCRIPTION
## Release v19.0.0

This PR bumps the relay version to v19.0.0.

### Related Issues and PRs
- Fixes #955 
- Related to #1087 

### Changes
- Bump version from 18.2.1 to 19.0.0 in Cargo.toml
- Update Cargo.lock