### PR TITLE
fix: only try multichain if `required_asset` is interop enabled

### DIFF
--- a/src/rpc/relay.rs
+++ b/src/rpc/relay.rs
@@ -1093,6 +1093,7 @@ impl Relay {
         // todo: this only supports one asset...
         if let Some(required_funds) = request.capabilities.required_funds.first()
             && self.inner.chains.interop().is_some()
+            && self.inner.chains.interop_asset(request.chain_id, required_funds.address).is_some()
         {
             self.determine_quote_strategy(
                 request,


### PR DESCRIPTION
We detected some issues running stress tests with our current staging configuration, which is a set of chains without interop enabled. The issue turned out to be the fact that we set `required_funds`, which leads us into the multichain branches of the relay.

This simply does a check before going into that branch to see if the asset we're requesting is even interop enabled.

A better fix would be https://github.com/ithacaxyz/relay/issues/948