### PR TITLE
feat: integrate simmode in chain

### DIFF
--- a/src/chains.rs
+++ b/src/chains.rs
@@ -12,7 +12,7 @@ use tracing::{info, warn};
 use url::Url;
 
 use crate::{
-    config::RelayConfig,
+    config::{RelayConfig, SimMode},
     constants::DEFAULT_POLL_INTERVAL,
     error::RelayError,
     liquidity::{
@@ -49,6 +49,8 @@ pub struct Chain {
     chain_id: ChainId,
     /// The supported assets on the chain.
     assets: Assets,
+    /// The simulation mode this chain supports
+    sim_mode: SimMode,
 }
 
 impl Chain {
@@ -75,6 +77,11 @@ impl Chain {
     /// Returns access to the [`TransactionService`] via its handle.
     pub const fn transactions(&self) -> &TransactionServiceHandle {
         &self.transactions
+    }
+
+    /// Returns the simulation mode [`SimMode`] that should be used when simulating calls.
+    pub const fn sim_mode(&self) -> SimMode {
+        self.sim_mode
     }
 }
 
@@ -130,6 +137,7 @@ impl Chains {
                         is_optimism,
                         chain_id: chain.id(),
                         assets: desc.assets.clone(),
+                        sim_mode: desc.sim_mode,
                     },
                 ))
             }))

--- a/src/config.rs
+++ b/src/config.rs
@@ -404,6 +404,13 @@ pub enum SimMode {
     Trace,
 }
 
+impl SimMode {
+    /// Returns true if this is [`SimMode::SimulateV1`]
+    pub const fn is_simulate_v1(&self) -> bool {
+        matches!(self, Self::SimulateV1)
+    }
+}
+
 /// Quote configuration.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/src/rpc/relay.rs
+++ b/src/rpc/relay.rs
@@ -510,6 +510,7 @@ impl Relay {
                 &intent_to_sign,
                 self.inner.asset_info.clone(),
                 gas_validation_offset,
+                chain.sim_mode(),
             )
             .await?;
 


### PR DESCRIPTION
propagates the existing simmode config to the `Chain` type and respecting it when doing simulation.

kept the hardcoded check until infra is confirmed