### PR TITLE
feat: propagate feeconfig to signer

### DIFF
--- a/src/chains.rs
+++ b/src/chains.rs
@@ -124,7 +124,6 @@ impl Chains {
 
                 let provider =
                     try_build_provider(chain.id(), &desc.endpoint, desc.sequencer.as_ref()).await?;
-                // TODO(mattsse): integrate fee config here?
                 let (service, handle) = TransactionService::new(
                     provider.clone(),
                     desc.flashblocks.as_ref(),
@@ -132,6 +131,7 @@ impl Chains {
                     storage.clone(),
                     config.transactions.clone(),
                     config.funder,
+                    desc.fees.clone(),
                 )
                 .await?;
                 tokio::spawn(service);

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -123,7 +123,7 @@ pub struct Args {
     /// Default value is `20.0` which means that priority fee for transactions will be chosen as
     /// 20th percentile of the priority fees of transactions in latest blocks.
     #[arg(long = "priority-fee-percentile", value_name = "PERCENTILE", default_value_t = EIP1559_FEE_ESTIMATION_REWARD_PERCENTILE)]
-    pub priority_fee_percentile: f64,
+    pub priority_fee_percentile: f64, // TODO(mattsse): remove
     /// Reads all values from the config file.
     ///
     /// This makes required CLI args not required, but it is important that any required CLI args
@@ -186,7 +186,6 @@ impl Args {
             .with_database_url(self.database_url)
             .with_max_pending_transactions(self.max_pending_transactions)
             .with_num_signers(self.num_signers)
-            .with_priority_fee_percentile(self.priority_fee_percentile)
             .with_resend_api_key(self.resend_api_key)
             .with_porto_base_url(self.porto_base_url)
             .with_binance_keys(self.binance_api_key, self.binance_api_secret)

--- a/src/config.rs
+++ b/src/config.rs
@@ -231,12 +231,6 @@ impl RelayConfig {
         self
     }
 
-    /// Sets the percentile of the priority fees to use for the transactions.
-    pub fn with_priority_fee_percentile(mut self, percentile: f64) -> Self {
-        self.transactions.priority_fee_percentile = percentile;
-        self
-    }
-
     /// Sets the Resend API key.
     pub fn with_resend_api_key(mut self, api_key: Option<String>) -> Self {
         self.email.resend_api_key = api_key.or(self.email.resend_api_key);
@@ -707,8 +701,6 @@ pub struct TransactionServiceConfig {
     /// for querying transactions.
     #[serde(with = "crate::serde::hash_map")]
     pub public_node_endpoints: HashMap<Chain, Url>,
-    /// Percentile of the priority fees to use for the transactions.
-    pub priority_fee_percentile: f64,
 }
 
 impl Default for TransactionServiceConfig {
@@ -722,7 +714,6 @@ impl Default for TransactionServiceConfig {
             transaction_timeout: Duration::from_secs(60),
             max_queued_per_eoa: 1,
             public_node_endpoints: HashMap::default(),
-            priority_fee_percentile: EIP1559_FEE_ESTIMATION_REWARD_PERCENTILE,
         }
     }
 }

--- a/src/rpc/relay.rs
+++ b/src/rpc/relay.rs
@@ -160,7 +160,6 @@ impl Relay {
         fee_recipient: Address,
         storage: RelayStorage,
         asset_info: AssetInfoServiceHandle,
-        priority_fee_percentile: f64,
         escrow_refund_threshold: u64,
     ) -> Self {
         let inner = RelayInner {
@@ -173,7 +172,6 @@ impl Relay {
             price_oracle,
             storage,
             asset_info,
-            priority_fee_percentile,
             escrow_refund_threshold,
         };
         Self { inner: Arc::new(inner) }
@@ -353,7 +351,7 @@ impl Relay {
                     .get_fee_history(
                         EIP1559_FEE_ESTIMATION_PAST_BLOCKS,
                         Default::default(),
-                        &[self.inner.priority_fee_percentile],
+                        &[chain.fee_config().priority_fee_percentile],
                     )
                     .await
                     .map_err(RelayError::from)
@@ -2194,8 +2192,6 @@ pub(super) struct RelayInner {
     storage: RelayStorage,
     /// AssetInfo
     asset_info: AssetInfoServiceHandle,
-    /// Percentile of the priority fees to use for the transactions.
-    priority_fee_percentile: f64,
     /// Escrow refund threshold in seconds
     escrow_refund_threshold: u64,
 }

--- a/src/spawn.rs
+++ b/src/spawn.rs
@@ -170,7 +170,6 @@ pub async fn try_spawn(config: RelayConfig, skip_diagnostics: bool) -> eyre::Res
         config.fee_recipient,
         storage.clone(),
         asset_info_handle,
-        config.transactions.priority_fee_percentile,
         config
             .interop
             .as_ref()

--- a/tests/e2e/cases/transactions.rs
+++ b/tests/e2e/cases/transactions.rs
@@ -19,7 +19,7 @@ use futures_util::{
 };
 use rand::{Rng, SeedableRng, rngs::StdRng};
 use relay::{
-    config::TransactionServiceConfig,
+    config::{FeeConfig, TransactionServiceConfig},
     signers::DynSigner,
     storage::StorageApi,
     transactions::{MIN_SIGNER_GAS, RelayTransactionKind, TransactionService, TransactionStatus},
@@ -626,6 +626,7 @@ async fn restart_with_pending() -> eyre::Result<()> {
         storage.clone(),
         config.transaction_service_config.clone(),
         env.funder,
+        FeeConfig::default(),
     )
     .await
     .unwrap();


### PR DESCRIPTION
towards https://github.com/ithacaxyz/relay/issues/1136 https://github.com/ithacaxyz/relay/issues/1128

effectively deprecates the global fee_percentile setting and uses the chain specific one in the signer

needs followup to enforce minimum fee, and pr for infra