### PR TITLE
chore: use intent settler address for `build_execute_send_transaction`

### DIFF
--- a/src/interop/settler/mod.rs
+++ b/src/interop/settler/mod.rs
@@ -52,6 +52,7 @@ pub trait Settler: Send + Sync + std::fmt::Debug {
         current_chain_id: u64,
         source_chains: Vec<u64>,
         orchestrator: Address,
+        intent_settler: Address,
     ) -> Result<Option<RelayTransaction>, SettlementError>;
 
     /// Encodes the settler-specific context for the given destination chains.

--- a/src/interop/settler/processor.rs
+++ b/src/interop/settler/processor.rs
@@ -197,14 +197,15 @@ impl SettlementProcessor {
                 "Building settlement transaction for destination"
             );
 
-            let orchestrator = dst_tx.quote().ok_or(SettlementError::MissingIntent)?.orchestrator;
+            let quote = dst_tx.quote().ok_or(SettlementError::MissingIntent)?;
             let result = self
                 .settler
                 .build_execute_send_transaction(
                     settlement_id,
                     destination_chain,
                     source_chains.clone(),
-                    orchestrator,
+                    quote.orchestrator,
+                    quote.intent.settler,
                 )
                 .await?;
 

--- a/src/interop/settler/simple.rs
+++ b/src/interop/settler/simple.rs
@@ -137,6 +137,7 @@ impl Settler for SimpleSettler {
         _current_chain_id: ChainId,
         _source_chains: Vec<ChainId>,
         _orchestrator: Address,
+        _intent_settler: Address,
     ) -> Result<Option<RelayTransaction>, SettlementError> {
         // The settlement is handled directly during intent execution
         Ok(None)

--- a/src/transactions/interop.rs
+++ b/src/transactions/interop.rs
@@ -1316,6 +1316,7 @@ mod tests {
             _current_chain_id: u64,
             _source_chains: Vec<u64>,
             _orchestrator: Address,
+            _intent_settler: Address,
         ) -> Result<Option<RelayTransaction>, crate::interop::SettlementError> {
             Ok(Some(RelayTransaction::new_internal(Address::default(), vec![], 0, 1_000_000)))
         }


### PR DESCRIPTION
## Summary
- Pass intent's settler address to `build_execute_send_transaction` instead of using relay's configured settler. We need this, in case we pass a new settler address to the Relay config, and we still need to handle old interop bundles using old settlement addresses.

## Changes
- Add `intent_settler` parameter to `Settler` trait's `build_execute_send_transaction` method
- Extract and pass `intent.settler` from quote in `SettlementProcessor`


🤖 Generated with [Claude Code](https://claude.ai/code)