### PR TITLE
chore: bump chains

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,9 +87,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-chains"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4195a29a4b87137b2bb02105e746102873bc03561805cf45c0e510c961f160e6"
+checksum = "a379c0d821498c996ceb9e7519fc2dab8286c35a203c1fb95f80ecd66e07cf2f"
 dependencies = [
  "alloy-primitives",
  "num_enum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ alloy = { version = "1.0.23", features = [
     "signer-aws",
     "rand",
 ], default-features = false }
-alloy-chains = "0.2"
+alloy-chains = "0.2.7"
 async-trait = "0.1"
 aws-config = "1.8"
 aws-sdk-kms = { version = "1", default-features = false }


### PR DESCRIPTION
includes is_opstack for katana and celo