### PR TITLE
chore: `.zed/settings.json` to exclude accounts submodule

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,0 +1,5 @@
+// Folder-specific settings
+//
+// For a full list of overridable settings, and general information on folder-specific settings,
+// see the documentation: https://zed.dev/docs/configuring-zed#settings-files
+{ "file_scan_exclusions": ["tests/account/**"] }


### PR DESCRIPTION
It's a common practice to exclude the submodules from search and commit this file, see https://github.com/zed-industries/zed/blob/9e8ec72bd5c697edc6b61f4e18542afc4e343a1b/.zed/settings.json#L50-L63