### PR TITLE
feat: use chain specific signers

### DIFF
--- a/src/diagnostics/mod.rs
+++ b/src/diagnostics/mod.rs
@@ -6,15 +6,13 @@
 mod chain;
 mod layerzero;
 
-use std::sync::Arc;
-
 use chain::ConnectedChains;
 pub use chain::{ChainDiagnostics, ChainDiagnosticsResult};
+use std::sync::Arc;
 
 use crate::{
     chains::Chains,
     config::{RelayConfig, SettlerImplementation},
-    signers::DynSigner,
 };
 use eyre::Result;
 use futures_util::future::try_join_all;
@@ -76,7 +74,6 @@ impl DiagnosticsReport {
 pub async fn run_diagnostics(
     config: &RelayConfig,
     chains: Arc<Chains>,
-    signers: &[DynSigner],
 ) -> Result<DiagnosticsReport> {
     let mut report = DiagnosticsReport {
         chains: Vec::new(),
@@ -95,7 +92,7 @@ pub async fn run_diagnostics(
     // Run chain diagnostics
     report.chains = try_join_all(chains.chains_iter().map(async |chain| {
         info!(chain_id = %chain.id(), "Running diagnostics");
-        ChainDiagnostics::new(chain.clone(), config).run(signers).await
+        ChainDiagnostics::new(chain.clone(), config).run().await
     }))
     .await?;
 

--- a/src/metrics/periodic/mod.rs
+++ b/src/metrics/periodic/mod.rs
@@ -4,7 +4,6 @@ use types::{BalanceCollector, LatencyCollector};
 mod job;
 use job::PeriodicJob;
 
-use alloy::primitives::Address;
 use std::{fmt::Debug, future::Future, sync::Arc, time::Duration};
 
 use crate::chains::Chains;
@@ -23,12 +22,9 @@ pub trait MetricCollector: Debug {
 }
 
 /// Spawns all available periodic metric collectors.
-pub async fn spawn_periodic_collectors(
-    signers: Vec<Address>,
-    chains: Arc<Chains>,
-) -> Result<(), MetricCollectorError> {
+pub async fn spawn_periodic_collectors(chains: Arc<Chains>) -> Result<(), MetricCollectorError> {
     PeriodicJob::launch_task(
-        BalanceCollector::new(signers, chains.clone()),
+        BalanceCollector::new(chains.clone()),
         tokio::time::interval(Duration::from_secs(5)),
     );
 


### PR DESCRIPTION
this is a  #1169 followup that moves signers into `Chain` this way we can obtain chain specific signers.

this simplifies the api a bit and also makes is possible to make some future simplifications