### PR TITLE
chore: release 21.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5229,7 +5229,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "relay"
-version = "21.0.4"
+version = "21.1.0"
 dependencies = [
  "alloy",
  "alloy-chains",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "relay"
-version = "21.0.4"
+version = "21.1.0"
 edition = "2024"
 publish = false
 


### PR DESCRIPTION
## Configuration Changes Required

### 1. Per-chain signer configuration (optional but recommended)

If you were using the `--num-signers` CLI flag, migrate to per-chain configuration:

```yaml
chains:
  base:
    endpoint: "..."
    signers:
      num_signers: 10  # Previously set via --num-signers flag
  optimism:
    endpoint: "..."
    signers:
      num_signers: 10
```

### 2. Signer balance configuration (optional)

New optional field for better signer balance management:

```yaml
chains:
  base:
    fees:
      signer_balance_config:
        type: gas  # or "balance"
        value: 1000000
```

### 3. New API Endpoint

* Added `wallet_addFaucetFunds` RPC method for faucet functionality (#1139)

### Other Changes

* Performance improvements for parallel funding simulations
* LayerZero settler improvements
* One log subscription per chain for better resource management