### PR TITLE
chore: rm outdated global num_signer setting

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,8 +2,8 @@
 use crate::{
     config::RelayConfig,
     constants::{
-        DEFAULT_MAX_TRANSACTIONS, DEFAULT_NUM_SIGNERS, DEFAULT_RPC_DEFAULT_MAX_CONNECTIONS,
-        INTENT_GAS_BUFFER, TX_GAS_BUFFER,
+        DEFAULT_MAX_TRANSACTIONS, DEFAULT_RPC_DEFAULT_MAX_CONNECTIONS, INTENT_GAS_BUFFER,
+        TX_GAS_BUFFER,
     },
     spawn::try_spawn_with_args,
 };
@@ -100,10 +100,6 @@ pub struct Args {
     /// The mnemonic to use for deriving transaction signers.
     #[arg(long = "signers-mnemonic", value_name = "MNEMONIC", env = "RELAY_MNEMONIC")]
     pub signers_mnemonic: Mnemonic<English>,
-    /// The number of signers to derive from mnemonic and use to send transactions.
-    #[arg(long = "num-signers", value_name = "NUM", default_value_t = DEFAULT_NUM_SIGNERS)]
-    // TODO(mattsse): remove
-    pub num_signers: usize,
     /// The funder signing key (hex private key or KMS ARN).
     #[arg(
         long = "funder-signing-key",

--- a/src/config.rs
+++ b/src/config.rs
@@ -802,8 +802,6 @@ impl LayerZeroConfig {
 /// Configuration for transaction service.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct TransactionServiceConfig {
-    /// Number of signers to derive from mnemonic and use for sending transactions.
-    pub num_signers: usize,
     /// Maximum number of transactions that can be pending at any given time.
     pub max_pending_transactions: usize,
     /// Maximum number of pending transactions that can be handled by a single signer.
@@ -828,7 +826,6 @@ pub struct TransactionServiceConfig {
 impl Default for TransactionServiceConfig {
     fn default() -> Self {
         Self {
-            num_signers: DEFAULT_NUM_SIGNERS,
             max_pending_transactions: DEFAULT_MAX_TRANSACTIONS,
             max_transactions_per_signer: 16,
             balance_check_interval: Duration::from_secs(5),

--- a/tests/e2e/cases/cli.rs
+++ b/tests/e2e/cases/cli.rs
@@ -38,7 +38,6 @@ async fn respawn_cli() -> eyre::Result<()> {
                 tx_gas_buffer: Default::default(),
                 database_url: Default::default(),
                 max_pending_transactions: Default::default(),
-                num_signers: Default::default(),
                 signers_mnemonic: mnemonic.parse().unwrap(),
                 funder_key: Some(B256::random().to_string()),
                 service_api_key: Default::default(),

--- a/tests/e2e/cases/fees.rs
+++ b/tests/e2e/cases/fees.rs
@@ -10,7 +10,6 @@ use alloy::{
 };
 use rand::{Rng, SeedableRng, rngs::StdRng};
 use relay::{
-    config::TransactionServiceConfig,
     rpc::RelayApiClient,
     signers::Eip712PayLoadSigner,
     types::{
@@ -25,10 +24,7 @@ async fn ensure_valid_fees() -> eyre::Result<()> {
     let fee_recipient = Address::random();
     let env = Environment::setup_with_config(EnvironmentConfig {
         fee_recipient,
-        transaction_service_config: TransactionServiceConfig {
-            num_signers: 1,
-            ..Default::default()
-        },
+        num_signers: 1,
         ..Default::default()
     })
     .await?;

--- a/tests/e2e/cases/multichain_usdt_transfer.rs
+++ b/tests/e2e/cases/multichain_usdt_transfer.rs
@@ -21,7 +21,6 @@ use alloy::{
 };
 use eyre::Result;
 use relay::{
-    config::TransactionServiceConfig,
     rpc::RelayApiClient,
     types::{
         Call, IERC20, KeyType, KeyWith712Signer,
@@ -196,15 +195,8 @@ impl MultichainTransferSetup {
     ) -> Result<Self> {
         let num_chains = 3;
         // Set up environment configuration
-        let mut env_config = EnvironmentConfig {
-            num_chains,
-            use_layerzero,
-            transaction_service_config: TransactionServiceConfig {
-                num_signers: 1,
-                ..Default::default()
-            },
-            ..Default::default()
-        };
+        let mut env_config =
+            EnvironmentConfig { num_chains, use_layerzero, num_signers: 1, ..Default::default() };
 
         // Override refund threshold if specified
         if let Some(threshold) = escrow_refund_threshold {

--- a/tests/e2e/cases/transactions.rs
+++ b/tests/e2e/cases/transactions.rs
@@ -354,7 +354,6 @@ async fn pause_out_of_funds() -> eyre::Result<()> {
     let env = Environment::setup_with_config(EnvironmentConfig {
         block_time: Some(0.2),
         transaction_service_config: TransactionServiceConfig {
-            num_signers,
             // set lower interval to make sure that we hit the pause logic
             balance_check_interval: Duration::from_millis(100),
             // set lower throughput to make sure that transactions are not getting included too
@@ -363,6 +362,7 @@ async fn pause_out_of_funds() -> eyre::Result<()> {
             ..Default::default()
         },
         fork_block_number: pinned_test_fork_block_number(),
+        num_signers,
         ..Default::default()
     })
     .await
@@ -438,7 +438,6 @@ async fn resume_paused() -> eyre::Result<()> {
     let env = Environment::setup_with_config(EnvironmentConfig {
         block_time: Some(0.2),
         transaction_service_config: TransactionServiceConfig {
-            num_signers,
             // set lower interval to make sure that we hit the pause logic
             balance_check_interval: Duration::from_millis(100),
             // set lower throughput to make sure that transactions are not getting included too
@@ -447,6 +446,7 @@ async fn resume_paused() -> eyre::Result<()> {
             ..Default::default()
         },
         fork_block_number: pinned_test_fork_block_number(),
+        num_signers,
         ..Default::default()
     })
     .await
@@ -575,11 +575,8 @@ async fn restart_with_pending() -> eyre::Result<()> {
         },
         ..Default::default()
     };
-    let signers = DynSigner::derive_from_mnemonic(
-        SIGNERS_MNEMONIC.parse()?,
-        config.transaction_service_config.num_signers,
-    )
-    .unwrap();
+    let signers =
+        DynSigner::derive_from_mnemonic(SIGNERS_MNEMONIC.parse()?, config.num_signers).unwrap();
     let env = Environment::setup_with_config(config.clone()).await.unwrap();
     let tx_service_handle =
         env.relay_handle.chains.get(env.chain_id()).unwrap().transactions().clone();
@@ -659,7 +656,6 @@ async fn test_signer_pull_gas() -> eyre::Result<()> {
         block_time: Some(0.5),
         transaction_service_config: TransactionServiceConfig {
             balance_check_interval: Duration::from_millis(100), // Check balance every 100ms
-            num_signers: 1,
             ..Default::default()
         },
         ..Default::default()

--- a/tests/e2e/environment.rs
+++ b/tests/e2e/environment.rs
@@ -58,6 +58,7 @@ pub struct EnvironmentConfig {
     pub block_time: Option<f64>,
     pub transaction_service_config: TransactionServiceConfig,
     pub rebalance_service_config: Option<RebalanceServiceConfig>,
+    pub num_signers: usize,
     /// The default block number to use for forking.
     ///
     /// Negative value represents `latest - num`.
@@ -74,11 +75,9 @@ pub struct EnvironmentConfig {
 impl Default for EnvironmentConfig {
     fn default() -> Self {
         Self {
+            num_signers: 1,
             block_time: None,
-            transaction_service_config: TransactionServiceConfig {
-                num_signers: 1,
-                ..Default::default()
-            },
+            transaction_service_config: TransactionServiceConfig::default(),
             rebalance_service_config: None,
             fork_block_number: None,
             fee_recipient: Address::ZERO,
@@ -412,10 +411,8 @@ impl Environment {
             .await
             .wrap_err("Relay signer load failed")?;
 
-        let signers = DynSigner::derive_from_mnemonic(
-            SIGNERS_MNEMONIC.parse()?,
-            config.transaction_service_config.num_signers,
-        )?;
+        let signers =
+            DynSigner::derive_from_mnemonic(SIGNERS_MNEMONIC.parse()?, config.num_signers)?;
 
         let eoa = DynSigner::from_signing_key(
             &std::env::var("TEST_EOA_PRIVATE_KEY").unwrap_or(EOA_PRIVATE_KEY.to_string()),
@@ -557,9 +554,7 @@ impl Environment {
                             flashblocks: None,
                             sim_mode: Default::default(),
                             fees: Default::default(),
-                            signers: SignerConfig {
-                                num_signers: config.transaction_service_config.num_signers,
-                            },
+                            signers: SignerConfig { num_signers: config.num_signers },
                         },
                     )
                 },


### PR DESCRIPTION
this can be removed now that this is chain specific.

this was used in the envconfig so I instead moved this to the envconfig itself