### PR TITLE
feat(config): make signer top up multiplier configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,9 @@ chains:
             value: 10000000000
         # optional, the minimum fee to set in wei
         minimum_fee: 100
+        # optional, the amount to multiply the min signer balance when determining how much to fund
+        # the account by when it is paused. The default is 3
+        top_up_multiplier: 2
 
 interop:
   settler:

--- a/src/transactions/signer.rs
+++ b/src/transactions/signer.rs
@@ -54,8 +54,8 @@ use tracing_opentelemetry::OpenTelemetrySpanExt;
 /// Lower bound of gas a signer should be able to afford before getting paused until being funded.
 pub const MIN_SIGNER_GAS: U256 = uint!(10_000_000_U256);
 
-/// Amount to top up when pulling gas (3 x MIN_SIGNER_GAS).
-pub const SIGNER_GAS_TOP_UP: U256 = uint!(30_000_000_U256);
+/// Amount to top up when pulling gas, by default this multiplies the minimum signer balance by 3.
+pub const TOP_UP_MULTIPLIER: u64 = 3;
 
 /// Errors that may occur while sending a transaction.
 #[derive(Debug, thiserror::Error)]
@@ -945,7 +945,7 @@ impl Signer {
     /// Initiates a pull gas transaction to top up the signer's balance using the funder. It will
     /// lock liquidity before broadcasting the transaction.
     pub async fn pull_gas(&self, fees: &Eip1559Estimation) -> Result<(), SignerError> {
-        let funding_amount = SIGNER_GAS_TOP_UP * U256::from(fees.max_fee_per_gas);
+        let funding_amount = self.fees.top_up_amount(fees.max_fee_per_gas);
 
         info!(
             amount = %funding_amount,


### PR DESCRIPTION
This make the funding amount a multiple of the min signer balance, this multiple is also configurable.

Fixes https://github.com/ithacaxyz/relay/issues/1166