### PR TITLE
feat(metrics): report balance as f64

### DIFF
--- a/src/metrics/periodic/types/balance.rs
+++ b/src/metrics/periodic/types/balance.rs
@@ -4,9 +4,13 @@ use crate::{
     chains::Chains,
     metrics::periodic::{MetricCollector, MetricCollectorError},
 };
-use alloy::{primitives::U256, providers::Provider};
+use alloy::{
+    primitives::{U256, utils::format_units},
+    providers::Provider,
+};
 use futures_util::StreamExt;
 use metrics::gauge;
+use tracing::error;
 
 /// This collector queries a chain endpoint for balance of the signers per chain.
 #[derive(Debug)]
@@ -34,16 +38,16 @@ impl MetricCollector for BalanceCollector {
                             .zip(chain.assets().native().map(|(_, asset)| asset.decimals))
                             .unwrap_or(("ETH", 18));
 
-                        let (div, rem) = balance.div_rem(U256::from(10).pow(U256::from(decimals)));
-                        let balance = f64::from(div) + f64::from(rem) / 10f64.powf(decimals as f64);
-
-                        gauge!(
-                            "balance",
-                            "address" => signer_addr.to_checksum(Some(chain.id())),
-                            "chain_id" => chain.id().to_string(),
-                            "symbol" => symbol.to_string(),
-                        )
-                        .set::<f64>(balance)
+                        match format_units_f64(*balance, decimals) {
+                            Ok(balance) => gauge!(
+                                "balance",
+                                "address" => signer_addr.to_checksum(Some(chain.id())),
+                                "chain_id" => chain.id().to_string(),
+                                "symbol" => symbol.to_string(),
+                            )
+                            .set::<f64>(balance),
+                            Err(err) => error!(?balance, ?err, "Failed to format balance"),
+                        }
                     })
                 })
             }
@@ -54,5 +58,23 @@ impl MetricCollector for BalanceCollector {
             .await;
 
         Ok(())
+    }
+}
+
+/// Formats a U256 value into a f64 with the specified number of decimals.
+fn format_units_f64(value: U256, decimals: u8) -> eyre::Result<f64> {
+    Ok(format_units(value, decimals)?.parse::<f64>()?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+
+    #[test]
+    fn test_format_units_f64() {
+        let value = U256::from_str("12345678901234567890").unwrap();
+        let decimals = 18;
+        assert_eq!(format_units_f64(value, decimals).unwrap(), 12.345678901234567);
     }
 }


### PR DESCRIPTION
Follow-up to https://github.com/ithacaxyz/relay/pull/1185

You can't really divide the value of the metric by its label value, so we need to report the balance already divided by token decimals.