### PR TITLE
release: 22.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5231,7 +5231,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "relay"
-version = "21.2.0"
+version = "22.0.0"
 dependencies = [
  "alloy",
  "alloy-chains",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "relay"
-version = "21.2.0"
+version = "22.0.0"
 edition = "2024"
 publish = false
 


### PR DESCRIPTION
## Summary
Release version 22.0.0 with the following changes since 21.2.0:

- feat(metrics): add layerzero per-chain native fee metrics (#1206)
- **BREAKING**: move settler address from global config to per-chain config (#1203)
- feat(stress): add `chain_id` to logs during funding (#1196)
- chore: revert submodule bump (#1204)

## Breaking Changes

### Settler Address Configuration
The `settler_address` has been moved from global LayerZero/SimpleSettler config to per-chain configuration. This allows different chains to have different settler addresses.

**Migration Guide:**

Update your config files to move `settler_address` to individual chain configs:

```yaml
# Before:
interop:
  settler:
    layer_zero:
      settler_address: "0x1234..."  # Remove this

# After:
chains:
  1:  # Ethereum
    settler_address: "0x1234..."  # Add here for chains with interop tokens
    assets:
      usdc:
        interop: true
```

Only chains with interop tokens need to specify their settler address.