### PR TITLE
feat(metrics): record eip1559 fees estimations

### DIFF
--- a/src/transactions/metrics.rs
+++ b/src/transactions/metrics.rs
@@ -44,6 +44,10 @@ pub struct TransactionServiceMetrics {
     pub blocks_until_inclusion: Histogram,
     /// How long transactions have spent in queue before being sent.
     pub time_in_queue: Histogram,
+    /// Maximum estimated fee per gas, in wei.
+    pub max_fee_per_gas: Histogram,
+    /// Maximum estimated priority fee per gas, in wei.
+    pub max_priority_fee_per_gas: Histogram,
 }
 
 /// Metrics of an individual signer, should be labeled with the signer address and chain ID.

--- a/src/transactions/signer.rs
+++ b/src/transactions/signer.rs
@@ -269,7 +269,10 @@ impl Signer {
     /// See also [`FeeConfig::adjusted_eip1559_estimation`]
     async fn estimate_eip1559_fees(&self) -> TransportResult<Eip1559Estimation> {
         let fees = self.provider.estimate_eip1559_fees().await?;
-        Ok(self.fees.adjusted_eip1559_estimation(fees))
+        let adjusted_fees = self.fees.adjusted_eip1559_estimation(fees);
+        self.metrics.max_fee_per_gas.record(adjusted_fees.max_fee_per_gas as f64);
+        self.metrics.max_priority_fee_per_gas.record(adjusted_fees.max_priority_fee_per_gas as f64);
+        Ok(adjusted_fees)
     }
 
     /// Invoked when a transaction is confirmed.


### PR DESCRIPTION
Record metrics for every EIP-1559 fees estimation. Helps us to see the surges in fees that can lead to signers being out of balance.