### PR TITLE
feat(ci): auto-assign PR to author

### DIFF
--- a/.github/workflows/auto-assign-pr.yml
+++ b/.github/workflows/auto-assign-pr.yml
@@ -1,0 +1,56 @@
+name: Auto Assign PR to Author
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+
+jobs:
+  auto-assign:
+    permissions:
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Membership
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+        run: |
+          gh api orgs/ithacaxyz/members/${{ env.PR_AUTHOR }} --silent 2> /dev/null \
+            && echo "IS_ORG_MEMBER=true" >> $GITHUB_ENV || echo "IS_ORG_MEMBER=false" >> $GITHUB_ENV
+
+      - name: Auto assign PR to author
+        if: env.IS_ORG_MEMBER == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request
+            const prAuthor = pr.user.login
+
+            console.log(`PR #${pr.number} author: ${prAuthor}`)
+            console.log(`Current assignees: ${pr.assignees.map(a => a.login).join(', ') || 'none'}`)
+
+            // Skip if PR already has assignees or author is a bot
+            if (pr.assignees.length > 0) {
+              console.log('PR already has assignees, skipping')
+              return
+            }
+
+            if (pr.user.type.toLowerCase() === 'bot') {
+              console.log('PR author is a bot, skipping')
+              return
+            }
+
+            try {
+              await github.rest.issues.addAssignees({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                assignees: [prAuthor]
+              })
+              console.log(`Successfully assigned PR #${pr.number} to ${prAuthor}`)
+            } catch (error) {
+              console.error(`Failed to assign PR: ${error.message}`)
+              throw error
+            }


### PR DESCRIPTION
we've been using this action in [Porto](https://github.com/ithacaxyz/porto/actions/workflows/auto-assign-pr.yml). I figured it would be helpful to have it here. It auto-assigns the PR to the author unless author is: a bot, not an org member, is already assigned.

working example in this repo (it ran on this PR):
https://github.com/ithacaxyz/relay/actions/runs/17271420095/job/49016923721?pr=1256