### PR TITLE
feat(relay): add symbol to native asset response

### DIFF
--- a/src/rpc/relay.rs
+++ b/src/rpc/relay.rs
@@ -46,6 +46,7 @@ use alloy::{
     },
     sol_types::{SolCall, SolValue},
 };
+use alloy_chains::NamedChain;
 use futures::{StreamExt, stream::FuturesOrdered};
 use futures_util::{future::try_join_all, join};
 use itertools::Itertools;
@@ -1879,13 +1880,18 @@ impl RelayApiServer for Relay {
                     let price = self.get_token_price(chain, asset).await;
 
                     if asset.asset_type.is_native() {
+                        let symbol = NamedChain::try_from(chain)
+                            .ok()
+                            .and_then(|c| c.native_currency_symbol())
+                            .map(ToString::to_string);
+
                         return Ok::<_, RelayError>(Asset7811 {
                             address: AddressOrNative::Native,
                             balance: chain_provider.get_balance(request.account).await?,
                             asset_type: asset.asset_type,
                             metadata: Some(AssetMetadataWithPrice {
                                 name: None,
-                                symbol: None,
+                                symbol,
                                 // use a constant 18 for native assets
                                 decimals: Some(18),
                                 uri: None,


### PR DESCRIPTION
Realized that `NamedChain` has what we want for native asset symbols, debated using `.to_string()` for asset name but realized it would be a bit weird to have e.g.:
```json
"symbol": "BNB",
"name": "binance-smart-chain"
```
or:
```json
"symbol": "ETH",
"name": "sepolia"
```