### PR TITLE
fix(metrics): tolerate same-block inclusion

### DIFF
--- a/src/transactions/signer.rs
+++ b/src/transactions/signer.rs
@@ -824,7 +824,7 @@ impl Signer {
             if let Some(submitted_at_block) = submitted_at_block {
                 self.metrics
                     .blocks_until_inclusion
-                    .record((included_at_block - submitted_at_block + 1) as f64);
+                    .record((included_at_block.saturating_sub(submitted_at_block + 1)) as f64);
             }
         }
 


### PR DESCRIPTION
One of the tests in https://github.com/ithacaxyz/relay/actions/runs/17304620512/job/49124276461

failed with:
```
    thread 'tokio-runtime-worker' panicked at src/transactions/signer.rs:827:30:
    attempt to subtract with overflow
```

which was this inclusion calculation code, meaning the submitted and included block were calculated to be the same. Just using saturating sub for now to prevent the panic