### PR TITLE
feat(Makefile): add local base-sepolia test runner

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -58,10 +58,12 @@ jobs:
       - name: Set fork environment
         if: ${{ matrix.variant == 'base_sepolia' }}
         run: |
-          echo "TEST_FORK_URL=https://sepolia.base.org" >> $GITHUB_ENV
-          echo "TEST_ORCHESTRATOR=0xe7d0fd392f3623bf04d594530f63e84bc2a9694f" >> $GITHUB_ENV
-          echo "TEST_PROXY=0xc1fd88abe262e192f4cbcbf240aa09941af54c82" >> $GITHUB_ENV
-          echo "TEST_SIMULATOR=0xe80e3a99455c4556a46b497990642dd225bada1d" >> $GITHUB_ENV
+          # Source the env file and export to GitHub Actions environment
+          source tests/assets/config/base_sepolia.env
+          echo "TEST_FORK_URL=$TEST_FORK_URL" >> $GITHUB_ENV
+          echo "TEST_ORCHESTRATOR=$TEST_ORCHESTRATOR" >> $GITHUB_ENV
+          echo "TEST_PROXY=$TEST_PROXY" >> $GITHUB_ENV
+          echo "TEST_SIMULATOR=$TEST_SIMULATOR" >> $GITHUB_ENV
 
       - name: Set database URL
         if: ${{ matrix.variant == 'pg' }}

--- a/Makefile
+++ b/Makefile
@@ -175,6 +175,27 @@ lint:
 test:
 	cargo test
 
+# Run base sepolia e2e tests
+# Usage: make test-base-sepolia [TEST=test_name]
+# Example: make test-base-sepolia TEST=auth_then_two
+test-base-sepolia: ## Run e2e tests against Base Sepolia fork. Use TEST=name to run specific test.
+	@echo "Loading Base Sepolia test configuration..."
+	@export $$(grep -v '^#' tests/assets/config/base_sepolia.env | xargs) && \
+	if [ -n "$(TEST)" ]; then \
+		echo "Running tests matching: $(TEST)"; \
+		cargo e2e -- \
+			--locked \
+			--workspace \
+			-E "test(~$(TEST))"; \
+	else \
+		export TEST_FILTER="(kind(lib) | kind(bin) | kind(proc-macro) | kind(test)) and not (test(~multichain) or test(~multi_chain))" && \
+		cargo e2e -- \
+			--locked \
+			--workspace \
+			-E "$$TEST_FILTER" \
+			--no-fail-fast; \
+	fi
+
 pr:
 	make lint && make test
 

--- a/tests/assets/config/base_sepolia.env
+++ b/tests/assets/config/base_sepolia.env
@@ -1,0 +1,6 @@
+# Base Sepolia E2E Test Configuration
+# Shared environment variables for Makefile and CI
+TEST_FORK_URL=https://sepolia.base.org
+TEST_ORCHESTRATOR=0xe7d0fd392f3623bf04d594530f63e84bc2a9694f
+TEST_PROXY=0xc1fd88abe262e192f4cbcbf240aa09941af54c82
+TEST_SIMULATOR=0xe80e3a99455c4556a46b497990642dd225bada1d


### PR DESCRIPTION
Adds a makefile target for doing the base-sepolia tests locally, the env vars are put in a separate file that is shared between CI and the makefile target