### PR TITLE
feat(metrics): record error span fields for Alloy transport

### DIFF
--- a/src/metrics/transport.rs
+++ b/src/metrics/transport.rs
@@ -92,8 +92,6 @@ where
 
         let fut = self.inner.call(request);
 
-        // todo: set `rpc.jsonrpc.error_code` and span status. this requires helpers in alloy to get
-        // jsonrpc error codes from responses
         async move {
             let instant = Instant::now();
             // the span handle is cloned here so we can record more fields later


### PR DESCRIPTION
Not exactly sure why it wasn't possible before https://github.com/ithacaxyz/relay/blob/5619ec0e8f9d9e3ba8a55796cafe80aff45e5cb8/src/metrics/transport.rs#L84-L85

cc @onbjerg would like your review here