### PR TITLE
perf: only estimate fees once for single-chain intents

### DIFF
--- a/tools/relay-tools/src/bin/stress/main.rs
+++ b/tools/relay-tools/src/bin/stress/main.rs
@@ -523,7 +523,7 @@ struct Args {
     #[arg(long = "relay-url", value_name = "RELAY_URL", required = true)]
     relay_url: Url,
     /// RPC URLs of the source chains
-    #[arg(long = "src-rpc", value_name = "RPC_URL", required = true)]
+    #[arg(long = "src-rpc", value_name = "RPC_URL", required = false)]
     src_rpc: Vec<Url>,
     /// RPC URL of the destination chain
     #[arg(long = "dst-rpc", value_name = "RPC_URL", required = true)]


### PR DESCRIPTION
Right now we're ending up going through `estimate_fee` twice for single-chain intents even when user has enough balance for both `requested_funds` and fees.

This PR changes logic to check if balance of requested asset is enough to not require a transfer from funder, and firstly builds a single-chain quote for intent. If user has enough funds for resulted fee, we simply return the quote and skip second `MultiOutput` estimate.

This can likely be optimized further to skip the second call too by re-using the fee from single-chain estimate + some buffer for the interop overhead