### PR TITLE
fix: `get_keys` for all chains on `chainwalker`

### DIFF
--- a/tools/relay-tools/src/bin/chainwalker/tester.rs
+++ b/tools/relay-tools/src/bin/chainwalker/tester.rs
@@ -159,10 +159,7 @@ impl InteropTester {
     async fn verify_fresh_account(&self, force: bool) -> Result<()> {
         match self
             .relay_client
-            .get_keys(GetKeysParameters {
-                address: self.test_account.address(),
-                chain_ids: vec![]
-            })
+            .get_keys(GetKeysParameters { address: self.test_account.address(), chain_ids: vec![] })
             .await
         {
             Ok(keys) => {
@@ -588,10 +585,7 @@ impl InteropTester {
         // Check if account is already delegated/initialized
         let mut account_initialized = self
             .relay_client
-            .get_keys(GetKeysParameters {
-                address: self.test_account.address(),
-                chain_ids: vec![],
-            })
+            .get_keys(GetKeysParameters { address: self.test_account.address(), chain_ids: vec![] })
             .await
             .is_ok();
 


### PR DESCRIPTION
defaulting to chain 1 is a bad idea if chain 1 is disabled...