### PR TITLE
feat(ci): add Docker image build for chainwalker

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,9 @@ jobs:
             ghcr_repo: ghcr.io/ithacaxyz/relay
           - dockerfile: Dockerfile.stress
             ghcr_repo: ghcr.io/ithacaxyz/relay-stress
-        dockerfile: [Dockerfile, Dockerfile.stress]
+          - dockerfile: Dockerfile.chainwalker
+            ghcr_repo: ghcr.io/ithacaxyz/relay-chainwalker
+        dockerfile: [Dockerfile, Dockerfile.stress, Dockerfile.chainwalker]
     runs-on: ubuntu-24.04
     permissions:
       packages: write

--- a/Dockerfile.chainwalker
+++ b/Dockerfile.chainwalker
@@ -1,0 +1,49 @@
+FROM lukemathwalker/cargo-chef:latest-rust-1 AS chef
+WORKDIR /app
+
+LABEL org.opencontainers.image.source=https://github.com/ithacaxyz/relay
+
+# Builds a cargo-chef plan
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+FROM chef AS builder
+COPY --from=planner /app/recipe.json recipe.json
+
+# Build profile, maxperf by default
+ARG BUILD_PROFILE=maxperf
+ENV BUILD_PROFILE $BUILD_PROFILE
+
+# Extra Cargo features
+ARG FEATURES=""
+ENV FEATURES $FEATURES
+
+# Install system dependencies
+RUN apt-get update && apt-get -y upgrade && apt-get install -y libclang-dev pkg-config
+
+# Builds dependencies
+RUN cargo chef cook --profile $BUILD_PROFILE --recipe-path recipe.json
+
+# Copy source
+COPY . .
+
+# Build application
+RUN cargo build --profile $BUILD_PROFILE --features "$FEATURES" --locked -p relay-tools --bin chainwalker
+
+# ARG is not resolved in COPY so we have to hack around it by copying the
+# binary to a temporary location
+RUN cp /app/target/$BUILD_PROFILE/chainwalker /app/chainwalker
+
+# Use Ubuntu as the release image
+FROM ubuntu AS runtime
+WORKDIR /app
+
+# Install runtime dependencies
+RUN apt-get update && apt-get -y upgrade && apt-get install -y ca-certificates && update-ca-certificates
+
+# Copy chainwalker over from the build stage
+COPY --from=builder /app/chainwalker /usr/local/bin
+
+EXPOSE 9119
+ENTRYPOINT ["/usr/local/bin/chainwalker"]


### PR DESCRIPTION
Add Dockerfile and CI configuration to build and publish chainwalker container image to GitHub Container Registry.