### PR TITLE
feat!: bump v24.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5287,7 +5287,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "relay"
-version = "23.0.4"
+version = "24.0.0"
 dependencies = [
  "alloy",
  "alloy-chains",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "relay"
-version = "23.0.4"
+version = "24.0.0"
 edition = "2024"
 publish = false
 


### PR DESCRIPTION
## Summary
- Make fee token optional in `prepare_calls` RPC endpoint, auto-selecting the best available token
- Simplify LayerZero configuration by removing endpoint IDs
- Integrate new LayerZero settler implementation with dedicated signer

## Breaking Changes
### API Changes
- **`prepare_calls`**: `fee_token` field in Meta is now optional (`Option<Address>`)
  - When not provided, relay auto-selects the best fee token based on user assets
  - Existing integrations passing explicit fee tokens remain compatible

### Configuration Changes  
- **LayerZero config**: Removed `endpoint_ids` field
  - Now only requires `endpoint_addresses` mapping
  - Added new `settler_signer_key` field (or `RELAY_SETTLER_SIGNER_KEY` env var)
  - **Migration required**: Remove `endpoint_ids` from config and add settler signer key

## Changes Since v23.0.3
- feat: automatic fee token selection when not specified
- feat: new LayerZero settler implementation with dedicated signer
- fix: P256 gas estimation when key not present
- fix: explicit gas limit setting
- chore: improved error metrics for Alloy transport