### PR TITLE
chore: simplify 7702 code override

### DIFF
--- a/src/estimation/mod.rs
+++ b/src/estimation/mod.rs
@@ -8,7 +8,7 @@
 pub mod fees;
 pub mod simulator;
 
-pub use simulator::{build_delegation_override, build_simulation_overrides};
+pub use simulator::build_simulation_overrides;
 
 pub mod arb;
 pub mod op;

--- a/src/estimation/simulator.rs
+++ b/src/estimation/simulator.rs
@@ -11,8 +11,7 @@ use crate::{
     types::{FeeEstimationContext, PartialIntent},
 };
 use alloy::{
-    eips::eip7702::constants::EIP7702_DELEGATION_DESIGNATOR,
-    primitives::{Address, Bytes, U256},
+    primitives::{Address, U256},
     providers::Provider,
     rpc::types::state::{AccountOverride, StateOverridesBuilder},
 };
@@ -52,11 +51,7 @@ pub async fn build_simulation_overrides<P: Provider>(
                     Default::default()
                 })
                 // we manually etch the 7702 designator since we do not have a signed auth item
-                .with_code_opt(context.stored_authorization.as_ref().map(|auth| {
-                    Bytes::from(
-                        [&EIP7702_DELEGATION_DESIGNATOR, auth.address().as_slice()].concat(),
-                    )
-                })),
+                .with_7702_delegation_designator_opt(context.stored_auth_address()),
         )
         .extend(context.state_overrides.clone());
 
@@ -76,17 +71,4 @@ pub async fn build_simulation_overrides<P: Provider>(
     }
 
     Ok(overrides)
-}
-
-/// Build state overrides for account delegation.
-///
-/// Creates the necessary state overrides to simulate an account with EIP-7702 delegation.
-pub fn build_delegation_override(
-    address: Address,
-    delegation_address: Address,
-) -> StateOverridesBuilder {
-    StateOverridesBuilder::default().with_code(
-        address,
-        Bytes::from([&EIP7702_DELEGATION_DESIGNATOR, delegation_address.as_slice()].concat()),
-    )
 }

--- a/src/types/intent/mod.rs
+++ b/src/types/intent/mod.rs
@@ -91,6 +91,13 @@ pub struct FeeEstimationContext {
     pub balance_overrides: BalanceOverrides,
 }
 
+impl FeeEstimationContext {
+    /// Returns the address of the stored [`SignedAuthorization`].
+    pub fn stored_auth_address(&self) -> Option<Address> {
+        self.stored_authorization.as_ref().map(|auth| auth.address)
+    }
+}
+
 mod eip712 {
     use crate::types::Call;
     use alloy::sol;


### PR DESCRIPTION
remove unused fn and use newer alloy builtin fn for this

```
    /// Convenience function that sets overrides the code with the EIP-7702 delegation designator
    /// for `delegation_address` if it is provided
    pub fn with_7702_delegation_designator_opt(self, delegation_address: Option<Address>) -> Self {
        if let Some(delegation_address) = delegation_address {
            self.with_7702_delegation_designator(delegation_address)
        } else {
            self
        }
    }

    /// Convenience function that sets overrides the code with the EIP-7702 delegation designator
    /// for `delegation_address`
    pub fn with_7702_delegation_designator(self, delegation_address: Address) -> Self {
        self.with_code(Bytes::from(
            [&EIP7702_DELEGATION_DESIGNATOR, delegation_address.as_slice()].concat(),
        ))
    }
```