### PR TITLE
feat: store precalls

### DIFF
--- a/.sqlx/query-349050d675179f714ad8cf61ad13a457aab1a08ffd7d73b63944aeba2fc6a36a.json
+++ b/.sqlx/query-349050d675179f714ad8cf61ad13a457aab1a08ffd7d73b63944aeba2fc6a36a.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT data\n            FROM precalls\n            WHERE chain_id = $1 AND address = $2\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "data",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Bytea"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "349050d675179f714ad8cf61ad13a457aab1a08ffd7d73b63944aeba2fc6a36a"
+}

--- a/.sqlx/query-7150f186ceabdaa8f4a1245a8986db4d2feed0d9b0a5b689105acc35a764451e.json
+++ b/.sqlx/query-7150f186ceabdaa8f4a1245a8986db4d2feed0d9b0a5b689105acc35a764451e.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            DELETE FROM precalls WHERE chain_id = $1 AND address = $2 AND nonce = $3\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Bytea",
+        "Bytea"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "7150f186ceabdaa8f4a1245a8986db4d2feed0d9b0a5b689105acc35a764451e"
+}

--- a/.sqlx/query-a430d775b648600b9648e00c315b75da85e010aa060a31ff44588d4735e23783.json
+++ b/.sqlx/query-a430d775b648600b9648e00c315b75da85e010aa060a31ff44588d4735e23783.json
@@ -1,0 +1,17 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO precalls (chain_id, address, data, nonce)\n            VALUES ($1, $2, $3, $4)\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Bytea",
+        "Jsonb",
+        "Bytea"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "a430d775b648600b9648e00c315b75da85e010aa060a31ff44588d4735e23783"
+}

--- a/migrations/0024_precalls.sql
+++ b/migrations/0024_precalls.sql
@@ -1,0 +1,10 @@
+create table if not exists precalls (
+    address bytea not null,
+    chain_id bigint not null,
+    nonce bytea not null,
+    data jsonb not null,
+    primary key (address, chain_id, nonce)
+);
+
+-- Index for efficient queries
+CREATE INDEX idx_precalls_address ON precalls(address);

--- a/src/error/keys.rs
+++ b/src/error/keys.rs
@@ -17,6 +17,9 @@ pub enum KeysError {
     /// Should only have admin authorization keys.
     #[error("should only have admin authorization keys")]
     OnlyAdminKeyAllowed,
+    /// Invalid signature.
+    #[error("invalid signature")]
+    InvalidSignature,
     /// Unknown key hash.
     #[error("key hash {0} is unknown")]
     UnknownKeyHash(KeyHash),
@@ -29,6 +32,7 @@ impl From<KeysError> for jsonrpsee::types::error::ErrorObject<'static> {
             | KeysError::P256SessionKeyOnly
             | KeysError::MissingAdminKey
             | KeysError::OnlyAdminKeyAllowed
+            | KeysError::InvalidSignature
             | KeysError::UnknownKeyHash { .. } => invalid_params(err.to_string()),
         }
     }

--- a/src/rpc/relay.rs
+++ b/src/rpc/relay.rs
@@ -22,33 +22,29 @@ use crate::{
             AddFaucetFundsParameters, AddFaucetFundsResponse, AddressOrNative, Asset7811,
             AssetFilterItem, CallKey, CallReceipt, CallStatusCode, ChainCapabilities,
             ChainFeeToken, ChainFees, GetAssetsParameters, GetAssetsResponse,
-            GetAuthorizationParameters, GetAuthorizationResponse, Meta, PrepareCallsCapabilities,
-            PrepareCallsContext, PrepareUpgradeAccountResponse, RelayCapabilities,
-            SendPreparedCallsCapabilities, UpgradeAccountContext, UpgradeAccountDigests,
-            ValidSignatureProof,
+            GetAuthorizationParameters, GetAuthorizationResponse, Meta, PreCallContext,
+            PrepareCallsCapabilities, PrepareCallsContext, PrepareUpgradeAccountResponse,
+            RelayCapabilities, SendPreparedCallsCapabilities, UpgradeAccountContext,
+            UpgradeAccountDigests, ValidSignatureProof,
         },
     },
     version::RELAY_SHORT_VERSION,
 };
 use alloy::{
     consensus::{TxEip1559, TxEip7702},
-    eips::{
-        eip1559::Eip1559Estimation,
-        eip7702::{SignedAuthorization, constants::EIP7702_DELEGATION_DESIGNATOR},
-    },
+    eips::{eip1559::Eip1559Estimation, eip7702::SignedAuthorization},
     primitives::{
-        Address, B256, BlockNumber, Bytes, ChainId, TxKind, U64, U256, aliases::B192, bytes,
+        Address, B256, BlockNumber, Bytes, ChainId, TxKind, U64, U256,
+        aliases::{B192, U192},
+        bytes,
     },
     providers::{DynProvider, Provider, utils::EIP1559_FEE_ESTIMATION_PAST_BLOCKS},
     rlp::Encodable,
-    rpc::types::{
-        Authorization, TransactionRequest,
-        state::{AccountOverride, StateOverridesBuilder},
-    },
+    rpc::types::{Authorization, TransactionRequest},
     sol_types::{SolCall, SolValue},
 };
 use alloy_chains::NamedChain;
-use futures::{StreamExt, stream::FuturesOrdered};
+use futures::{StreamExt, future::TryJoinAll, stream::FuturesOrdered};
 use futures_util::{TryStreamExt, future::try_join_all, join, stream::FuturesUnordered};
 use itertools::Itertools;
 use jsonrpsee::{
@@ -602,8 +598,7 @@ impl Relay {
         &self,
         quotes: SignedQuotes,
         capabilities: SendPreparedCallsCapabilities,
-        signature: Bytes,
-        key: CallKey,
+        signature: Signature,
     ) -> RpcResult<BundleId> {
         // if we do **not** get an error here, then the quote ttl must be in the past, which means
         // it is expired
@@ -622,15 +617,7 @@ impl Relay {
 
         let bundle_id = BundleId(*quotes.hash());
 
-        // compute real signature
-        let key_hash = key.key_hash();
-        let signature = Signature {
-            innerSignature: signature.clone(),
-            keyHash: key_hash,
-            prehash: key.prehash,
-        }
-        .abi_encode_packed()
-        .into();
+        let signature = signature.abi_encode_packed().into();
 
         // single chain workflow
         if quotes.ty().multi_chain_root.is_none() {
@@ -1016,10 +1003,54 @@ impl Relay {
 
         let key_hash = request_key.key_hash();
 
-        // Find the key that authorizes this intent
-        let Some(key) = self
-            .try_find_key(eoa, key_hash, &request.capabilities.pre_calls, request.chain_id)
+        let mut account = Account::new(eoa, self.provider(request.chain_id)?);
+        if !account.is_delegated().await? {
+            let Some(stored) = self.inner.storage.read_account(&eoa).await? else {
+                return Err(StorageError::AccountDoesNotExist(eoa).into());
+            };
+
+            account = account.with_overrides(stored.state_overrides()?);
+        }
+
+        let stored_precalls = self
+            .inner
+            .storage
+            .read_precalls_for_eoa(request.chain_id, eoa)
             .await?
+            .into_iter()
+            // Only retain precalls that are relevant for this intent's signing key.
+            .filter(|call| {
+                call.authorized_keys()
+                    .is_ok_and(|keys| keys.iter().any(|key| key.key_hash() == key_hash))
+            })
+            // Check precall nonce
+            .map(async |call| {
+                let seq_key = U192::from(call.nonce >> 64);
+                let nonce = account.get_nonce_for_sequence(seq_key).await?;
+                if call.nonce == nonce {
+                    return Ok::<_, RelayError>(Some(call));
+                } else if call.nonce < nonce {
+                    // Remove if nonce is already used.
+                    self.inner.storage.remove_precall(request.chain_id, eoa, call.nonce).await?;
+                }
+
+                Ok(None)
+            })
+            .collect::<TryJoinAll<_>>()
+            .await?
+            .into_iter()
+            .flatten();
+
+        let pre_calls = request
+            .capabilities
+            .pre_calls
+            .iter()
+            .cloned()
+            .chain(stored_precalls)
+            .collect::<Vec<_>>();
+
+        // Find the key that authorizes this intent
+        let Some(key) = self.try_find_key(eoa, key_hash, &pre_calls, request.chain_id).await?
         else {
             return Err(KeysError::UnknownKeyHash(key_hash).into());
         };
@@ -1046,7 +1077,7 @@ impl Relay {
                         .stored_account()
                         .iter()
                         .map(|acc| acc.pre_call.clone())
-                        .chain(request.capabilities.pre_calls.clone())
+                        .chain(pre_calls)
                         .collect(),
                     fund_transfers: intent_kind.fund_transfers(),
                     delegation_implementation: delegation_status.try_implementation()?,
@@ -1136,14 +1167,20 @@ impl Relay {
 
         // If we're dealing with a PreCall do not estimate
         let (asset_diff, context) = if request.capabilities.pre_call {
-            let precall = SignedCall {
+            let call = SignedCall {
                 eoa: request.from.unwrap_or_default(),
                 executionData: request.calls.abi_encode().into(),
                 nonce,
                 signature: Bytes::new(),
             };
 
-            (AssetDiffResponse::default(), PrepareCallsContext::with_precall(precall))
+            (
+                AssetDiffResponse::default(),
+                PrepareCallsContext::with_precall(PreCallContext {
+                    call,
+                    chain_id: request.chain_id,
+                }),
+            )
         } else {
             // Regular flow - sender and delegation status are required
             let Some(ref delegation_status) = delegation_status else {
@@ -2127,20 +2164,78 @@ impl RelayApiServer for Relay {
         request: SendPreparedCallsParameters,
     ) -> RpcResult<SendPreparedCallsResponse> {
         let SendPreparedCallsParameters { capabilities, context, signature, key } = request;
-        let Some(quotes) = context.take_quote() else {
-            return Err(QuoteError::QuoteNotFound.into());
+
+        // compute real signature
+        let key_hash = key.key_hash();
+        let signature = Signature {
+            innerSignature: signature.clone(),
+            keyHash: key_hash,
+            prehash: key.prehash,
         };
 
-        // broadcasts intents in transactions
-        let bundle_id =
-            self.send_intents(quotes, capabilities, signature, key).await.inspect_err(|err| {
-                error!(
-                    %err,
-                    "Failed to submit call bundle transaction.",
-                );
-            })?;
+        let id = match context {
+            PrepareCallsContext::Quote(quotes) => {
+                self.send_intents(*quotes, capabilities, signature).await.inspect_err(|err| {
+                    error!(
+                        %err,
+                        "Failed to submit call bundle transaction.",
+                    );
+                })?
+            }
+            PrepareCallsContext::PreCall(PreCallContext { mut call, chain_id }) => {
+                let eoa = call.eoa;
+                if eoa.is_zero() {
+                    return Err(IntentError::MissingSender.into());
+                }
 
-        Ok(SendPreparedCallsResponse { id: bundle_id })
+                let provider = self.provider(chain_id)?;
+
+                // Ensure that the key exists in the account
+                let Some(key) = self
+                    .get_keys_for_chain(call.eoa, chain_id)
+                    .await?
+                    .into_iter()
+                    .find(|key| key.authorize_key.key.key_hash() == key_hash)
+                else {
+                    return Err(KeysError::UnknownKeyHash(key_hash))?;
+                };
+
+                // We only support storing precalls signed by admin keys
+                if !key.authorize_key.key.isSuperAdmin {
+                    return Err(KeysError::OnlyAdminKeyAllowed)?;
+                }
+
+                // Build the account
+                let mut account = Account::new(eoa, &provider);
+                if !account.is_delegated().await? {
+                    let Some(stored) = self.inner.storage.read_account(&eoa).await? else {
+                        return Err(StorageError::AccountDoesNotExist(eoa).into());
+                    };
+
+                    account = account.with_overrides(stored.state_overrides()?);
+                }
+
+                // Verify that signature is valid
+                let (digest, _) = call
+                    .compute_eip712_data(
+                        account.get_orchestrator().await.map_err(RelayError::from)?,
+                        &provider,
+                    )
+                    .await?;
+
+                if account.validate_signature(digest, signature.clone()).await? != Some(key_hash) {
+                    return Err(KeysError::InvalidSignature.into());
+                }
+
+                // Store the precall
+                call.signature = signature.abi_encode_packed().into();
+                self.inner.storage.store_precall(chain_id, call).await?;
+
+                Default::default()
+            }
+        };
+
+        Ok(SendPreparedCallsResponse { id })
     }
 
     async fn upgrade_account(&self, request: UpgradeAccountParameters) -> RpcResult<()> {
@@ -2393,30 +2488,12 @@ impl RelayApiServer for Relay {
                 return Err(StorageError::AccountDoesNotExist(address).into());
             };
 
-            account = account.with_overrides(
-                StateOverridesBuilder::with_capacity(1)
-                    .append(
-                        stored.address,
-                        AccountOverride::default()
-                            .with_code(Bytes::from(
-                                [
-                                    &EIP7702_DELEGATION_DESIGNATOR,
-                                    stored.signed_authorization.address.as_slice(),
-                                ]
-                                .concat(),
-                            ))
-                            .with_state_diff(
-                                stored
-                                    .authorized_keys()?
-                                    .into_iter()
-                                    .flat_map(|k| k.authorize_key.key.storage_slots().into_iter()),
-                            ),
-                    )
-                    .build(),
-            );
+            account = account.with_overrides(stored.state_overrides()?);
 
             init_pre_call = Some(stored.pre_call);
         }
+
+        let digest = account.digest_erc1271(digest);
 
         let results = try_join_all(
             signatures.into_iter().map(|signature| account.validate_signature(digest, signature)),

--- a/src/storage/api.rs
+++ b/src/storage/api.rs
@@ -10,7 +10,7 @@ use crate::{
         PendingTransaction, PullGasState, RelayTransaction, TransactionStatus, TxId,
         interop::{BundleStatus, BundleWithStatus, InteropBundle},
     },
-    types::{CreatableAccount, rpc::BundleId},
+    types::{CreatableAccount, SignedCall, rpc::BundleId},
 };
 use alloy::{
     consensus::TxEnvelope,
@@ -278,4 +278,17 @@ pub trait StorageApi: Debug + Send + Sync {
         signer: Address,
         chain_id: ChainId,
     ) -> Result<Vec<TxEnvelope>>;
+
+    /// Stores a precall.
+    async fn store_precall(&self, chain_id: ChainId, call: SignedCall) -> Result<()>;
+
+    /// Reads precalls for a given EOA.
+    async fn read_precalls_for_eoa(
+        &self,
+        chain_id: ChainId,
+        eoa: Address,
+    ) -> Result<Vec<SignedCall>>;
+
+    /// Removes a precall.
+    async fn remove_precall(&self, chain_id: ChainId, eoa: Address, nonce: U256) -> Result<()>;
 }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -17,7 +17,7 @@ use crate::{
         bridge::{BridgeTransfer, BridgeTransferId, BridgeTransferState},
     },
     transactions::{PendingTransaction, PullGasState, RelayTransaction, TransactionStatus, TxId},
-    types::{CreatableAccount, rpc::BundleId},
+    types::{CreatableAccount, SignedCall, rpc::BundleId},
 };
 use alloy::{
     consensus::TxEnvelope,
@@ -329,5 +329,26 @@ impl StorageApi for RelayStorage {
         chain_id: ChainId,
     ) -> api::Result<Vec<TxEnvelope>> {
         self.inner.load_pending_pull_gas_transactions(signer, chain_id).await
+    }
+
+    async fn store_precall(&self, chain_id: ChainId, call: SignedCall) -> api::Result<()> {
+        self.inner.store_precall(chain_id, call).await
+    }
+
+    async fn read_precalls_for_eoa(
+        &self,
+        chain_id: ChainId,
+        eoa: Address,
+    ) -> api::Result<Vec<SignedCall>> {
+        self.inner.read_precalls_for_eoa(chain_id, eoa).await
+    }
+
+    async fn remove_precall(
+        &self,
+        chain_id: ChainId,
+        eoa: Address,
+        nonce: U256,
+    ) -> api::Result<()> {
+        self.inner.remove_precall(chain_id, eoa, nonce).await
     }
 }

--- a/src/types/intent/enum.rs
+++ b/src/types/intent/enum.rs
@@ -1,6 +1,6 @@
 use super::{IntentV04, IntentV05, SignedCall, SignedCalls, Transfer};
 use crate::{
-    error::{IntentError, MerkleError},
+    error::{IntentError, MerkleError, RelayError},
     signers::Eip712PayLoadSigner,
     types::{IntentKind, Key, LazyMerkleTree, OrchestratorContract, Signature},
 };
@@ -628,7 +628,7 @@ impl SignedCalls for Intent {
         &self,
         orchestrator_address: Address,
         provider: &DynProvider,
-    ) -> eyre::Result<(B256, alloy::dyn_abi::TypedData)>
+    ) -> Result<(B256, alloy::dyn_abi::TypedData), RelayError>
     where
         Self: Sync,
     {

--- a/src/types/intent/mod.rs
+++ b/src/types/intent/mod.rs
@@ -1,6 +1,6 @@
 use super::{Call, IDelegation::authorizeCall, Key, MerkleLeafInfo};
 use crate::{
-    error::{IntentError, MerkleError},
+    error::{IntentError, MerkleError, RelayError},
     types::{
         CallPermission,
         IthacaAccount::{setCanExecuteCall, setSpendLimitCall},
@@ -211,7 +211,7 @@ pub trait SignedCalls {
         &self,
         orchestrator_address: Address,
         provider: &DynProvider,
-    ) -> impl Future<Output = eyre::Result<(B256, TypedData)>> + Send
+    ) -> impl Future<Output = Result<(B256, TypedData), RelayError>> + Send
     where
         Self: Sync;
 }
@@ -229,7 +229,7 @@ impl SignedCalls for SignedCall {
         &self,
         orchestrator_address: Address,
         provider: &DynProvider,
-    ) -> eyre::Result<(B256, TypedData)>
+    ) -> Result<(B256, TypedData), RelayError>
     where
         Self: Sync,
     {

--- a/src/types/intent/v04.rs
+++ b/src/types/intent/v04.rs
@@ -1,5 +1,8 @@
 use super::{SignedCall, SignedCalls};
-use crate::types::{Key, Orchestrator};
+use crate::{
+    error::RelayError,
+    types::{Key, Orchestrator},
+};
 use alloy::{
     dyn_abi::TypedData,
     primitives::{Address, B256, Keccak256, U256, keccak256},
@@ -150,7 +153,7 @@ impl SignedCalls for IntentV04 {
         &self,
         orchestrator_address: Address,
         provider: &DynProvider,
-    ) -> eyre::Result<(B256, TypedData)>
+    ) -> Result<(B256, TypedData), RelayError>
     where
         Self: Sync,
     {

--- a/src/types/intent/v05.rs
+++ b/src/types/intent/v05.rs
@@ -1,5 +1,8 @@
 use super::{SignedCall, SignedCalls};
-use crate::types::{Key, Orchestrator};
+use crate::{
+    error::RelayError,
+    types::{Key, Orchestrator},
+};
 use alloy::{
     dyn_abi::TypedData,
     primitives::{Address, B256, Keccak256, U256, keccak256},
@@ -142,7 +145,7 @@ impl SignedCalls for IntentV05 {
         &self,
         orchestrator_address: Address,
         provider: &DynProvider,
-    ) -> eyre::Result<(B256, alloy::dyn_abi::TypedData)>
+    ) -> Result<(B256, alloy::dyn_abi::TypedData), RelayError>
     where
         Self: Sync,
     {

--- a/src/types/rpc/calls.rs
+++ b/src/types/rpc/calls.rs
@@ -392,6 +392,28 @@ pub struct PrepareCallsResponse {
     pub key: Option<CallKey>,
 }
 
+/// Response context for a precall.
+#[derive(
+    Debug,
+    Clone,
+    Serialize,
+    Deserialize,
+    PartialEq,
+    derive_more::Deref,
+    derive_more::DerefMut
+)]
+#[serde(rename_all = "camelCase")]
+pub struct PreCallContext {
+    /// Inner [`SignedCall`].
+    #[serde(flatten)]
+    #[deref]
+    #[deref_mut]
+    pub call: SignedCall,
+    /// The chain ID the precall is for.
+    #[serde(with = "alloy::serde::quantity")]
+    pub chain_id: ChainId,
+}
+
 /// Response context from `wallet_prepareCalls`.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
@@ -401,7 +423,7 @@ pub enum PrepareCallsContext {
     Quote(Box<SignedQuotes>),
     /// The [`PreCall`] of the prepared call bundle.
     #[serde(rename = "preCall")]
-    PreCall(SignedCall),
+    PreCall(PreCallContext),
 }
 
 impl PrepareCallsContext {
@@ -411,7 +433,7 @@ impl PrepareCallsContext {
     }
 
     /// Initializes [`PrepareCallsContext`] with a [`PreCall`].
-    pub fn with_precall(precall: SignedCall) -> Self {
+    pub fn with_precall(precall: PreCallContext) -> Self {
         Self::PreCall(precall)
     }
 
@@ -440,7 +462,7 @@ impl PrepareCallsContext {
     }
 
     /// Consumes self and returns precall if it exists.
-    pub fn take_precall(self) -> Option<SignedCall> {
+    pub fn take_precall(self) -> Option<PreCallContext> {
         match self {
             PrepareCallsContext::Quote(_) => None,
             PrepareCallsContext::PreCall(precall) => Some(precall),
@@ -457,7 +479,7 @@ impl PrepareCallsContext {
         maybe_stored: Option<&CreatableAccount>,
         latest_orchestrator: Address,
         provider: &DynProvider,
-    ) -> eyre::Result<(B256, TypedData)> {
+    ) -> Result<(B256, TypedData), RelayError> {
         match self {
             PrepareCallsContext::Quote(context) => {
                 let output_quote = context.ty().quotes.last().expect("should exist");

--- a/src/types/storage.rs
+++ b/src/types/storage.rs
@@ -3,6 +3,7 @@ use crate::error::RelayError;
 use alloy::{
     eips::eip7702::SignedAuthorization,
     primitives::{Address, Bytes},
+    rpc::types::state::{AccountOverride, StateOverride, StateOverridesBuilder},
     sol_types::SolValue,
 };
 use serde::{Deserialize, Serialize};
@@ -37,5 +38,21 @@ impl CreatableAccount {
     /// Return the list of authorized keys as [`AuthorizeKeyResponse`].
     pub fn authorized_keys(&self) -> Result<Vec<AuthorizeKeyResponse>, RelayError> {
         Ok(self.pre_call.authorized_keys_with_permissions()?)
+    }
+
+    /// Builds state overrides for the account, including 7702 autorization and authorized keys.
+    pub fn state_overrides(&self) -> Result<StateOverride, RelayError> {
+        Ok(StateOverridesBuilder::with_capacity(1)
+            .append(
+                self.address,
+                AccountOverride::default()
+                    .with_7702_delegation_designator(self.signed_authorization.address)
+                    .with_state_diff(
+                        self.authorized_keys()?
+                            .into_iter()
+                            .flat_map(|k| k.authorize_key.key.storage_slots().into_iter()),
+                    ),
+            )
+            .build())
     }
 }

--- a/tests/e2e/cases/delegation.rs
+++ b/tests/e2e/cases/delegation.rs
@@ -325,7 +325,7 @@ async fn upgrade_delegation_with_precall() -> eyre::Result<()> {
                 authorize_keys: vec![],
                 revoke_keys: vec![],
                 meta: Meta { fee_payer: None, fee_token: Some(env.fee_token), nonce: None },
-                pre_calls: vec![precall],
+                pre_calls: vec![precall.call],
                 pre_call: false,
                 required_funds: vec![],
             },

--- a/tests/e2e/cases/simple.rs
+++ b/tests/e2e/cases/simple.rs
@@ -468,7 +468,7 @@ async fn empty_request_nonce() -> eyre::Result<()> {
                 authorize_keys: vec![],
                 revoke_keys: vec![],
                 meta: Meta { fee_payer: None, fee_token: Some(env.fee_token), nonce: None },
-                pre_calls: vec![precall],
+                pre_calls: vec![precall.call],
                 pre_call: false,
                 required_funds: vec![],
             },

--- a/tests/e2e/mod.rs
+++ b/tests/e2e/mod.rs
@@ -134,7 +134,7 @@ pub async fn prepare_calls(
     env: &Environment,
     pre_call: bool,
 ) -> eyre::Result<Option<(Bytes, PrepareCallsContext)>> {
-    let pre_calls = build_pre_calls(env, &tx.pre_calls, tx_num).await?;
+    build_pre_calls(env, &tx.pre_calls, tx_num).await?;
 
     let response = env
         .relay_endpoint
@@ -150,7 +150,7 @@ pub async fn prepare_calls(
                     fee_token: Some(tx.fee_token.unwrap_or(env.fee_token)),
                     nonce: tx.nonce,
                 },
-                pre_calls,
+                pre_calls: vec![],
                 pre_call,
                 required_funds: vec![],
             },

--- a/tests/e2e/types.rs
+++ b/tests/e2e/types.rs
@@ -3,7 +3,6 @@ use alloy::{
     eips::eip7702::{SignedAuthorization, constants::EIP7702_DELEGATION_DESIGNATOR},
     primitives::{Address, U256},
     providers::Provider,
-    sol_types::SolValue,
 };
 use derive_more::Debug;
 use eyre::WrapErr;
@@ -13,7 +12,6 @@ use relay::{
     types::{
         Call, KeyWith712Signer, ORCHESTRATOR_NO_ERROR,
         OrchestratorContract::IntentExecuted,
-        Signature, SignedCall,
         rpc::{AuthorizeKey, BundleId, CallStatusCode, RevokeKey},
     },
 };
@@ -260,21 +258,16 @@ pub async fn build_pre_calls<'a>(
     env: &Environment,
     pre_calls: &[TxContext<'a>],
     tx_num: usize,
-) -> eyre::Result<Vec<SignedCall>> {
-    let pre_calls = join_all(pre_calls.iter().map(|tx| async move {
+) -> eyre::Result<()> {
+    join_all(pre_calls.iter().map(|tx| async move {
         let signer = tx.key.expect("intent should have a key");
         let (signature, context) =
             prepare_calls(tx_num, tx, signer, env, true).await.unwrap().unwrap();
-        let mut intent = context.take_precall().unwrap();
-        intent.signature =
-            Signature { innerSignature: signature, keyHash: signer.key_hash(), prehash: false }
-                .abi_encode_packed()
-                .into();
-        intent
+        send_prepared_calls(env, signer, signature, context).await.unwrap();
     }))
     .await;
 
-    Ok(pre_calls)
+    Ok(())
 }
 
 /// Helper macro for checking the outcome of a successful transaction.


### PR DESCRIPTION
Closes #1301 

Adds support for storing precalls in the relay. This is implemented by supporting precalls in `sendPreparedCalls`. If `sendPreparedCalls` receives a precall signed by an admin key, ths precall is getting saved into relay database.

After that, once `prepareCalls` is called, all precalls relevant to the signing key of the intent are included into it.