### PR TITLE
Revert "fix: use `key.settler_address` as `sender` on `get_current_inbound_nonce`"

### DIFF
--- a/src/interop/settler/layerzero/batcher/processor.rs
+++ b/src/interop/settler/layerzero/batcher/processor.rs
@@ -1,11 +1,14 @@
 use super::{LayerZeroBatchMessage, LayerZeroPoolHandle, types::SettlementPathKey};
 use crate::{
-    interop::settler::{SettlementError, layerzero::contracts::ILayerZeroEndpointV2},
+    interop::settler::{
+        SettlementError,
+        layerzero::contracts::{ILayerZeroEndpointV2, ILayerZeroSettler},
+    },
     transactions::{RelayTransaction, TransactionServiceHandle, TransactionStatus, TxId},
     types::{Call3, LZChainConfigs, TransactionServiceHandles, aggregate3Call},
 };
 use alloy::{
-    primitives::{B256, ChainId},
+    primitives::ChainId,
     providers::{MULTICALL3_ADDRESS, Provider},
     rpc::types::TransactionRequest,
     sol_types::SolCall,
@@ -318,16 +321,11 @@ impl LayerZeroBatchProcessor {
         let endpoint = ILayerZeroEndpointV2::new(config.endpoint_address, &config.provider);
 
         // Get the peer address for the source endpoint
-        // TODO(joshie): Once contracts team fixes peers() endpoint to return the real peer,
-        // use the commented code below instead of using key.settler_address as the sender (eg.
-        // Katana has a different settler address)
-        //
-        // let sender = ILayerZeroSettler::new(key.settler_address, &config.provider)
-        //     .peers(key.src_eid)
-        //     .call()
-        //     .await
-        //     .map_err(|e| SettlementError::InternalError(e.to_string()))?;
-        let sender = B256::left_padding_from(key.settler_address.as_slice());
+        let sender = ILayerZeroSettler::new(key.settler_address, &config.provider)
+            .peers(key.src_eid)
+            .call()
+            .await
+            .map_err(|e| SettlementError::InternalError(e.to_string()))?;
 
         let nonce = endpoint
             .inboundNonce(key.settler_address, key.src_eid, sender)


### PR DESCRIPTION
Closes https://github.com/ithacaxyz/relay/issues/1176
Reverts ithacaxyz/relay#1175

This is fixed in newest contracts https://github.com/ithacaxyz/account/pull/300