### PR TITLE
fix: arbitrum gas estimation

### DIFF
--- a/src/provider.rs
+++ b/src/provider.rs
@@ -4,7 +4,7 @@ use crate::{
     estimation::{
         arb::{
             ARB_NODE_INTERFACE_ADDRESS,
-            ArbNodeInterface::{self, gasEstimateL1ComponentReturn},
+            ArbNodeInterface::{self},
         },
         op::{OP_GAS_PRICE_ORACLE_ADDRESS, OpGasPriceOracle},
     },
@@ -47,7 +47,7 @@ pub trait ProviderExt: Provider {
     /// Estimates L1 DA fee components of an Arbitrum rollup for given transaction parameters by
     /// using [`NodeInterface`]. Returns the raw gas estimate and base fee estimate components
     /// after applying adjustments based on [`ARB_GAS_ESTIMATE_7702_MARGIN_PERCENT`].
-    fn estimate_l1_arb_fee_components(
+    fn estimate_l1_arb_fee_gas(
         &self,
         chain_id: ChainId,
         to: Address,
@@ -55,7 +55,7 @@ pub trait ProviderExt: Provider {
         fees: Eip1559Estimation,
         auth: Option<SignedAuthorization>,
         calldata: Bytes,
-    ) -> impl Future<Output = TransportResult<gasEstimateL1ComponentReturn>> + Send
+    ) -> impl Future<Output = TransportResult<u64>> + Send
     where
         Self: Sized,
     {
@@ -79,7 +79,7 @@ pub trait ProviderExt: Provider {
                             / 100;
                     }
 
-                    components
+                    components.gasEstimateForL1
                 })
                 .map_err(TransportErrorKind::custom)
         }

--- a/src/rpc/extra_fee.rs
+++ b/src/rpc/extra_fee.rs
@@ -12,9 +12,7 @@ pub enum ExtraFeeInfo {
     /// https://docs.arbitrum.io/build-decentralized-apps/how-to-estimate-gas#breaking-down-the-formula
     Arbitrum {
         /// L1 gas estimate for the transaction
-        l1_gas_estimate: u64,
-        /// L1 base fee estimate
-        l1_base_fee_estimate: U256,
+        gas_estimate: u64,
     },
     /// Optimism L2 with calculated L1 fee.
     ///
@@ -33,9 +31,7 @@ impl ExtraFeeInfo {
     /// Returns the calculated extra fee based on the L2 type
     pub fn extra_fee(&self) -> U256 {
         match self {
-            Self::Arbitrum { l1_gas_estimate, l1_base_fee_estimate } => {
-                *l1_base_fee_estimate * U256::from(*l1_gas_estimate)
-            }
+            Self::Arbitrum { .. } => U256::ZERO,
             Self::Optimism { l1_fee } => *l1_fee,
             Self::None => U256::ZERO,
         }
@@ -45,7 +41,7 @@ impl ExtraFeeInfo {
     /// return zero on chains that are not arbitrum.
     pub fn extra_gas(&self) -> u64 {
         match self {
-            Self::Arbitrum { l1_gas_estimate, .. } => *l1_gas_estimate,
+            Self::Arbitrum { gas_estimate, .. } => *gas_estimate,
             _ => 0,
         }
     }

--- a/src/rpc/relay.rs
+++ b/src/rpc/relay.rs
@@ -551,6 +551,7 @@ impl Relay {
             )
             .await?;
 
+        // this should return zero on all non-arbitrum chains, we add this to the gaslimit
         gas_estimate.tx += extra_fee_info.extra_gas();
 
         let extra_fee_native = extra_fee_info.extra_fee();


### PR DESCRIPTION
Follow-up for https://github.com/ithacaxyz/relay/pull/1232

The `gasEstimateForL1` is amount of gas we will have to pay on L2, so multiplying it by l1BaseFee doesn't make sense as we will pay L2 fees for it 

Also, we have this codepath https://github.com/ithacaxyz/relay/blob/8a313ee81805d5ff2824836d9ea3075071e154f9/src/transactions/transaction.rs#L141-L146

which is currently not working correctly because `extra_payment` is calculated twice — both as `quote.extra_payment` and due to increased gas_limit.

This PR changes the arbitrum component to simply increase `gas_estimate.tx` which should result in all values being calculated correctly