### PR TITLE
test: change RPC URL for layerzero mainnet diagnostics

### DIFF
--- a/src/interop/settler/layerzero/contracts.rs
+++ b/src/interop/settler/layerzero/contracts.rs
@@ -134,7 +134,7 @@ mod tests {
     #[tokio::test]
     async fn test_layerzero_diagnostics_ethereum_mainnet() {
         let ethereum_provider = ProviderBuilder::new()
-            .connect_http("https://reth-ethereum.ithaca.xyz/rpc".parse().unwrap());
+            .connect_http("https://eu-central-mainnet.rpc.ithaca.xyz".parse().unwrap());
         let endpoint = ILayerZeroEndpointV2::new(
             address!("0x1a44076050125825900e736c501f859c50fE728c"),
             &ethereum_provider,


### PR DESCRIPTION
Similar to https://github.com/foundry-rs/foundry/pull/11602 while `reth-ethereum.ithaca.xyz` is down.