### PR TITLE
feat(chainwalker): --no-key argument to use EOA detection flow

### DIFF
--- a/tools/relay-tools/src/bin/chainwalker/main.rs
+++ b/tools/relay-tools/src/bin/chainwalker/main.rs
@@ -39,6 +39,11 @@ pub struct Args {
     #[arg(long = "no-run")]
     no_run: bool,
 
+    /// Do not pass a separate `key` to `prepareCalls` requests and let the relay to detect EOA
+    /// signature instead
+    #[arg(long = "no-key")]
+    no_key: bool,
+
     /// Continue even if account has been used before (only use if testing same account
     /// implementation)
     #[arg(long = "force")]
@@ -78,6 +83,7 @@ async fn main() -> Result<()> {
         exclude_chains: args.exclude_chains,
         transfer_percentage: args.transfer_percentage,
         no_run: args.no_run,
+        no_key: args.no_key,
         skip_settlement_wait: args.skip_settlement_wait,
         account_key,
     };

--- a/tools/relay-tools/src/bin/chainwalker/tester.rs
+++ b/tools/relay-tools/src/bin/chainwalker/tester.rs
@@ -22,6 +22,7 @@ use relay_tools::common::{
 };
 use std::{
     collections::{HashMap, HashSet},
+    ops::Not,
     time::{Duration, Instant},
 };
 use tracing::{debug, error, info, warn};
@@ -37,6 +38,7 @@ pub struct InteropTester {
     pub transfer_percentage: u8,
     pub no_run: bool,
     pub skip_settlement_wait: bool,
+    pub no_key: bool,
     pub account_key: KeyWith712Signer,
 }
 
@@ -812,7 +814,7 @@ impl InteropTester {
             },
             state_overrides: Default::default(),
             balance_overrides: Default::default(),
-            key: Some(key.to_call_key()),
+            key: self.no_key.not().then_some(key.to_call_key()),
         };
 
         let prepare_result = loop {
@@ -871,7 +873,7 @@ impl InteropTester {
             .send_prepared_calls(SendPreparedCallsParameters {
                 capabilities: Default::default(),
                 context,
-                key: Some(key.to_call_key()),
+                key: self.no_key.not().then_some(key.to_call_key()),
                 signature,
             })
             .await;


### PR DESCRIPTION
Helps testing https://github.com/ithacaxyz/relay/issues/1126

Additionally we can authorize second secp256k1 public key from the same private key when creating an account, and test this `--no-key` flow using the first secp256k1 key.