### PR TITLE
chore: add `.gitattributes`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,4 @@
 .gitattributes !filter !diff
 
 Dockerfile.* linguist-language=Dockerfile
+.zed/*.json linguist-language=JSON-with-Comments

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+* text=auto
+.gitattributes !filter !diff
+
+Dockerfile.* linguist-language=Dockerfile


### PR DESCRIPTION
adds syntax highlighting for `Dockerfile.*` files
