### PR TITLE
feat: reject quotes with deficits in `sendPreparedCalls`

### DIFF
--- a/src/error/quote.rs
+++ b/src/error/quote.rs
@@ -11,6 +11,9 @@ pub enum QuoteError {
     /// The quote was not found.
     #[error("expected quote was not found")]
     QuoteNotFound,
+    /// The quote has deficits.
+    #[error("quote has asset deficits and is expected to fail")]
+    QuoteHasDeficits,
     /// The provided quote was not signed by the relay.
     #[error("invalid quote signer")]
     InvalidQuoteSignature,
@@ -60,6 +63,7 @@ impl From<QuoteError> for jsonrpsee::types::error::ErrorObject<'static> {
             | QuoteError::InvalidNumberOfIntents { .. }
             | QuoteError::InvalidFeeAmount { .. }
             | QuoteError::MissingRequiredFunds
+            | QuoteError::QuoteHasDeficits
             | QuoteError::MultichainDisabled => invalid_params(err.to_string()),
             QuoteError::UnavailablePrice(..)
             | QuoteError::UnavailablePriceFeed

--- a/src/rpc/relay.rs
+++ b/src/rpc/relay.rs
@@ -620,7 +620,6 @@ impl Relay {
             native_fee_estimate,
             authorization_address: context.stored_authorization.as_ref().map(|auth| auth.address),
             orchestrator: *orchestrator.address(),
-            has_deficits: !asset_deficits.is_empty() || !fee_token_deficit.is_zero(),
             fee_token_deficit,
             asset_deficits,
         };
@@ -647,7 +646,7 @@ impl Relay {
         }
 
         // If any of the quotes have deficits, return an error
-        if quotes.ty().quotes.iter().any(|q| q.has_deficits) {
+        if quotes.ty().quotes.iter().any(|q| q.has_deficits()) {
             return Err(QuoteError::QuoteHasDeficits.into());
         }
 

--- a/src/rpc/relay.rs
+++ b/src/rpc/relay.rs
@@ -384,6 +384,13 @@ impl Relay {
         let fee_token_balance =
             assets_response.balance_on_chain(chain_id, context.fee_token.into());
 
+        let fee_token_funding = intent
+            .fund_transfers
+            .iter()
+            .filter(|(token, _)| *token == context.fee_token)
+            .map(|(_, amount)| amount)
+            .sum::<U256>();
+
         // Build state overrides for simulation
         let overrides =
             build_simulation_overrides(&intent, &context, mock_from, fee_token_balance, &provider)
@@ -572,14 +579,23 @@ impl Relay {
             .and_then(|(_, diffs)| {
                 diffs.iter().find(|diff| diff.address.unwrap_or_default() == context.fee_token)
             })
-            .filter(|diff| diff.direction.is_outgoing())
-            .map(|diff| diff.value)
-            .unwrap_or(U256::ZERO);
+            .map(|diff| {
+                if diff.direction.is_outgoing() {
+                    // intent spent entire funding along with some extra amount
+                    diff.value.saturating_add(fee_token_funding)
+                } else {
+                    // the actual spending here might be negative but we cap it at
+                    // `fee_token_funding` as this is the maximum amount that can be spent on the
+                    // fees (everything else is received after fee payment)
+                    fee_token_funding.saturating_sub(diff.value)
+                }
+            })
+            .unwrap_or(fee_token_funding);
 
         // Calculate fee token deficit accounting for any additional spending
-        let fee_token_deficit = intent_to_sign
-            .total_payment_max_amount()
-            .saturating_sub(fee_token_balance.saturating_sub(fee_token_spending));
+        let fee_token_deficit = intent_to_sign.total_payment_max_amount().saturating_sub(
+            fee_token_balance.saturating_add(fee_token_funding).saturating_sub(fee_token_spending),
+        );
 
         // Record fee token deficit in asset deficits
         if !fee_token_deficit.is_zero() {

--- a/src/types/quote.rs
+++ b/src/types/quote.rs
@@ -140,6 +140,8 @@ pub struct Quote {
     /// Assets user is missing for the intent to execute correctly.
     #[serde(default, skip_serializing_if = "AssetDeficits::is_empty")]
     pub asset_deficits: AssetDeficits,
+    /// Whether the quote has deficits.
+    pub has_deficits: bool,
 }
 
 impl Quote {
@@ -152,6 +154,7 @@ impl Quote {
         }
         hasher.update(self.intent.digest());
         hasher.update(self.orchestrator);
+        hasher.update([self.has_deficits as u8]);
         hasher.finalize()
     }
 }

--- a/src/types/quote.rs
+++ b/src/types/quote.rs
@@ -140,11 +140,14 @@ pub struct Quote {
     /// Assets user is missing for the intent to execute correctly.
     #[serde(default, skip_serializing_if = "AssetDeficits::is_empty")]
     pub asset_deficits: AssetDeficits,
-    /// Whether the quote has deficits.
-    pub has_deficits: bool,
 }
 
 impl Quote {
+    /// Returns true if the quote has deficits.
+    pub fn has_deficits(&self) -> bool {
+        !self.asset_deficits.is_empty() || !self.fee_token_deficit.is_zero()
+    }
+
     /// Compute a digest of the quote for signing.
     pub fn digest(&self) -> B256 {
         let mut hasher = Keccak256::new();
@@ -154,7 +157,7 @@ impl Quote {
         }
         hasher.update(self.intent.digest());
         hasher.update(self.orchestrator);
-        hasher.update([self.has_deficits as u8]);
+        hasher.update([self.has_deficits() as u8]);
         hasher.finalize()
     }
 }


### PR DESCRIPTION
Closes https://github.com/ithacaxyz/relay/issues/1395

Explicltly rejects quotes with asset deficits when user attempts to send them