### PR TITLE
fix: correct spelling errors in code comments

### DIFF
--- a/src/transactions/signer.rs
+++ b/src/transactions/signer.rs
@@ -612,7 +612,8 @@ impl Signer {
     ///     1. We failed to send a transaction. This is very unlikely, and if happens, hard to
     ///        recover as it most likely signals critical KMS or RPC failure.
     ///     2. We failed to wait for a transaction to be mined. This is more likely, and means that
-    ///        transaction wa successfully broadcasted but never confirmed likely causing a nonce gap.
+    ///        transaction wa successfully broadcasted but never confirmed likely causing a nonce
+    ///        gap.
     #[instrument(skip_all, fields(signer = %self.address(), chain_id = %self.chain_id, %nonce))]
     async fn close_nonce_gap(&self, nonce: u64, min_fees: Option<Eip1559Estimation>) {
         self.metrics.detected_nonce_gaps.increment(1);

--- a/src/transactions/signer.rs
+++ b/src/transactions/signer.rs
@@ -612,7 +612,7 @@ impl Signer {
     ///     1. We failed to send a transaction. This is very unlikely, and if happens, hard to
     ///        recover as it most likely signals critical KMS or RPC failure.
     ///     2. We failed to wait for a transaction to be mined. This is more likely, and means that
-    ///        transaction wa succesfuly broadcasted but never confirmed likely causing a nonce gap.
+    ///        transaction wa successfully broadcasted but never confirmed likely causing a nonce gap.
     #[instrument(skip_all, fields(signer = %self.address(), chain_id = %self.chain_id, %nonce))]
     async fn close_nonce_gap(&self, nonce: u64, min_fees: Option<Eip1559Estimation>) {
         self.metrics.detected_nonce_gaps.increment(1);
@@ -841,7 +841,7 @@ impl Signer {
             .await
             .wrap_err("failed to read pending transactions")?;
 
-        // Make sure that loaded transactions are not getting overriden by the new ones
+        // Make sure that loaded transactions are not getting overridden by the new ones
         {
             let mut lock = self.nonce.lock().await;
             if let Some(nonce) = loaded_transactions.iter().map(|tx| tx.nonce() + 1).max()

--- a/src/types/storage.rs
+++ b/src/types/storage.rs
@@ -40,7 +40,7 @@ impl CreatableAccount {
         Ok(self.pre_call.authorized_keys_with_permissions()?)
     }
 
-    /// Builds state overrides for the account, including 7702 autorization and authorized keys.
+    /// Builds state overrides for the account, including 7702 authorization and authorized keys.
     pub fn state_overrides(&self) -> Result<StateOverride, RelayError> {
         Ok(StateOverridesBuilder::with_capacity(1)
             .append(


### PR DESCRIPTION

- **`src/transactions/signer.rs`**
  - Fixed "succesfuly" → "successfully" 
  - Fixed "overriden" → "overridden"

- **`src/types/storage.rs`**
  - Fixed "autorization" → "authorization"

