### PR TITLE
chore: bump accounts to v0.5.6

### DIFF
--- a/src/types/funder.rs
+++ b/src/types/funder.rs
@@ -49,6 +49,7 @@ sol! {
 
         function pullGas(uint256 amount) external;
         function setGasWallet(address[] memory wallets, bool isGasWallet);
+        function setOrchestrators(address[] memory ocs, bool val);
         function gasWallets(address wallet) external returns (bool);
 
         function owner() external view returns (address);

--- a/tests/e2e/cases/snapshots/tests__e2e__cases__rpc_snap__get_capabilities.snap
+++ b/tests/e2e/cases/snapshots/tests__e2e__cases__rpc_snap__get_capabilities.snap
@@ -7,11 +7,11 @@ expression: response
     "contracts": {
       "orchestrator": {
         "address": "0x700b6a60ce7eaaea56f065753d8dcb9653dbad35",
-        "version": "0.5.3"
+        "version": "0.5.5"
       },
       "accountImplementation": {
         "address": "0xb19b36b1456e65e3a6d514d3f715f204bd59f431",
-        "version": "0.5.5"
+        "version": "0.5.9"
       },
       "legacyOrchestrators": [
         {

--- a/tests/e2e/cases/snapshots/tests__e2e__cases__rpc_snap__prepare_calls.snap
+++ b/tests/e2e/cases/snapshots/tests__e2e__cases__rpc_snap__prepare_calls.snap
@@ -120,7 +120,7 @@ expression: value
       "chainId": "0x7a69",
       "name": "Orchestrator",
       "verifyingContract": "0x700b6a60ce7eaaea56f065753d8dcb9653dbad35",
-      "version": "0.5.3"
+      "version": "0.5.5"
     },
     "message": {
       "calls": [

--- a/tests/e2e/cases/snapshots/tests__e2e__cases__rpc_snap__prepare_upgrade_account.snap
+++ b/tests/e2e/cases/snapshots/tests__e2e__cases__rpc_snap__prepare_upgrade_account.snap
@@ -26,7 +26,7 @@ expression: response
   "typedData": {
     "domain": {
       "name": "Orchestrator",
-      "version": "0.5.3",
+      "version": "0.5.5",
       "verifyingContract": "0x700b6a60ce7eaaea56f065753d8dcb9653dbad35"
     },
     "types": {

--- a/tests/e2e/environment.rs
+++ b/tests/e2e/environment.rs
@@ -310,6 +310,18 @@ async fn setup_chain_with_contracts<P: Provider>(
         .get_receipt()
         .await?;
 
+    // Set up orchestrators
+    provider
+        .send_transaction(TransactionRequest::default().with_to(contracts.funder).with_call(
+            &IFunder::setOrchestratorsCall {
+                ocs: vec![contracts.orchestrator, contracts.legacy_orchestrator.orchestrator],
+                val: true,
+            },
+        ))
+        .await?
+        .get_receipt()
+        .await?;
+
     // Fund EOA and mint tokens
     let holders = &[eoa_address, contracts.funder]
         .iter()
@@ -1151,13 +1163,13 @@ async fn deploy_orchestrator<P: Provider + WalletProvider>(
 async fn deploy_funder<P: Provider + WalletProvider>(
     provider: &P,
     contracts_path: &Path,
-    orchestrator: Address,
+    _orchestrator: Address,
 ) -> eyre::Result<Address> {
     let funder_eoa = provider.default_signer_address();
     deploy_contract(
         provider,
         &contracts_path.join("SimpleFunder.sol/SimpleFunder.json"),
-        Some((funder_eoa, orchestrator, funder_eoa).abi_encode().into()),
+        Some((funder_eoa, funder_eoa).abi_encode().into()),
     )
     .await
 }

--- a/tests/e2e/environment.rs
+++ b/tests/e2e/environment.rs
@@ -1032,7 +1032,7 @@ async fn deploy_all_contracts<P: Provider + WalletProvider>(
     };
 
     // Prepare futures for parallel deployment
-    let funder_future = async { deploy_funder(provider, &contracts_path, orchestrator).await };
+    let funder_future = async { deploy_funder(provider, &contracts_path).await };
 
     let delegation_future = async {
         if let Ok(address) = std::env::var("TEST_PROXY") {
@@ -1163,7 +1163,6 @@ async fn deploy_orchestrator<P: Provider + WalletProvider>(
 async fn deploy_funder<P: Provider + WalletProvider>(
     provider: &P,
     contracts_path: &Path,
-    _orchestrator: Address,
 ) -> eyre::Result<Address> {
     let funder_eoa = provider.default_signer_address();
     deploy_contract(


### PR DESCRIPTION
Updates the account submodule to v0.5.6 ([07c9780](https://github.com/ithacaxyz/account/tree/07c9780e88e79d9b6c97325d9c39fd6aace1b464))