### PR TITLE
chore: bump account to v0.5.7

### DIFF
--- a/tests/e2e/cases/snapshots/tests__e2e__cases__rpc_snap__get_capabilities.snap
+++ b/tests/e2e/cases/snapshots/tests__e2e__cases__rpc_snap__get_capabilities.snap
@@ -11,7 +11,7 @@ expression: response
       },
       "accountImplementation": {
         "address": "0xb19b36b1456e65e3a6d514d3f715f204bd59f431",
-        "version": "0.5.9"
+        "version": "0.5.10"
       },
       "legacyOrchestrators": [
         {


### PR DESCRIPTION
Bumps account to https://github.com/ithacaxyz/account/tree/7997f6ab22dc0076be4e0ee7a6cbd4cb7e12b591 (0.5.7)