### PR TITLE
fix typos in code comments

### DIFF
--- a/src/liquidity/bridge/binance.rs
+++ b/src/liquidity/bridge/binance.rs
@@ -188,7 +188,7 @@ impl BinanceBridge {
                     deposit_addresses.insert((chain.id(), contract_address), deposit_address);
                 }
 
-                // If withdrawals are supported, fetch neccesary context.
+                // If withdrawals are supported, fetch necessary context.
                 if network.withdraw_enable.is_some_and(|enable| enable) {
                     // This represents amount of decimals accepted by Binance for withdrawal amount.
                     let withdraw_decimals =

--- a/src/rpc/relay.rs
+++ b/src/rpc/relay.rs
@@ -1518,7 +1518,7 @@ impl Relay {
                         RelayError::InternalError(eyre::eyre!("no quote after simulation"))
                     })?;
 
-                    // If we could successfuly simulate the intent without any deficits, then we can
+                    // If we could successfully simulate the intent without any deficits, then we can
                     // just do this single chain instead.
                     if quote.asset_deficits.is_empty() {
                         debug!(


### PR DESCRIPTION

Fixed minor spelling errors in code comments across two files.

- **`src/liquidity/bridge/binance.rs`**: Fixed "neccesary" → "necessary" 
- **`src/rpc/relay.rs`**: Fixed "successfuly" → "successfully" 

