### PR TITLE
[wip] support sourcing multiple assets

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -854,7 +854,7 @@ impl Default for TransactionServiceConfig {
             balance_check_interval: Duration::from_secs(5),
             nonce_check_interval: Duration::from_secs(60),
             transaction_timeout: Duration::from_secs(60),
-            max_queued_per_eoa: 1,
+            max_queued_per_eoa: 2,
             public_node_endpoints: HashMap::default(),
         }
     }

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -95,6 +95,11 @@ impl RelayError {
     pub fn internal(err: impl Error + Send + Sync + 'static) -> Self {
         Self::InternalError(err.into())
     }
+
+    /// Creates an [`RelayError::InternalError`] from a message.
+    pub fn internal_msg(msg: impl Into<String>) -> Self {
+        Self::InternalError(eyre::eyre!(msg.into()))
+    }
 }
 
 impl From<reqwest::Error> for RelayError {

--- a/src/interop/refund/processor.rs
+++ b/src/interop/refund/processor.rs
@@ -217,6 +217,7 @@ impl RefundProcessor {
                     .filter(|(_, status)| status.is_confirmed())
                     .and_then(|_| tx.extract_escrow_details())
             })
+            .flatten()
             .collect())
     }
 

--- a/src/transactions/interop.rs
+++ b/src/transactions/interop.rs
@@ -147,7 +147,7 @@ impl InteropBundle {
         settlement_id: B256,
     ) -> Result<EscrowInfo, SettlementError> {
         let escrow_details: Vec<EscrowDetails> =
-            self.src_txs.iter().filter_map(|tx| tx.extract_escrow_details()).collect();
+            self.src_txs.iter().filter_map(|tx| tx.extract_escrow_details()).flatten().collect();
 
         // Filter escrows for this specific settlement and chain
         let escrow_ids: Vec<B256> = escrow_details

--- a/src/transactions/service.rs
+++ b/src/transactions/service.rs
@@ -629,13 +629,12 @@ mod tests {
                 max_priority_fee_per_gas: Default::default(),
             },
             authorization_address: Default::default(),
-            additional_authorization: Default::default(),
             orchestrator: Default::default(),
             intent: Intent::latest().with_eoa(sender).with_nonce(U256::random()),
             fee_token_deficit: Default::default(),
             asset_deficits: Default::default(),
         };
-        RelayTransaction::new(quote, vec![], B256::random())
+        RelayTransaction::new(quote, None, B256::random())
     }
 
     #[test]

--- a/src/transactions/service.rs
+++ b/src/transactions/service.rs
@@ -629,12 +629,13 @@ mod tests {
                 max_priority_fee_per_gas: Default::default(),
             },
             authorization_address: Default::default(),
+            additional_authorization: Default::default(),
             orchestrator: Default::default(),
             intent: Intent::latest().with_eoa(sender).with_nonce(U256::random()),
             fee_token_deficit: Default::default(),
             asset_deficits: Default::default(),
         };
-        RelayTransaction::new(quote, None, B256::random())
+        RelayTransaction::new(quote, vec![], B256::random())
     }
 
     #[test]

--- a/src/types/intent/mod.rs
+++ b/src/types/intent/mod.rs
@@ -340,10 +340,8 @@ pub struct FundingIntentContext {
     pub eoa: Address,
     /// The chain where funds will be escrowed
     pub chain_id: ChainId,
-    /// The asset to be escrowed (native or ERC20)
-    pub asset: AddressOrNative,
-    /// The amount to escrow
-    pub amount: U256,
+    /// Assets to be escrowed
+    pub assets: Vec<(AddressOrNative, U256)>,
     /// The fee token to use for gas payment
     pub fee_token: Address,
     /// The output intent digest this funding will support

--- a/src/types/intent/mod.rs
+++ b/src/types/intent/mod.rs
@@ -353,6 +353,19 @@ pub struct FundingIntentContext {
     pub output_orchestrator: Address,
 }
 
+/// A single sourced asset, part of [`FundSource`].
+#[derive(Debug, Clone)]
+pub struct SourcedAsset {
+    /// The address of the asset on the source chain.
+    pub address_source: Address,
+    /// The address of the asset on the destination chain.
+    pub address_destination: Address,
+    /// The amount of the asset on the source chain.
+    pub amount_source: U256,
+    /// The amount of the asset on the destination chain.
+    pub amount_destination: U256,
+}
+
 /// A funding source.
 ///
 /// A funding source is an amount of assets on a specific chain, and an associated cost with using
@@ -361,16 +374,10 @@ pub struct FundingIntentContext {
 pub struct FundSource {
     /// The chain ID the funds are on.
     pub chain_id: ChainId,
-    /// The amount of funds on that chain.
-    pub amount_source: U256,
-    /// The amount of funds on that chain, denominated in the output chain's asset decimals.
-    pub amount_destination: U256,
-    /// The address of the funds.
-    ///
-    /// # Note
-    ///
-    /// This can (and probably will!) differ from chain to chain.
-    pub address: Address,
+    /// The assets that were sourced.
+    pub assets: Vec<SourcedAsset>,
+    /// The fee token that was used to source the funds.
+    pub fee_token: Address,
     /// The cost of transferring the funds.
     ///
     /// The cost is in base units of the funds we are trying to transfer; in the future, we may

--- a/src/types/rpc/assets.rs
+++ b/src/types/rpc/assets.rs
@@ -110,13 +110,19 @@ impl GetAssetsParameters {
     }
 
     /// Generates parameters to get specific assets for an account on specific chains.
-    pub fn for_assets_on_chains(account: Address, assets: HashMap<ChainId, Address>) -> Self {
+    pub fn for_assets_on_chains(account: Address, assets: HashMap<ChainId, Vec<Address>>) -> Self {
         Self {
             account,
             asset_filter: assets
                 .into_iter()
-                .map(|(chain_id, address)| {
-                    (chain_id, vec![AssetFilterItem::fungible(address.into())])
+                .map(|(chain_id, assets)| {
+                    (
+                        chain_id,
+                        assets
+                            .into_iter()
+                            .map(|asset| AssetFilterItem::fungible(asset.into()))
+                            .collect(),
+                    )
                 })
                 .collect(),
             ..Default::default()

--- a/tests/e2e/cases/multichain_usdt_transfer.rs
+++ b/tests/e2e/cases/multichain_usdt_transfer.rs
@@ -181,6 +181,61 @@ async fn test_multichain_usdt_transfer_empty_destination() -> Result<()> {
     Ok(())
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn test_multichain_usdt_transfer_source_fee_token() -> Result<()> {
+    let env =
+        Environment::setup_with_config(EnvironmentConfig { num_chains: 3, ..Default::default() })
+            .await?;
+    let eoa = env.eoa.address();
+
+    // Create a key for signing
+    let key = KeyWith712Signer::random_admin(KeyType::Secp256k1)?.unwrap();
+
+    // Account upgrade deployed onchain.
+    upgrade_account_lazily(&env, &[key.to_authorized()], AuthKind::Auth).await?;
+
+    let balance = IERC20::new(env.erc20, env.provider_for(0)).balanceOf(eoa).call().await?;
+
+    // Set balance of the fee token to 0
+    let slot = StorageSlotFinder::balance_of(env.provider_for(0), env.fee_token, eoa)
+        .find_slot()
+        .await?
+        .unwrap();
+    env.provider_for(0).anvil_set_storage_at(env.fee_token, slot.into(), B256::ZERO).await?;
+
+    // Prepare the calls on chain 3 with required funds
+    let prepare_result = env
+        .relay_endpoint
+        .prepare_calls(PrepareCallsParameters {
+            calls: vec![Call::transfer(
+                env.erc20,
+                Address::random(),
+                balance * U256::from(11) / U256::from(10),
+            )],
+            chain_id: env.chain_id_for(0),
+            from: Some(eoa),
+            capabilities: PrepareCallsCapabilities {
+                authorize_keys: vec![],
+                revoke_keys: vec![],
+                meta: Meta { fee_payer: None, fee_token: Some(env.fee_token), nonce: None },
+                pre_calls: vec![],
+                pre_call: false,
+                required_funds: vec![],
+            },
+            state_overrides: Default::default(),
+            balance_overrides: Default::default(),
+            key: Some(key.to_call_key()),
+        })
+        .await?;
+
+    let PrepareCallsResponse { context, digest, .. } = prepare_result;
+    let quotes = context.quote().expect("should always return quotes");
+
+    dbg!(quotes);
+
+    Ok(())
+}
+
 /// Result of multichain transfer setup
 pub struct MultichainTransferSetup {
     // todo: make these private

--- a/tests/e2e/environment.rs
+++ b/tests/e2e/environment.rs
@@ -586,7 +586,7 @@ impl Environment {
             // Each ERC20 has the UID derived from the order it was deployed. The native token
             // is given the UID ETH with 18 decimals.
             //
-            // Only ETH and the first ERC20 is relayable across chains.
+            // Only ETH and the first two ERC20s are relayable across chains.
             alloy::contract::Result::<_>::Ok(Assets::new(HashMap::from_iter(
                 std::iter::once((
                     AssetUid::new("eth".to_string()),
@@ -606,7 +606,7 @@ impl Environment {
                                     address: *contract,
                                     decimals: provider.get_token_decimals(*contract).await?,
                                     fee_token: true,
-                                    interop: idx == 0,
+                                    interop: idx < 2,
                                 },
                             ))
                         },


### PR DESCRIPTION
ref https://github.com/ithacaxyz/relay/issues/1231 testcase 5

Implements support for sourcing multiple assets, primarily focusing on a usecase of a "main" asset being sourced plus a fee token.

This changes `source_funds` to accept a `Vec` of required assets that are then sourced across different chains.

Logic for picking a funding chains and fee tokens for them can likely be improved so marking as draft for now