### PR TITLE
feat(config): add environment variable support for Twilio credentials

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -266,6 +266,27 @@ impl RelayConfig {
         self
     }
 
+    /// Sets the Twilio credentials.
+    pub fn with_twilio_credentials(
+        mut self,
+        account_sid: Option<String>,
+        auth_token: Option<String>,
+        verify_service_sid: Option<String>,
+    ) -> Self {
+        if let Some(phone) = self.phone.as_mut() {
+            if let Some(sid) = account_sid {
+                phone.twilio_account_sid = sid;
+            }
+            if let Some(token) = auth_token {
+                phone.twilio_auth_token = token;
+            }
+            if let Some(service_sid) = verify_service_sid {
+                phone.twilio_verify_service_sid = service_sid;
+            }
+        }
+        self
+    }
+
     /// Sets the configuration for the transaction service.
     pub fn with_transaction_service_config(mut self, config: TransactionServiceConfig) -> Self {
         self.transactions = config;

--- a/src/spawn.rs
+++ b/src/spawn.rs
@@ -78,6 +78,11 @@ pub async fn try_spawn_with_args(args: Args, config_path: &Path) -> eyre::Result
         config
             .with_resend_api_key(std::env::var("RESEND_API_KEY").ok())
             .with_onramp_worker_secret(std::env::var("ONRAMP_WORKER_SECRET").ok())
+            .with_twilio_credentials(
+                std::env::var("TWILIO_ACCOUNT_SID").ok(),
+                std::env::var("TWILIO_AUTH_TOKEN").ok(),
+                std::env::var("TWILIO_VERIFY_SERVICE_SID").ok(),
+            )
             .with_simple_settler_owner_key(std::env::var("RELAY_SETTLER_OWNER_KEY").ok())
             .with_funder_owner_key(std::env::var("RELAY_FUNDER_OWNER_KEY").ok())
             .with_binance_keys(


### PR DESCRIPTION
Add support for loading Twilio credentials from environment variables (TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, TWILIO_VERIFY_SERVICE_SID). Environment variables take precedence over config file values, following the same pattern as other secrets like ONRAMP_WORKER_SECRET.

This allows keeping sensitive Twilio credentials out of config files while maintaining backward compatibility with existing configurations.